### PR TITLE
Fix display of budgets when votes count is activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 **Fixed**:
 
+- **decidim-budgets**: Fix display of budgets when votes count is activated. [\#268](https://github.com/OpenSourcePolitics/decidim/pull/268)
 - **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)
 - **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#200](https://github.com/OpenSourcePolitics/decidim/pull/200)
 - **decidim-core**: Fix test consistency [#222](https://github.com/OpenSourcePolitics/decidim/pull/222)

--- a/decidim-budgets/app/assets/stylesheets/decidim/budgets/budget/_budget-card.scss
+++ b/decidim-budgets/app/assets/stylesheets/decidim/budgets/budget/_budget-card.scss
@@ -1,0 +1,9 @@
+.card__content{
+  .hidden{
+    display: none;
+  }
+}
+
+.card__support_votes{
+  margin-left: 0;
+}

--- a/decidim-budgets/app/assets/stylesheets/decidim/budgets/budget/_budget-list.scss
+++ b/decidim-budgets/app/assets/stylesheets/decidim/budgets/budget/_budget-list.scss
@@ -34,3 +34,15 @@
 .budget--list__action{
   margin-bottom: 0;
 }
+
+.budget-list__data_votes{
+  @include breakpoint(medium){
+    flex-basis: 21rem;
+  }
+}
+
+.budget-list__number_votes{
+  @include breakpoint(medium){
+    font-size: 1.3rem;
+  }
+}

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
@@ -11,22 +11,22 @@
   </div>
   <% if current_user.present? %>
     <% if current_order && current_order.projects.include?(project) %>
-      <div class="card--list__data budget-list__data budget-list__data--added">
-        <span class="card--list__data__number budget-list__number">
+      <div class="card--list__data budget-list__data budget-list__data--added <%= "budget-list__data_votes" if current_settings.show_votes? %>">
+        <span class="card--list__data__number budget-list__number <%= "budget-list__number_votes" if current_settings.show_votes? %>">
           <%= budget_to_currency(project.budget) %>
         </span>
         <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out? || !current_participatory_space.can_participate?(current_user), class: "button tiny budget--list__action success" do %>
           <%= icon("check", class: "icon--small", aria_label: t(".remove"), role: "img") %>
         <% end %>
         <% if current_settings.show_votes? %>
-          <div class="card__support" style="width: 7em">
+          <div class="card__support card__support_votes" style="width: 7em">
             <span><%= t(".count", count: project.confirmed_orders_count) %></span>
           </div>
         <% end %>
       </div>
     <% else %>
-      <div class="card--list__data budget-list__data">
-        <span class="card--list__data__number budget-list__number">
+      <div class="card--list__data budget-list__data <%= 'budget-list__data_votes' if current_settings.show_votes? %>">
+        <span class="card--list__data__number budget-list__number <%= 'budget-list__number_votes' if current_settings.show_votes? %>">
           <%= budget_to_currency(project.budget) %>
         </span>
         <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out? || !current_participatory_space.can_participate?(current_user), class: "button tiny hollow budget--list__action" do %>
@@ -40,8 +40,8 @@
       </div>
     <% end %>
   <% else %>
-    <div class="card--list__data budget-list__data">
-      <span class="card--list__data__number budget-list__number">
+    <div class="card--list__data budget-list__data <%= 'budget-list__data_votes' if current_settings.show_votes? %>">
+      <span class="card--list__data__number budget-list__number <%= 'budget-list__number_votes' if current_settings.show_votes? %>">
         <%= budget_to_currency(project.budget) %>
       </span>
       <a href="#" class="button tiny hollow budget--list__action disabled" data-toggle="loginModal">

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
@@ -25,8 +25,8 @@
         <% end %>
       </div>
     <% else %>
-      <div class="card--list__data budget-list__data <%= 'budget-list__data_votes' if current_settings.show_votes? %>">
-        <span class="card--list__data__number budget-list__number <%= 'budget-list__number_votes' if current_settings.show_votes? %>">
+      <div class="card--list__data budget-list__data <%= "budget-list__data_votes" if current_settings.show_votes? %>">
+        <span class="card--list__data__number budget-list__number <%= "budget-list__number_votes" if current_settings.show_votes? %>">
           <%= budget_to_currency(project.budget) %>
         </span>
         <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true, "redirect-url": project_path(project) }, disabled: !current_settings.votes_enabled? || current_order_checked_out? || !current_participatory_space.can_participate?(current_user), class: "button tiny hollow budget--list__action" do %>
@@ -40,8 +40,8 @@
       </div>
     <% end %>
   <% else %>
-    <div class="card--list__data budget-list__data <%= 'budget-list__data_votes' if current_settings.show_votes? %>">
-      <span class="card--list__data__number budget-list__number <%= 'budget-list__number_votes' if current_settings.show_votes? %>">
+    <div class="card--list__data budget-list__data <%= "budget-list__data_votes" if current_settings.show_votes? %>">
+      <span class="card--list__data__number budget-list__number <%= "budget-list__number_votes" if current_settings.show_votes? %>">
         <%= budget_to_currency(project.budget) %>
       </span>
       <a href="#" class="button tiny hollow budget--list__action disabled" data-toggle="loginModal">

--- a/decidim-core/app/forms/decidim/attachment_form.rb
+++ b/decidim-core/app/forms/decidim/attachment_form.rb
@@ -11,6 +11,5 @@ module Decidim
 
     validates :title, presence: true, if: ->(form) { form.file.present? }
     validates :file, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }
-
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix display of budgets when votes count is activated

#### :pushpin: Related Issues
- Fixes #266

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/45702601-8c575680-bb72-11e8-8f8d-741f83e65267.png)

