### PR TITLE
Add email validation to Managed User Promotion Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 **Fixed**:
 
+- **decidim-admin**: Add email validation to ManagedUserPromotionForm. [\#295](https://github.com/OpenSourcePolitics/decidim/pull/295)
 - **decidim-budgets**: Fix display of budgets when votes count is activated. [\#268](https://github.com/OpenSourcePolitics/decidim/pull/268)
 - **decidim-accountability**: Fix accountability progress to be between 0 and 100 if provided. [\#3952](https://github.com/decidim/decidim/pull/3952)
 - **decidim-participatory_processes**: Fix hastag display on participatory processes. [\#200](https://github.com/OpenSourcePolitics/decidim/pull/200)

--- a/decidim-admin/app/forms/decidim/admin/managed_user_promotion_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/managed_user_promotion_form.rb
@@ -8,6 +8,19 @@ module Decidim
       attribute :email, String
 
       validates :email, presence: true, 'valid_email_2/email': { disposable: true }
+      validate :unique_email
+
+      private
+
+      def unique_email
+        return true if Decidim::User.where(
+          organization: context.current_organization,
+          email: email
+        ).where.not(id: context.current_user.id).empty?
+
+        errors.add :email, :taken
+        false
+      end
     end
   end
 end

--- a/decidim-admin/spec/commands/decidim/admin/promote_managed_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/promote_managed_user_spec.rb
@@ -18,7 +18,8 @@ module Decidim::Admin
       ManagedUserPromotionForm.from_params(
         form_params
       ).with_context(
-        current_organization: organization
+        current_organization: organization,
+        current_user: current_user
       )
     end
     let!(:user) { create :user, :managed, organization: organization }

--- a/decidim-admin/spec/forms/managed_user_promotion_form_spec.rb
+++ b/decidim-admin/spec/forms/managed_user_promotion_form_spec.rb
@@ -5,7 +5,15 @@ require "spec_helper"
 module Decidim
   module Admin
     describe ManagedUserPromotionForm do
-      subject { described_class.from_params(attributes) }
+      subject do
+        described_class.from_params(attributes).with_context(
+          current_organization: current_organization,
+          current_user: user
+        )
+      end
+
+      let(:current_organization) { create(:organization) }
+      let!(:user) { create :user, :confirmed, organization: current_organization }
 
       let(:email) { "foo@example.org" }
       let(:attributes) do
@@ -22,6 +30,12 @@ module Decidim
 
       context "when email is missing" do
         let(:email) {}
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when email already exist" do
+        let!(:another_user) { create :user, :confirmed, email: email, organization: current_organization }
 
         it { is_expected.to be_invalid }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Add validation to Managed User Promotion Form to avoid an unexplicit error on the form.

#### :pushpin: Related Issues
- Fixes #294 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/46344357-2c1be680-c641-11e8-93b3-1b0df1601719.png)

