### PR TITLE
0.12 stable skip first login authorization

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -23,6 +23,7 @@ module Decidim
       end
 
       def first_login_and_not_authorized?(user)
+        return false if Decidim.config.skip_first_login_authorization
         user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any?
       end
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -147,6 +147,11 @@ module Decidim
     end
   end
 
+  # Exposes a configuration option: the first_login_authorization boolean
+  config_accessor :skip_first_login_authorization do
+    false
+  end
+
   # Exposes a configuration option: the currency unit
   config_accessor :currency_unit do
     "€"

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -30,8 +30,17 @@ module Decidim
               let(:user) { build(:user, sign_in_count: 1) }
 
               context "when there are authorization handlers" do
-                context "when there is no skip first login authorization option activated" do
+                context "when there is no skip first login authorization option" do
                   before do
+                    user.organization.available_authorizations = ["dummy_authorization_handler"]
+                    user.organization.save
+                  end
+                  it { is_expected.to eq("/authorizations/first_login") }
+                end
+
+                context "when there is a skip first login authorization option activated" do
+                  before do
+                    Decidim.config.skip_first_login_authorization = false
                     user.organization.available_authorizations = ["dummy_authorization_handler"]
                     user.organization.save
                   end

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -30,12 +30,22 @@ module Decidim
               let(:user) { build(:user, sign_in_count: 1) }
 
               context "when there are authorization handlers" do
-                before do
-                  user.organization.available_authorizations = ["dummy_authorization_handler"]
-                  user.organization.save
+                context "when there is no skip first login authorization option activated" do
+                  before do
+                    user.organization.available_authorizations = ["dummy_authorization_handler"]
+                    user.organization.save
+                  end
+                  it { is_expected.to eq("/authorizations/first_login") }
                 end
 
-                it { is_expected.to eq("/authorizations/first_login") }
+                context "when there is a skip first login authorization option activated" do
+                  before do
+                    Decidim.config.skip_first_login_authorization = true
+                    user.organization.available_authorizations = ["dummy_authorization_handler"]
+                    user.organization.save
+                  end
+                  it { is_expected.to eq("/") }
+                end
 
                 context "when there's a pending redirection" do
                   before do


### PR DESCRIPTION
#### :tophat: What? Why?
Because choice is important! Add an initialization variable that allows to skip first login_authorization

#### 😱 How to use?
In your `config/initializers/decidim.rb` add the following line : 
```
config.skip_first_login_authorization = true
```
Default value is set to *false*

#### :pushpin: Related Issues
- Fixes #172 

#### :clipboard: Subtasks
- [x] Add CHANGELOG entry
- [x] Add tests

#### :ghost: GIF
![](https://media.giphy.com/media/iFjp2GQYKBleg/giphy.gif)
