### PR TITLE
Fix display of comments count when comment has been moderated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ use the following command in your rails console : `Decidim::User.find_each { |us
 
 **Fixed**:
 
+- **decidim-core**: Fix comments count when a comment has been moderated [\#349](https://github.com/OpenSourcePolitics/decidim/pull/349)
 - **decidim-core**: Fix newsletter notification modal [\#342](https://github.com/OpenSourcePolitics/decidim/pull/342) 
 - **decidim-proposals**: Fix responsive car preview for proposals[\#325](https://github.com/OpenSourcePolitics/decidim/pull/325)
 - **decidim-budgets**: Add hyphens to budget card. [\#305](https://github.com/OpenSourcePolitics/decidim/pull/305)

--- a/decidim-core/app/cells/decidim/card_m_cell.rb
+++ b/decidim-core/app/cells/decidim/card_m_cell.rb
@@ -101,6 +101,7 @@ module Decidim
     end
 
     def comments_count
+      return model.comments.not_hidden.count if model.comments.respond_to? :not_hidden
       model.comments.count
     end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -21,6 +21,24 @@ describe "Explore meetings", type: :system do
       end
     end
 
+    context "when comments have been moderated" do
+      let(:meeting) { create(:meeting, component: component) }
+      let!(:comments) { create_list(:comment, 3, commentable: meeting) }
+      let!(:moderation) { create :moderation, reportable: comments.first, hidden_at: 1.day.ago }
+
+      it "displays unhidden comments count" do
+        visit_component
+
+        within("#meeting_#{meeting.id}") do
+          within(".card__status") do
+            within(".card-data__item:last-child") do
+              expect(page).to have_content(2)
+            end
+          end
+        end
+      end
+    end
+
     context "when filtering" do
       it "allows searching by text" do
         visit_component

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -256,6 +256,23 @@ describe "Proposals", type: :system do
       expect(page).to have_css(".card--proposal", count: 3)
     end
 
+    context "when comments have been moderated" do
+      let(:proposal) { create(:proposal, component: component) }
+      let(:author) { create(:user, :confirmed, organization: component.organization) }
+      let!(:comments) { create_list(:comment, 3, commentable: proposal) }
+      let!(:moderation) { create :moderation, reportable: comments.first, hidden_at: 1.day.ago }
+
+      it "displays unhidden comments count" do
+        visit_component
+
+        within("#proposal_#{proposal.id}") do
+          within(".card-data__item:last-child") do
+            expect(page).to have_content(2)
+          end
+        end
+      end
+    end
+
     describe "default ordering" do
       it_behaves_like "a random proposal ordering"
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix comments count when a comment has been moderated

#### :pushpin: Related Issues
- Fixes : 
#215

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add system test for proposals
- [x] Add system test for meetings
