### PR TITLE
Fix empty action btn text

### DIFF
--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -25,6 +25,12 @@ module Decidim
       Truncato.truncate(text, options)
     end
 
+    def translated_in_current_locale(attribute)
+      return if attribute.nil?
+
+      attribute[I18n.locale.to_s].present?
+    end
+
     def present(object)
       presenter = "#{object.class.name}Presenter".constantize.new(object)
 

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m_cell.rb
@@ -37,7 +37,7 @@ module Decidim
       end
 
       def step_action_btn_text
-        if model.active_step&.action_btn_text
+        if translated_in_current_locale(model.active_step&.action_btn_text)
           translated_attribute(model.active_step.action_btn_text)
         else
           t("participatory_processes.participatory_process.take_part", scope: "layouts.decidim")

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -16,7 +16,7 @@ module Decidim
       end
 
       def action_btn(process, locale)
-        if process.active_step&.action_btn_text
+        if translated_in_current_locale(promoted_process.active_step&.action_btn_text)
           translated_attribute(process.active_step.action_btn_text)
         else
           locale

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
@@ -17,7 +17,7 @@
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to participatory_process_path(promoted_process), class: "button expanded button--sc" do %>
-              <% if promoted_process.active_step&.action_btn_text %>
+              <% if translated_in_current_locale(promoted_process.active_step&.action_btn_text) %>
                 <%= translated_attribute(promoted_process.active_step.action_btn_text) %>
               <% else %>
                 <%= t("participatory_processes.promoted_process.take_part", scope: "layouts.decidim") %>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -235,7 +235,7 @@ describe "Participatory Processes", type: :system do
           end
 
           context "with action button" do
-            let(:action_btn_text) { "SEE" }
+            let(:action_btn_text) { { en: "SEE", ca: "", es: "" } }
             let!(:active_step) do
               create(:participatory_process_step,
                      :active,
@@ -257,8 +257,33 @@ describe "Participatory Processes", type: :system do
               end
             end
 
+            context "when action btn is blank in current locale" do
+              let(:action_btn_text) { { en: "", ca: "HEY!", es: "HEY!" } }
+
+              it "display default button" do
+                visit decidim_participatory_processes.participatory_processes_path
+                within find("#processes-grid .column", text: translated(promoted_process.title)) do
+                  within ".card__footer .card__button" do
+                    expect(page).to have_content("TAKE PART")
+                  end
+                end
+              end
+            end
+
+            context "when action btn is blank in another locale" do
+              let(:action_btn_text) { { en: "HEY!", ca: "", es: "" } }
+
+              it "display default button" do
+                visit decidim_participatory_processes.participatory_processes_path
+                within find("#processes-grid .column", text: translated(promoted_process.title)) do
+                  within ".card__footer .card__button" do
+                    expect(page).to have_content("HEY!")
+                  end
+                end
+              end
+            end
+
             it "display custom button" do
-              active_step.action_btn_text = "SEE"
               visit decidim_participatory_processes.participatory_processes_path
               within find("#processes-grid .column", text: translated(promoted_process.title)) do
                 within ".card__footer .card__button" do
@@ -281,7 +306,7 @@ describe "Participatory Processes", type: :system do
           end
 
           context "with action button" do
-            let(:action_btn_text) { "SEE" }
+            let(:action_btn_text) { { en: "SEE", ca: "SEE", es: "SEE" } }
             let!(:active_step) do
               create(:participatory_process_step,
                      :active,
@@ -307,6 +332,32 @@ describe "Participatory Processes", type: :system do
                 within find("#highlighted-processes .card--full .card--full__image") do
                   within ".button" do
                     expect(page).to have_content("TAKE PART")
+                  end
+                end
+              end
+            end
+
+            context "when action btn is blank in current locale" do
+              let(:action_btn_text) { { en: "", ca: "HEY!", es: "HEY!" } }
+
+              it "display default button" do
+                visit decidim_participatory_processes.participatory_processes_path
+                within find("#highlighted-processes .card--full .card--full__image") do
+                  within ".button" do
+                    expect(page).to have_content("TAKE PART")
+                  end
+                end
+              end
+            end
+
+            context "when action btn is blank in another locale" do
+              let(:action_btn_text) { { en: "HEY!", ca: "", es: "" } }
+
+              it "display default button" do
+                visit decidim_participatory_processes.participatory_processes_path
+                within find("#highlighted-processes .card--full .card--full__image") do
+                  within ".button" do
+                    expect(page).to have_content("HEY!")
                   end
                 end
               end


### PR DESCRIPTION
#### :tophat: What? Why?
Fix action btn text when a participatory process is created without it.

#### :pushpin: Related Issues
- Fixes #407

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [X] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20232956/52793307-ba7f8a80-306d-11e9-888e-9c9a407f7409.png)


### :ghost: GIF (optional)
![Description](https://media.giphy.com/media/HshpySC5VVtok/giphy.gif)
