### PR TITLE
Fix upstream moderation for the "debates" feature

### DIFF
--- a/decidim-debates/lib/decidim/debates/feature.rb
+++ b/decidim-debates/lib/decidim/debates/feature.rb
@@ -14,6 +14,7 @@ Decidim.register_feature(:debates) do |feature|
   feature.settings(:global) do |settings|
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :comments_upstream_moderation_enabled, type: :boolean, default: false
   end
 
   feature.settings(:step) do |settings|


### PR DESCRIPTION
#### :tophat: What? Why?
Now as a user I can comment on a debate
For every new feature integrated by the Decidim team we'll need to add the `comment_upstream_moderation_enabled` method to the `feature.rb`

#### :pushpin: Related Issues
- Closes #77