### PR TITLE
Fix unwanted mandatory tests execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 **Fixed**:
 
+- **decidim-core**: Fix test consistency [#222](https://github.com/OpenSourcePolitics/decidim/pull/222)
 - **decidim-core**: Add shinier signature. [#186](https://github.com/OpenSourcePolitics/decidim/pull/186)
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/0.11-stable)

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -29,9 +29,14 @@ module Decidim
             context "when it is the first time to log in" do
               let(:user) { build(:user, sign_in_count: 1) }
 
+              # the first test would fail if tested in a non linear order, this corrects this problem.
+              # TODO : Find a more elegant solution
+              initial_value = Decidim.config.skip_first_login_authorization
+
               context "when there are authorization handlers" do
                 context "when there is no skip first login authorization option" do
                   before do
+                    Decidim.config.skip_first_login_authorization = initial_value
                     user.organization.available_authorizations = ["dummy_authorization_handler"]
                     user.organization.save
                   end


### PR DESCRIPTION
#### :tophat: What? Why?
The skip first login authorization option test was messing around and causing some inconsistency, this quick-fix stop this problem.

#### :pushpin: Related Issues
- Related to #221 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
