### PR TITLE
Fix vote module checkbox in proposals

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/edit.html.erb
@@ -5,3 +5,55 @@
     <%= form.submit t(".update") %>
   </div>
 <% end %>
+<script type="text/javascript">
+
+function disableClick(supports, votes){
+  if (supports.is(":checked")){
+    votes.prop("disabled", true);
+  } else if (votes.is(":checked")){
+    supports.prop("disabled", true);
+  }
+}
+
+function switchDisabling(check1, check2){
+ check1.change(function(){
+      if ($(this).is(":checked")){
+      check2.prop("disabled", true);
+    } else if (!check2.is(":checked") && !$(this).is(":checked")){
+      $(this).prop("disabled", false);
+      check2.prop("disabled", false);
+    } else {
+      $(this).prop("disabled", false);
+      check2.prop("disabled", false);
+    }
+  })
+}
+
+$(document).ready(function() {
+
+  <% if current_participatory_space.has_steps? %>
+
+    <% current_participatory_space.steps.each do |step| %>
+
+      var step_id = <%= step.id %>;
+      var $supports = $('input[name="component[step_settings][' + step_id + '][votes_enabled]"]')
+      var $votes = $('input[name="component[step_settings][' + step_id + '][votes_weight_enabled]"]')
+      disableClick($supports, $votes)
+      switchDisabling($supports, $votes)
+      switchDisabling($votes, $supports)
+
+    <% end %>
+
+  <% else %>
+
+    var participatory_space_id = <%= current_participatory_space.id %>;
+    var $supports = $('input[name="component[step_settings][' + participatory_space_id + '][votes_enabled]"]')
+    var $votes = $('input[name="component[step_settings][' + participatory_space_id + '][votes_weight_enabled]"]')
+    disableClick($supports, $votes)
+    switchDisabling($supports, $votes)
+    switchDisabling($votes, $supports)
+  <% end %>
+
+});
+
+</script>

--- a/decidim-admin/app/views/decidim/admin/components/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/new.html.erb
@@ -6,3 +6,37 @@
     <%= form.submit t(".add") %>
   </div>
 <% end %>
+<script type="text/javascript">
+
+function disableClick(supports, votes){
+  if (supports.is(":checked")){
+    votes.prop("disabled", true);
+  } else if (votes.is(":checked")){
+    supports.prop("disabled", true);
+  }
+}
+
+function switchDisabling(check1, check2){
+ check1.change(function(){
+      if ($(this).is(":checked")){
+      check2.prop("disabled", true);
+    } else if (!check2.is(":checked") && !$(this).is(":checked")){
+      $(this).prop("disabled", false);
+      check2.prop("disabled", false);
+    } else {
+      $(this).prop("disabled", false);
+      check2.prop("disabled", false);
+    }
+  })
+}
+
+$(document).ready(function() {
+  var participatory_space_id = <%= current_participatory_space.id %>;
+  var $supports = $('input[name="component[step_settings][' + participatory_space_id + '][votes_enabled]"]')
+  var $votes = $('input[name="component[step_settings][' + participatory_space_id + '][votes_weight_enabled]"]')
+  disableClick($supports, $votes)
+  switchDisabling($supports, $votes)
+  switchDisabling($votes, $supports)
+});
+
+</script>


### PR DESCRIPTION
#### :tophat: What? Why?
It used to be possible to select both votes module (simple & for/against/neutral).
Now it's not possible anymore :nail_care:

#### :pushpin: Related Issues
- Fixes #287 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry : **truth is, I didn't, because the code was part of former `0.12-stable` and this code had not been backported in `0.12-stable-budget`. So no new development here.**
