### PR TITLE
0.12 - Exports fixes

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/result_serializer.rb
+++ b/decidim-accountability/lib/decidim/accountability/result_serializer.rb
@@ -6,6 +6,7 @@ module Decidim
     # formats.
     class ResultSerializer < Decidim::Exporters::Serializer
       include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
 
       # Public: Initializes the serializer with a result.
       def initialize(result)
@@ -18,11 +19,11 @@ module Decidim
           id: result.id,
           category: {
             id: result.category.try(:id),
-            name: result.category.try(:name)
+            name: result.category.try(:name) || empty_translatable
           },
           scope: {
             id: result.scope.try(:id),
-            name: result.scope.try(:name)
+            name: result.scope.try(:name) || empty_translatable
           },
           parent: {
             id: result.parent.try(:id)
@@ -34,7 +35,7 @@ module Decidim
           status: {
             id: result.status.try(:id),
             key: result.status.try(:key),
-            name: result.status.try(:name)
+            name: result.status.try(:name) || empty_translatable
           },
           progress: result.progress,
           created_at: result.created_at,

--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -4,6 +4,7 @@ module Decidim
   module Comments
     class CommentSerializer < Decidim::Exporters::Serializer
       include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
 
       # Serializes a comment
       def serialize
@@ -19,7 +20,7 @@ module Decidim
           depth: resource.depth,
           user_group: {
             id: resource.user_group.try(:id),
-            name: resource.user_group.try(:name)
+            name: resource.user_group.try(:name) || empty_translatable
           },
           commentable_id: resource.decidim_commentable_id,
           commentable_type: resource.decidim_commentable_type,

--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -23,7 +23,7 @@ module Decidim
 
     def empty_translatable(locales = Decidim.available_locales)
       locales.each_with_object({}) do |locale, result|
-        result[locale.to_s] = ''
+        result[locale.to_s] = ""
       end
     end
 

--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -20,6 +20,13 @@ module Decidim
         end
       end
     end
-    module_function :multi_translation
+
+    def empty_translatable(locales = Decidim.available_locales)
+      locales.each_with_object({}) do |locale, result|
+        result[locale.to_s] = ''
+      end
+    end
+
+    module_function :multi_translation, :empty_translatable
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -6,6 +6,7 @@ module Decidim
     # formats.
     class ProposalSerializer < Decidim::Exporters::Serializer
       include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
 
       # Public: Initializes the serializer with a proposal.
       def initialize(proposal)
@@ -18,11 +19,11 @@ module Decidim
           id: @proposal.id,
           category: {
             id: @proposal.category.try(:id),
-            name: @proposal.category.try(:name)
+            name: @proposal.category.try(:name) || empty_translatable
           },
           scope: {
             id: @proposal.scope.try(:id),
-            name: @proposal.scope.try(:name)
+            name: @proposal.scope.try(:name) || empty_translatable
           },
           title: @proposal.title,
           body: @proposal.body,

--- a/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
@@ -15,6 +15,7 @@ module Decidim
       # Public: Exports a hash with the serialized data for the user answers.
       def serialize
         @survey_answers.each_with_index.inject({}) do |serialized, (answer, idx)|
+          serialized.update(:date => answer.created_at.strftime("%Y-%m-%d %H:%M:%S"))
           serialized.update("#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer))
         end
       end

--- a/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
@@ -22,8 +22,13 @@ module Decidim
       private
 
       def normalize_body(answer)
-        answer.body || answer.choices.pluck(:body)
+        answer.body || normalize_choices(answer.choices)
       end
+
+      def normalize_choices(choices)
+        choices.collect { |c| c.try(:custom_body) || c.try(:body) }
+      end
+
     end
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/survey_user_answers_serializer.rb
@@ -15,7 +15,7 @@ module Decidim
       # Public: Exports a hash with the serialized data for the user answers.
       def serialize
         @survey_answers.each_with_index.inject({}) do |serialized, (answer, idx)|
-          serialized.update(:date => answer.created_at.strftime("%Y-%m-%d %H:%M:%S"))
+          serialized.update(date: answer.created_at.strftime("%Y-%m-%d %H:%M:%S"))
           serialized.update("#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer))
         end
       end
@@ -29,7 +29,6 @@ module Decidim
       def normalize_choices(choices)
         choices.collect { |c| c.try(:custom_body) || c.try(:body) }
       end
-
     end
   end
 end


### PR DESCRIPTION
:bug: #417 : fix exports translatable_attr when first line is empty

#### :tophat: What? Why?
Mainly aim to fix #417, but will provides a few fixes for exports for `0.12-stable` ++

- add `empty_translatable` helper to provide blank values
- fix `Decidim::Proposals::ProposalSerializer`
- fix `Decidim::Comments::CommentSerializer`
- fix `Decidim::Accountability::ResultSerializer`
- fix `Decidim::Surveys::SurveyUserAnswersSerializer`
- add `created_at` to survey answer export
- **TODO** : need specific tests on headers

#### :pushpin: Related Issues
- Fixes #417 
- Fixes #360 
- Add #226 

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add tests
