### PR TITLE
Fix/0.12 NEW content processors

### DIFF
--- a/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    #
+    # Decorator for results
+    #
+    class ResultPresenter < SimpleDelegator
+      include Rails.application.routes.mounted_helpers
+      include ActionView::Helpers::UrlHelper
+      include Decidim::TranslationsHelper
+
+      def result_path
+        result = __getobj__
+        Decidim::ResourceLocatorPresenter.new(result).path
+      end
+
+      def display_mention
+        link_to translated_attribute(title), result_path
+      end
+    end
+  end
+end

--- a/decidim-accountability/lib/decidim/accountability.rb
+++ b/decidim-accountability/lib/decidim/accountability.rb
@@ -10,4 +10,11 @@ module Decidim
   module Accountability
     autoload :ResultSerializer, "decidim/accountability/result_serializer"
   end
+  module ContentParsers
+    autoload :ResultParser, "decidim/content_parsers/result_parser"
+  end
+
+  module ContentRenderers
+    autoload :ResultRenderer, "decidim/content_renderers/result_renderer"
+  end
 end

--- a/decidim-accountability/lib/decidim/accountability/engine.rb
+++ b/decidim-accountability/lib/decidim/accountability/engine.rb
@@ -56,6 +56,12 @@ module Decidim
           end
         end
       end
+
+      initializer "decidim.content_processors" do |_app|
+        Decidim.configure do |config|
+          config.content_processors += [:result]
+        end
+      end
     end
   end
 end

--- a/decidim-accountability/lib/decidim/content_parsers/result_parser.rb
+++ b/decidim-accountability/lib/decidim/content_parsers/result_parser.rb
@@ -21,7 +21,7 @@ module Decidim
 
       # Matches a URL
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
-      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/results\/'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/(Result|results)\/'
       URL_REGEX_END_CHAR = '[\w]'
       URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
       # Matches a mentioned Result ID (~(d)+ expression)

--- a/decidim-accountability/lib/decidim/content_parsers/result_parser.rb
+++ b/decidim-accountability/lib/decidim/content_parsers/result_parser.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentParsers
+    # A parser that searches mentions of Results in content.
+    #
+    # This parser accepts two ways for linking Results.
+    # - Using a standard url starting with http or https.
+    # - With a word starting with `~` and digits afterwards will be considered a possible mentioned result.
+    # For example `~1234`, but no `~ 1234`.
+    #
+    # Also fills a `Metadata#linked_results` attribute.
+    #
+    # @see BaseParser Examples of how to use a content parser
+    class ResultParser < BaseParser
+      # Class used as a container for metadata
+      #
+      # @!attribute linked_results
+      #   @return [Array] an array of Decidim::Accountability::Result mentioned in content
+      Metadata = Struct.new(:linked_results)
+
+      # Matches a URL
+      URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/results\/'
+      URL_REGEX_END_CHAR = '[\w]'
+      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
+      # Matches a mentioned Result ID (~(d)+ expression)
+      ID_REGEX = /~(\d+)/
+
+      def initialize(content, context)
+        super
+        @metadata = Metadata.new([])
+      end
+
+      # Replaces found mentions matching an existing
+      # Result with a global id for that Result. Other mentions found that doesn't
+      # match an existing Result are returned as they are.
+      #
+      # @return [String] the content with the valid mentions replaced by a global id.
+      def rewrite
+        rewrited_content = parse_for_urls(content)
+        parse_for_ids(rewrited_content)
+      end
+
+      # (see BaseParser#metadata)
+      attr_reader :metadata
+
+      private
+
+      def parse_for_urls(content)
+        content.gsub(URL_REGEX) do |match|
+          result = result_from_url_match(match)
+          if result
+            @metadata.linked_results << result.id
+            result.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def parse_for_ids(content)
+        content.gsub(ID_REGEX) do |match|
+          result = result_from_id_match(Regexp.last_match(1))
+          if result
+            @metadata.linked_results << result.id
+            result.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def result_from_url_match(match)
+        uri = URI.parse(match)
+        return if uri.path.blank?
+        result_id = uri.path.split("/").last
+        find_result_by_id(result_id)
+      rescue URI::InvalidURIError
+        Rails.logger.error("#{e.message}=>#{e.backtrace}")
+        nil
+      end
+
+      def result_from_id_match(match)
+        result_id = match
+        find_result_by_id(result_id)
+      end
+
+      def find_result_by_id(id)
+        if id.present?
+          spaces = Decidim.participatory_space_manifests.flat_map do |manifest|
+            manifest.participatory_spaces.call(context[:current_organization]).public_spaces
+          end
+          components = Component.where(participatory_space: spaces).published
+          Decidim::Accountability::Result.where(component: components).find_by(id: id)
+        end
+      end
+    end
+  end
+end

--- a/decidim-accountability/lib/decidim/content_renderers/result_renderer.rb
+++ b/decidim-accountability/lib/decidim/content_renderers/result_renderer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentRenderers
+    # A renderer that searches Global IDs representing results in content
+    # and replaces it with a link to their show page.
+    #
+    # e.g. gid://<APP_NAME>/Decidim::Accountability::Result/1
+    #
+    # @see BaseRenderer Examples of how to use a content renderer
+    class ResultRenderer < BaseRenderer
+      # Matches a global id representing a Decidim::User
+      GLOBAL_ID_REGEX = %r{gid:\/\/([\w-]*\/Decidim::Accountability::Result\/(\d+))}i
+
+      # Replaces found Global IDs matching an existing result with
+      # a link to its show page. The Global IDs representing an
+      # invalid Decidim::Accountability::Result are replaced with '???' string.
+      #
+      # @return [String] the content ready to display (contains HTML)
+      def render
+        content.gsub(GLOBAL_ID_REGEX) do |result_gid|
+          begin
+            result = GlobalID::Locator.locate(result_gid)
+            Decidim::Accountability::ResultPresenter.new(result).display_mention
+          rescue ActiveRecord::RecordNotFound
+            result_id = result_gid.split("/").last
+            "~#{result_id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    #
+    # Decorator for projects
+    #
+    class ProjectPresenter < SimpleDelegator
+      include Rails.application.routes.mounted_helpers
+      include ActionView::Helpers::UrlHelper
+      include Decidim::TranslationsHelper
+
+      def author
+        @author ||= Decidim::UserPresenter.new(super)
+      end
+
+      def project_path
+        project = __getobj__
+        Decidim::ResourceLocatorPresenter.new(project).path
+      end
+
+      def display_mention
+        link_to translated_attribute(title), project_path
+      end
+    end
+  end
+end

--- a/decidim-budgets/lib/decidim/budgets.rb
+++ b/decidim-budgets/lib/decidim/budgets.rb
@@ -9,4 +9,11 @@ module Decidim
   # Base module for this engine.
   module Budgets
   end
+  module ContentParsers
+    autoload :ProjectParser, "decidim/content_parsers/project_parser"
+  end
+
+  module ContentRenderers
+    autoload :ProjectRenderer, "decidim/content_renderers/project_renderer"
+  end
 end

--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -31,6 +31,12 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Budgets::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Budgets::Engine.root}/app/views") # for partials
       end
+
+      initializer "decidim.content_processors" do |_app|
+        Decidim.configure do |config|
+          config.content_processors += [:project]
+        end
+      end
     end
   end
 end

--- a/decidim-budgets/lib/decidim/content_parsers/project_parser.rb
+++ b/decidim-budgets/lib/decidim/content_parsers/project_parser.rb
@@ -21,7 +21,7 @@ module Decidim
 
       # Matches a URL
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
-      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/projects\/'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/(Project|projects)\/'
       URL_REGEX_END_CHAR = '[\w]'
       URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
       # Matches a mentioned Project ID (~(d)+ expression)

--- a/decidim-budgets/lib/decidim/content_parsers/project_parser.rb
+++ b/decidim-budgets/lib/decidim/content_parsers/project_parser.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentParsers
+    # A parser that searches mentions of Projects in content.
+    #
+    # This parser accepts two ways for linking Projects.
+    # - Using a standard url starting with http or https.
+    # - With a word starting with `~` and digits afterwards will be considered a possible mentioned project.
+    # For example `~1234`, but no `~ 1234`.
+    #
+    # Also fills a `Metadata#linked_projects` attribute.
+    #
+    # @see BaseParser Examples of how to use a content parser
+    class ProjectParser < BaseParser
+      # Class used as a container for metadata
+      #
+      # @!attribute linked_projects
+      #   @return [Array] an array of Decidim::Budgets::Project mentioned in content
+      Metadata = Struct.new(:linked_projects)
+
+      # Matches a URL
+      URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/projects\/'
+      URL_REGEX_END_CHAR = '[\w]'
+      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
+      # Matches a mentioned Project ID (~(d)+ expression)
+      ID_REGEX = /~(\d+)/
+
+      def initialize(content, context)
+        super
+        @metadata = Metadata.new([])
+      end
+
+      # Replaces found mentions matching an existing
+      # Project with a global id for that Project. Other mentions found that doesn't
+      # match an existing Project are returned as they are.
+      #
+      # @return [String] the content with the valid mentions replaced by a global id.
+      def rewrite
+        rewrited_content = parse_for_urls(content)
+        parse_for_ids(rewrited_content)
+      end
+
+      # (see BaseParser#metadata)
+      attr_reader :metadata
+
+      private
+
+      def parse_for_urls(content)
+        content.gsub(URL_REGEX) do |match|
+          project = project_from_url_match(match)
+          if project
+            @metadata.linked_projects << project.id
+            project.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def parse_for_ids(content)
+        content.gsub(ID_REGEX) do |match|
+          project = project_from_id_match(Regexp.last_match(1))
+          if project
+            @metadata.linked_projects << project.id
+            project.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def project_from_url_match(match)
+        uri = URI.parse(match)
+        return if uri.path.blank?
+        project_id = uri.path.split("/").last
+        find_project_by_id(project_id)
+      rescue URI::InvalidURIError
+        Rails.logger.error("#{e.message}=>#{e.backtrace}")
+        nil
+      end
+
+      def project_from_id_match(match)
+        project_id = match
+        find_project_by_id(project_id)
+      end
+
+      def find_project_by_id(id)
+        if id.present?
+          spaces = Decidim.participatory_space_manifests.flat_map do |manifest|
+            manifest.participatory_spaces.call(context[:current_organization]).public_spaces
+          end
+          components = Component.where(participatory_space: spaces).published
+          Decidim::Budgets::Project.where(component: components).find_by(id: id)
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/lib/decidim/content_renderers/project_renderer.rb
+++ b/decidim-budgets/lib/decidim/content_renderers/project_renderer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentRenderers
+    # A renderer that searches Global IDs representing projects in content
+    # and replaces it with a link to their show page.
+    #
+    # e.g. gid://<APP_NAME>/Decidim::Budgets::Project/1
+    #
+    # @see BaseRenderer Examples of how to use a content renderer
+    class ProjectRenderer < BaseRenderer
+      # Matches a global id representing a Decidim::User
+      GLOBAL_ID_REGEX = %r{gid:\/\/([\w-]*\/Decidim::Budgets::Project\/(\d+))}i
+
+      # Replaces found Global IDs matching an existing project with
+      # a link to its show page. The Global IDs representing an
+      # invalid Decidim::Projects::Project are replaced with '???' string.
+      #
+      # @return [String] the content ready to display (contains HTML)
+      def render
+        content.gsub(GLOBAL_ID_REGEX) do |project_gid|
+          begin
+            project = GlobalID::Locator.locate(project_gid)
+            Decidim::Budgets::ProjectPresenter.new(project).display_mention
+          rescue ActiveRecord::RecordNotFound
+            project_id = project_gid.split("/").last
+            "~#{project_id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -20,9 +20,10 @@ module Decidim
       Metadata = Struct.new(:linked_proposals)
 
       # Matches a URL
-      URL_REGEX_PART1 = '(?i)\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|'
-      URL_REGEX_PART2 = '\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
-      URL_REGEX = /#{URL_REGEX_PART1}#{URL_REGEX_PART2}/i
+      URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/proposals\/'
+      URL_REGEX_END_CHAR = '[\w]'
+      URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
       # Matches a mentioned Proposal ID (~(d)+ expression)
       ID_REGEX = /~(\d+)/
 
@@ -72,8 +73,12 @@ module Decidim
 
       def proposal_from_url_match(match)
         uri = URI.parse(match)
+        return if uri.path.blank?
         proposal_id = uri.path.split("/").last
         find_proposal_by_id(proposal_id)
+      rescue URI::InvalidURIError
+        Rails.logger.error("#{e.message}=>#{e.backtrace}")
+        nil
       end
 
       def proposal_from_id_match(match)

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -21,7 +21,7 @@ module Decidim
 
       # Matches a URL
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
-      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/proposals\/'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+\/(Proposal|proposals)\/'
       URL_REGEX_END_CHAR = '[\w]'
       URL_REGEX = /#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}#{URL_REGEX_END_CHAR}/i
       # Matches a mentioned Proposal ID (~(d)+ expression)


### PR DESCRIPTION
#### :tophat: What? Why?
Detected with #421 : Component object path (like Results or Projects) are interpreted as Proposals when adding a link in a comment.

> We might leave this one opened to push it to `0.16-stable`

This PR intend to : 
- check the embed link for actual reference to `/proposals/` in their path
- add the same mecanism for `Accountability` `Results`
- add the same mecanism for `Budgets` `Projects`
- the new content processors should check for their "model" in the parsed urls (like the fix for `/proposals/`)

#### :pushpin: Related Issues
- Fixes #421

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] **TODO** Add specific tests

