### PR TITLE
Delete incorrect test

### DIFF
--- a/decidim-admin/spec/system/admin_manages_navbar_links_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_navbar_links_spec.rb
@@ -51,7 +51,6 @@ describe "Navbar Links", type: :system do
           expect(page).to have_content(translated(navbar_link.title, locale: :en))
           expect(page).to have_content(navbar_link.link)
           expect(page).to have_content(navbar_link.weight)
-          expect(find_link(navbar_link.link)[:target]).to eq(navbar_link.target)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The navbar links tests were inconsistent, this was due to a badly written test.
