### PR TITLE
[Backport] Backport/surveys/destroy component without answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 - **skip first login authorization** : Add an initializer otion to skip first login authorization [\#176](https://github.com/OpenSourcePolitics/decidim/pull/176)
 
+**Backported**:
+
+- **decidim-surveys**: Allow deleting surveys components when there are no answers [#211](https://github.com/OpenSourcePolitics/decidim/pull/211)
+
 **Fixed**:
 
 - **decidim-core**: Add shinier signature. [#186](https://github.com/OpenSourcePolitics/decidim/pull/186)

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -16,7 +16,10 @@ Decidim.register_component(:surveys) do |component|
   end
 
   component.on(:before_destroy) do |instance|
-    raise "Can't destroy this component when there are surveys" if Decidim::Surveys::Survey.where(component: instance).any?
+    survey_answers_for_component = Decidim::Surveys::SurveyAnswer
+                                   .includes(:survey)
+                                   .where(decidim_surveys_surveys: { decidim_component_id: instance.id })
+    raise "Can't destroy this component when there are survey answers" if survey_answers_for_component.any?
   end
 
   component.register_stat :surveys_count do |components, start_at, end_at|

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 require "spec_helper"
+
 describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
   subject { component }
 
@@ -18,9 +20,9 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
       end
       it "raises an error" do
         expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
-                                                                             RuntimeError,
-                                                                             "Can't destroy this component when there are survey answers"
-                                                                           )
+          RuntimeError,
+          "Can't destroy this component when there are survey answers"
+        )
       end
     end
   end

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "spec_helper"
+describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
+  subject { component }
+
+  let(:component) { create :surveys_component }
+
+  describe "before_destroy hooks" do
+    context "when there are no answers" do
+      it "does not raise any error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.not_to raise_error
+      end
+    end
+    context "with answers" do
+      before do
+        survey = create :survey, component: component
+        create :survey_answer, survey: survey
+      end
+      it "raises an error" do
+        expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
+                                                                             RuntimeError,
+                                                                             "Can't destroy this component when there are survey answers"
+                                                                           )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Allow deleting surveys components when there are no answers

#### :pushpin: Related Issues
- Related to [#4013](https://github.com/decidim/decidim/pull/4013)
- Fixes #205 
