### PR TITLE
:bug: fix translatable_presence asterisk when only one locale

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -40,7 +40,7 @@ module Decidim
         return send(
           type,
           "#{name}_#{locales.first.to_s.gsub("-", "__")}",
-          options.merge(label: options[:label] || label_for(name))
+          options.merge(label: label_i18n(name, options[:label] || label_for(name)))
         )
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When only one locale is activated, the asterisk for required field is missing. 

### 2 Locales
![steamroll formulaire rencontre](https://user-images.githubusercontent.com/464350/50108056-956cc800-0234-11e9-9562-80c3d36c737a.png)

### 1 Locale
![nancy formulaire rencontre](https://user-images.githubusercontent.com/464350/50108078-9f8ec680-0234-11e9-8656-4460f0c644da.png)


