### PR TITLE
Fix/accountability progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ use the following command in your rails console : `Decidim::ParticipatoryProcess
 you should update existing image if you don't want to reupload them.
 use the following command in your rails console : `Decidim::User.find_each { |user| user.avatar.recreate_versions! if user.avatar? }`
 
-
+- **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)
 
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/0.11-stable)

--- a/decidim-accountability/app/forms/decidim/accountability/admin/result_form.rb
+++ b/decidim-accountability/app/forms/decidim/accountability/admin/result_form.rb
@@ -25,6 +25,8 @@ module Decidim
 
         validates :title, translatable_presence: true
 
+        validates :progress, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, if: ->(form) { form.progress.present? }
+
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
 

--- a/decidim-accountability/spec/forms/admin/result_form_spec.rb
+++ b/decidim-accountability/spec/forms/admin/result_form_spec.rb
@@ -49,7 +49,6 @@ module Decidim::Accountability
     end
 
     it { is_expected.to be_valid }
-
     describe "when progress is negative" do
       let(:progress) { -12 }
 
@@ -57,7 +56,6 @@ module Decidim::Accountability
     end
 
     describe "when progress is greater than 100" do
-
       let(:progress) { 999 }
 
       it { is_expected.not_to be_valid }
@@ -74,7 +72,6 @@ module Decidim::Accountability
 
       it { is_expected.to be_valid }
     end
-
 
     describe "when title is missing" do
       let(:title) { { en: nil } }

--- a/decidim-accountability/spec/forms/admin/result_form_spec.rb
+++ b/decidim-accountability/spec/forms/admin/result_form_spec.rb
@@ -50,6 +50,32 @@ module Decidim::Accountability
 
     it { is_expected.to be_valid }
 
+    describe "when progress is negative" do
+      let(:progress) { -12 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when progress is greater than 100" do
+
+      let(:progress) { 999 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when progress is between 0 and 100" do
+      let(:progress) { (0..100).to_a.sample }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe "when progress is empty" do
+      let(:progress) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+
     describe "when title is missing" do
       let(:title) { { en: nil } }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix accountability progress to be between 0 and 100 if provided

Progress was not constrained to a range, you could choose a number superior to 100 resulting in error.
![image](https://user-images.githubusercontent.com/20232956/43594811-756dff08-967b-11e8-9710-a6958c577d84.png)
![image](https://user-images.githubusercontent.com/20232956/43594836-81692e4a-967b-11e8-9691-98ae25bb89cb.png)
![image](https://user-images.githubusercontent.com/20232956/43594944-cd6f5508-967b-11e8-94f9-0f0e207718cc.png)


The range is now within 0 to 100 and can be empty.

Fixes #3956
Related : #144

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/43594915-beb081b8-967b-11e8-99c5-46a084767772.png)

#### :ghost: GIF
![](https://media.giphy.com/media/Mp4hQy51LjY6A/giphy.gif)
