### PR TITLE
Proposals caps first (for MEL)

### DIFF
--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -9,7 +9,6 @@ class EtiquetteValidator < ActiveModel::EachValidator
     validate_caps(record, attribute, value)
     validate_marks(record, attribute, value)
     validate_long_words(record, attribute, value)
-    validate_caps_first(record, attribute, value)
     validate_length(record, attribute, value)
   end
 
@@ -30,11 +29,6 @@ class EtiquetteValidator < ActiveModel::EachValidator
   def validate_long_words(record, attribute, value)
     return if value.scan(/[A-z]{35,}/).empty?
     record.errors.add(attribute, options[:message] || :long_words)
-  end
-
-  def validate_caps_first(record, attribute, value)
-    return if value.scan(/\A[a-z]{1}/).empty?
-    record.errors.add(attribute, options[:message] || :must_start_with_caps)
   end
 
   def validate_length(record, attribute, value)

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -54,18 +54,16 @@ describe EtiquetteValidator do
     it { is_expected.to be_invalid }
   end
 
-  context "when the text is written starting in downcase" do
-    context "with a single line body" do
-      let(:body) { "i no care about grammer" }
+  context "with a single line body" do
+    let(:body) { "i no care about grammer" }
 
-      it { is_expected.to be_invalid }
-    end
+    it { is_expected.to be_valid }
+  end
 
-    context "with a multiple line body with the second line starting in downcase" do
-      let(:body) { "This is a multiline body\nwith a line starting with downcase." }
+  context "with a multiple line body with the second line starting in downcase" do
+    let(:body) { "This is a multiline body\nwith a line starting with downcase." }
 
-      it { is_expected.to be_valid }
-    end
+    it { is_expected.to be_valid }
   end
 
   context "when the body is too short" do

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -49,8 +49,8 @@ module Decidim
 
         def attributes
           {
-            title: form.title,
-            body: form.body,
+            title: form.formatted_title,
+            body: form.formatted_body,
             category: form.category,
             scope: form.scope,
             component: form.component,

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -47,8 +47,8 @@ module Decidim
 
       def create_proposal
         @proposal = Proposal.create!(
-          title: form.title,
-          body: form.body,
+          title: form.formatted_title,
+          body: form.formatted_body,
           category: form.category,
           scope: form.scope,
           author: @current_user,

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -39,8 +39,8 @@ module Decidim
 
       def update_proposal
         @proposal.update!(
-          title: form.title,
-          body: form.body,
+          title: form.formatted_title,
+          body: form.formatted_body,
           category: form.category,
           scope: form.scope,
           author: current_user,

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -1,74 +1,74 @@
 # frozen_string_literal: true
 
 module Decidim
-  module Proposals
-    module Admin
-      # A form object to be used when admin users want to create a proposal.
-      class ProposalForm < Decidim::Form
-        mimic :proposal
+  module Admin
+    # A form object to be used when admin users want to create a proposal.
+    class ProposalForm < Decidim::Form
+      mimic :proposal
 
-        attribute :title, String
-        attribute :body, String
-        attribute :address, String
-        attribute :latitude, Float
-        attribute :longitude, Float
-        attribute :category_id, Integer
-        attribute :scope_id, Integer
-        attribute :attachment, AttachmentForm
+      include Decidim::Proposals::Concerns::FormattedAttributes
 
-        validates :title, :body, presence: true
-        validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
-        validates :category, presence: true, if: ->(form) { form.category_id.present? }
-        validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
+      attribute :title, String
+      attribute :body, String
+      attribute :address, String
+      attribute :latitude, Float
+      attribute :longitude, Float
+      attribute :category_id, Integer
+      attribute :scope_id, Integer
+      attribute :attachment, AttachmentForm
 
-        validate :scope_belongs_to_participatory_space_scope
+      validates :title, :body, presence: true
+      validates :address, geocoding: true, if: -> { current_component.settings.geocoding_enabled? }
+      validates :category, presence: true, if: ->(form) { form.category_id.present? }
+      validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 
-        validate :notify_missing_attachment_if_errored
+      validate :scope_belongs_to_participatory_space_scope
 
-        delegate :categories, to: :current_component
+      validate :notify_missing_attachment_if_errored
 
-        def map_model(model)
-          return unless model.categorization
+      delegate :categories, to: :current_component
 
-          self.category_id = model.categorization.decidim_category_id
-        end
+      def map_model(model)
+        return unless model.categorization
 
-        alias component current_component
+        self.category_id = model.categorization.decidim_category_id
+      end
 
-        # Finds the Category from the category_id.
-        #
-        # Returns a Decidim::Category
-        def category
-          @category ||= categories.find_by(id: category_id)
-        end
+      alias component current_component
 
-        # Finds the Scope from the given decidim_scope_id, uses participatory space scope if missing.
-        #
-        # Returns a Decidim::Scope
-        def scope
-          @scope ||= @scope_id ? current_participatory_space.scopes.find_by(id: @scope_id) : current_participatory_space.scope
-        end
+      # Finds the Category from the category_id.
+      #
+      # Returns a Decidim::Category
+      def category
+        @category ||= categories.find_by(id: category_id)
+      end
 
-        # Scope identifier
-        #
-        # Returns the scope identifier related to the proposal
-        def scope_id
-          @scope_id || scope&.id
-        end
+      # Finds the Scope from the given decidim_scope_id, uses participatory space scope if missing.
+      #
+      # Returns a Decidim::Scope
+      def scope
+        @scope ||= @scope_id ? current_participatory_space.scopes.find_by(id: @scope_id) : current_participatory_space.scope
+      end
 
-        private
+      # Scope identifier
+      #
+      # Returns the scope identifier related to the proposal
+      def scope_id
+        @scope_id || scope&.id
+      end
 
-        def scope_belongs_to_participatory_space_scope
-          errors.add(:scope_id, :invalid) if current_participatory_space.out_of_scope?(scope)
-        end
+      private
 
-        # This method will add an error to the `attachment` field only if there's
-        # any error in any other field. This is needed because when the form has
-        # an error, the attachment is lost, so we need a way to inform the user of
-        # this problem.
-        def notify_missing_attachment_if_errored
-          errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
-        end
+      def scope_belongs_to_participatory_space_scope
+        errors.add(:scope_id, :invalid) if current_participatory_space.out_of_scope?(scope)
+      end
+
+      # This method will add an error to the `attachment` field only if there's
+      # any error in any other field. This is needed because when the form has
+      # an error, the attachment is lost, so we need a way to inform the user of
+      # this problem.
+      def notify_missing_attachment_if_errored
+        errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/concerns/formatted_attributes.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/concerns/formatted_attributes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Concerns
+      module FormattedAttributes
+        extend ActiveSupport::Concern
+        included do
+          def formatted_title
+            title.titleize
+          end
+
+          def formatted_body
+            body.titleize
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -6,6 +6,8 @@ module Decidim
     class ProposalForm < Decidim::Form
       mimic :proposal
 
+      include Decidim::Proposals::Concerns::FormattedAttributes
+
       attribute :title, String
       attribute :body, String
       attribute :address, String


### PR DESCRIPTION
#### :tophat: What? Why?
Capitalize title and body for the user is more friendly and avoid the frustration of getting your proposals rejected for a typo, or because you don't know it was mandatory.

#### :pushpin: Related Issues
- Fixes #248

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add tests

### :camera: Screenshots (optional)
![2018-09-13 18 51 12](https://user-images.githubusercontent.com/20232956/45503075-132cbd80-b786-11e8-9bd4-d65b9504a48b.gif)
