### PR TITLE
[Backport] Add link to user profile and link to conversation from admin space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 - **skip first login authorization** : Add an initializer otion to skip first login authorization [\#176](https://github.com/OpenSourcePolitics/decidim/pull/176)
 
-**Fixed**:
+**Added**:
 
 - **decidim-core**: Add shinier signature. [#186](https://github.com/OpenSourcePolitics/decidim/pull/186)
+- **decidim-admin**:Add link to user profile and link to conversation from admin space. [\#208](https://github.com/OpenSourcePolitics/decidim/pull/208)
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/0.11-stable)
 

--- a/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
@@ -8,6 +8,7 @@ module Decidim
       layout "decidim/admin/users"
 
       helper_method :user
+      helper Decidim::Messaging::ConversationHelper
 
       def index
         enforce_permission_to :read, :officialization

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -62,7 +62,7 @@
             <td><%= translated_attribute(user.officialized_as) %></td>
 
             <td class="table-list__actions">
-              <%=  icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
+              <%= icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
               <% if user.officialized? %>
                 <%= icon "circle-check", class: "action-icon action-icon--disabled" %>
                 <%= icon_link_to "pencil", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -2,21 +2,21 @@
   <div class="column medium-3">
     <span class="dropdown-menu-inverted_label"><%= t(".filter_by") %> :</span>
     <ul class="dropdown menu dropdown-inverted" data-dropdown-menu data-close-on-click-inside="false">
-        <li class="is-dropdown-submenu-parent">
-          <a href="#">
+      <li class="is-dropdown-submenu-parent">
+        <a href="#">
           <% if @state.present? %>
             <%= t(".filter.#{@state}") %>
           <% else %>
             <%= t(".filter.all") %>
           <% end %>
-          </a>
-          <ul class="menu is-dropdown-submenu">
-            <li><%= link_to t(".filter.officialized"), url_for(state: "officialized", q: @query) %></li>
-            <li><%= link_to t(".filter.not_officialized"), url_for(state: "not_officialized", q: @query) %></li>
-            <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
-          </ul>
-        </li>
-      </ul>
+        </a>
+        <ul class="menu is-dropdown-submenu">
+          <li><%= link_to t(".filter.officialized"), url_for(state: "officialized", q: @query) %></li>
+          <li><%= link_to t(".filter.not_officialized"), url_for(state: "not_officialized", q: @query) %></li>
+          <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
+        </ul>
+      </li>
+    </ul>
   </div>
   <div class="column medium-4">
     <%= form_tag "", method: :get do %>
@@ -43,37 +43,38 @@
     <div class="table-scroll">
       <table class="table-list">
         <thead>
-          <tr>
-            <th><%= t(".name") %></th>
-            <th><%= t(".nickname") %></th>
-            <th><%= t(".created_at") %></th>
-            <th><%= t(".status") %></th>
-            <th><%= t(".badge") %></th>
-            <th><%= t(".actions") %></th>
-          </tr>
+        <tr>
+          <th><%= t(".name") %></th>
+          <th><%= t(".nickname") %></th>
+          <th><%= t(".created_at") %></th>
+          <th><%= t(".status") %></th>
+          <th><%= t(".badge") %></th>
+          <th><%= t(".actions") %></th>
+        </tr>
         </thead>
         <tbody>
-          <% @users.each do |user| %>
-            <tr data-user-id="<%= user.id %>">
-              <td><%= user.name %></td>
-              <td><%= user.nickname %></td>
-              <td><%= l user.created_at, format: :short %></td>
-              <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
-              <td><%= translated_attribute(user.officialized_as) %></td>
+        <% @users.each do |user| %>
+          <tr data-user-id="<%= user.id %>">
+            <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
+            <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
+            <td><%= l user.created_at, format: :short %></td>
+            <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
+            <td><%= translated_attribute(user.officialized_as) %></td>
 
-              <td class="table-list__actions">
-                <% if user.officialized? %>
-                  <%= icon "circle-check", class: "action-icon action-icon--disabled" %>
-                  <%= icon_link_to "pencil", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>
-                  <%= icon_link_to "circle-x", officialization_path(user.id), t(".unofficialize"), method: :delete, class: "action-icon--reject" %>
-                <% else %>
-                  <%= icon_link_to "circle-check", new_officialization_path(user_id: user.id), t(".officialize"), class: "action-icon--verify" %>
-                  <%= icon "pencil", class: "action-icon action-icon--disabled" %>
-                  <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
+            <td class="table-list__actions">
+              <%=  icon_link_to "envelope-closed", current_or_new_conversation_path_with(user), t("decidim.contact"), class:"action-icon--new" %>
+              <% if user.officialized? %>
+                <%= icon "circle-check", class: "action-icon action-icon--disabled" %>
+                <%= icon_link_to "pencil", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>
+                <%= icon_link_to "circle-x", officialization_path(user.id), t(".unofficialize"), method: :delete, class: "action-icon--reject" %>
+              <% else %>
+                <%= icon_link_to "circle-check", new_officialization_path(user_id: user.id), t(".officialize"), class: "action-icon--verify" %>
+                <%= icon "pencil", class: "action-icon action-icon--disabled" %>
+                <%= icon "circle-x", class: "action-icon action-icon--disabled" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
         </tbody>
       </table>
       <%= paginate @users, theme: "decidim" %>

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -131,4 +131,49 @@ describe "Admin manages officializations", type: :system do
       end
     end
   end
+
+  describe "contacting the user" do
+    let!(:user) { create(:user, organization: organization) }
+
+    before do
+      click_link "Officializations"
+    end
+
+    it "redirect to conversation path" do
+      within "tr[data-user-id=\"#{user.id}\"]" do
+        click_link "Contact"
+      end
+      expect(page).to have_current_path decidim.new_conversation_path(recipient_id: user.id)
+    end
+  end
+
+  describe "clicking on user name" do
+    let!(:user) { create(:user, organization: organization) }
+
+    before do
+      click_link "Officializations"
+    end
+
+    it "redirect to user profile page" do
+      within "tr[data-user-id=\"#{user.id}\"]" do
+        click_link user.name
+      end
+      expect(page).to have_current_path decidim.profile_path(user.nickname)
+    end
+  end
+
+  describe "clicking on user nickname" do
+    let!(:user) { create(:user, organization: organization) }
+
+    before do
+      click_link "Officializations"
+    end
+
+    it "redirect to user profile page" do
+      within "tr[data-user-id=\"#{user.id}\"]" do
+        click_link user.nickname
+      end
+      expect(page).to have_current_path decidim.profile_path(user.nickname)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The administrator can start a conversation directly from the back office with a user.
The administrator can also directly visit the user profile.

#### :pushpin: Related Issues
- #138

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests

### :camera: Screenshots (optional)
![2018-08-13 18 50 28](https://user-images.githubusercontent.com/20232956/44045767-de4a0e3e-9f29-11e8-8f9b-2a0b83df3852.gif)
![2018-08-13 18 50 46](https://user-images.githubusercontent.com/20232956/44045768-de6d4548-9f29-11e8-9d54-5d48483a256b.gif)



