### PR TITLE
Add format in french datepicker locale

### DIFF
--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.fr.js
@@ -4,6 +4,7 @@
  */
 ;(function($){
 	$.fn.fdatepicker.dates['fr'] = {
+    format: 'dd/mm/yyyy',
 		days: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
 		daysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"],
 		daysMin: ["D", "L", "Ma", "Me", "J", "V", "S", "D"],


### PR DESCRIPTION
#### :tophat: What? Why?
French date format in datepicker in admin dashboard wasn't right. Now the format is set to dd/mm/yyyy

#### :pushpin: Related Issues
- Fixes #34 