### PR TITLE
Hide withdrawn proposals from index

### DIFF
--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -57,7 +57,7 @@ module Decidim
         when "withdrawn"
           query.withdrawn
         when "except_rejected"
-          query.except_rejected
+          query.except_rejected.except_withdrawn
         else # Assume 'not_withdrawn'
           query.except_withdrawn
         end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -103,7 +103,19 @@ module Decidim
             end
           end
 
-          context "when filtering accpeted proposals" do
+          context "when filtering :except_rejected proposals" do
+            let(:state) { "except_rejected" }
+
+            it "hides withdrawn and rejected proposals" do
+              create(:proposal, :withdrawn, component: component)
+              create(:proposal, :rejected, component: component)
+              accepted_proposal = create(:proposal, :accepted, component: component)
+              expect(subject.size).to eq(2)
+              expect(subject).to match_array([accepted_proposal, proposal])
+            end
+          end
+
+          context "when filtering accepted proposals" do
             let(:state) { "accepted" }
 
             it "returns only accepted proposals" do


### PR DESCRIPTION
#### :tophat: What? Why?
Withdrawn proposals are being shown on the proposals index. This PR hides those withdrawn proposals from that view.

#### :pushpin: Related Issues
- Related to #4012
- Fixes #204 
