### PR TITLE
Fix notifications sending when there's no component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 **Backported**:
 
+- **decidim-core**: Fix notifications sending when there's no component. [\#348](https://github.com/opensourcepolitics/decidim/pull/348)
 - **decidim-surveys**: Allow deleting surveys components when there are no answers [#211](https://github.com/OpenSourcePolitics/decidim/pull/211)
 - **decidim-proposals**: Hide withdrawn proposals from index [\#4012](https://github.com/decidim/decidim/pull/4012)
 - **decidim-proposals**: Hide withdrawn proposals from index [\#4012](https://github.com/decidim/decidim/pull/4012)

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -73,7 +73,7 @@ module Decidim
       def notifiable?
         return false if resource.is_a?(Decidim::Publicable) && !resource.published?
         return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
-        return false unless component&.published?
+        return false if component && !component.published?
 
         return false if participatory_space.is_a?(Decidim::Participable) && !participatory_space.can_participate?(user)
 
@@ -90,6 +90,7 @@ module Decidim
       end
 
       def participatory_space
+        return resource if resource.is_a?(Decidim::ParticipatorySpaceResourceable)
         component&.participatory_space
       end
 

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -119,16 +119,17 @@ module Decidim
           it { is_expected.not_to be_notifiable }
         end
       end
-    end
 
-    context "when the resource is a participatory space" do
-      let(:resource) { build(:participatory_process) }
+      context "when the resource is a participatory space" do
+        let(:resource) { build(:participatory_process) }
 
-      it { is_expected.to be_notifiable }
-      context "when it is not published" do
-        let(:resource) { build(:participatory_process, :unpublished) }
+        it { is_expected.to be_notifiable }
 
-        it { is_expected.not_to be_notifiable }
+        context "when it is not published" do
+          let(:resource) { build(:participatory_process, :unpublished) }
+
+          it { is_expected.not_to be_notifiable }
+        end
       end
     end
   end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -120,5 +120,16 @@ module Decidim
         end
       end
     end
+
+    context "when the resource is a participatory space" do
+      let(:resource) { build(:participatory_process) }
+
+      it { is_expected.to be_notifiable }
+      context "when it is not published" do
+        let(:resource) { build(:participatory_process, :unpublished) }
+
+        it { is_expected.not_to be_notifiable }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If a notification was triggered by a resource that didn't have a component (like attaching a file to a participatory process), no notification was being sent.

#### :pushpin: Related Issues
- Backported from #3792
- Fixes #344 #297

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
