### PR TITLE
Don't display '#' if there is no hashtag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ you should update existing image if you don't want to reupload them.
 use the following command in your rails console : `Decidim::User.find_each { |user| user.avatar.recreate_versions! if user.avatar? }`
 
 - **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)
+- **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#200](https://github.com/OpenSourcePolitics/decidim/pull/200)
 
 - **skip first login authorization** : Add an initializer otion to skip first login authorization [\#176](https://github.com/OpenSourcePolitics/decidim/pull/176)
 

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
@@ -1,6 +1,8 @@
-<%= link_to(
-  "##{model.hashtag}",
-  "https://twitter.com/hashtag/#{model.hashtag}",
-  class: "card__text--category",
-  target: "_blank"
- ) %>
+<% if model.hashtag.present? %>
+  <%= link_to(
+        "##{model.hashtag}",
+        "https://twitter.com/hashtag/#{model.hashtag}",
+        class: "card__text--category",
+        target: "_blank"
+      ) %>
+<% end %>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe "Participatory Processes", type: :system do
   let(:organization) { create(:organization) }
   let(:show_statistics) { true }
+  let(:hashtag) { true }
   let(:base_process) do
     create(
       :participatory_process,
@@ -266,6 +267,14 @@ describe "Participatory Processes", type: :system do
 
         it "the stats for those components are not visible" do
           expect(page).to have_no_content("3 PROPOSALS")
+        end
+
+        context "and the process doesn't have hashtag" do
+          let(:hashtag) { false }
+
+          it "the stats for those components are not visible" do
+            expect(page).to have_no_content("#")
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Hashtags on Participatory Processes should only appear when the field is filled by the admin.

#### :pushpin: Related Issues
- Fixes #193

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/44456167-27a2ed80-a600-11e8-896a-a717e9b3c9a6.png)
