### PR TITLE
Restore Debates export form component manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 ## 0.16 - OSP specific changes:
 
 Upgrade note:
-- Changes ruby version from 2.3 to 2.5.3 
+- Changes ruby version from 2.3 to 2.5.3
 
 **Added**:
 
 - **decidim-budgets**: Add Email notification for vote confirmation. [\#489](https://github.com/OpenSourcePolitics/decidim/pull/489)
-- **decidim-proposals**: Add multiple fields to proposals export. [\#602](https://github.com/OpenSourcePolitics/decidim/pull/602) 
+- **decidim-proposals**: Add multiple fields to proposals export. [\#602](https://github.com/OpenSourcePolitics/decidim/pull/602)
 - **decidim-proposals**: Change collaborative draft contributors permissions [\#4712](https://github.com/decidim/decidim/pull/4712)
 - **decidim-proposals**: Lists are imported as a single proposal. [\#4801](https://github.com/decidim/decidim/pull/4801)
 - **decidim-admin**: Add css variables for multitenant custom colors. [\#4882](https://github.com/decidim/decidim/pull/4882)
@@ -43,6 +43,7 @@ Upgrade note:
 - **decidim-proposals** Public view of Participatory Text is now preserving new lines. [\#4801](https://github.com/decidim/decidim/pull/4801)
 - **decidim-core**: Fix action authorizer with blank permissions [\#4746](https://github.com/decidim/decidim/pull/4746)
 - **decidim-assemblies**: Fix assemblies filter by type [\#4777](https://github.com/decidim/decidim/pull/4777)
+- **decidim-debates**: Restore Debates export form component manifest [\#633](https://github.com/OpenSourcePolitics/decidim/pull/633)
 
 ## [0.16.0](https://github.com/decidim/decidim/tree/v0.16.0)
 

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -36,6 +36,28 @@ Decidim.register_component(:debates) do |component|
 
   component.actions = %w(create)
 
+  component.exports :debates do |exports|
+    exports.collection do |component_instance|
+      Decidim::Debates::Debate
+        .where(component: component_instance)
+        .includes(component: { participatory_space: :organization })
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Debates::DebateSerializer
+  end
+
+  component.exports :comments do |exports|
+    exports.collection do |component_instance|
+      Decidim::Comments::Export.comments_for_resource(
+        Decidim::Debates::Debate, component_instance
+      )
+    end
+
+    exports.serializer Decidim::Comments::CommentSerializer
+  end
+
   component.seeds do |participatory_space|
     admin_user = Decidim::User.find_by(
       organization: participatory_space.organization,

--- a/decidim-debates/lib/decidim/debates/debate_serializer.rb
+++ b/decidim-debates/lib/decidim/debates/debate_serializer.rb
@@ -5,7 +5,9 @@ module Decidim
     # This class serializes a debate so can be exported to CSV, JSON or other
     # formats.
     class DebateSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
 
       # Public: Initializes the serializer with a debate.
       def initialize(debate)
@@ -15,14 +17,24 @@ module Decidim
       # Public: Exports a hash with the serialized data for this debate.
       def serialize
         {
-          id: @debate.id,
-          author_id: @debate.author.try(:id),
-          title: @debate.title,
-          description: @debate.description,
-          comments: @debate.comments.count,
-          created_at: @debate.created_at,
+          id: debate.id,
+          title: present(debate).title,
+          description: present(debate).description,
+          comments: debate.comments.count,
           url: url,
-          component: { id: component.id }
+          category: {
+            id: debate.category.try(:id),
+            name: debate.category.try(:name) || empty_translatable
+          },
+          component: { id: component.id },
+          participatory_space: {
+            id: debate.participatory_space.id,
+            url: Decidim::ResourceLocatorPresenter.new(debate.participatory_space).url
+          },
+          created_at: debate.created_at,
+          start_time: debate.start_time,
+          end_time: debate.end_time,
+          author_url: Decidim::UserPresenter.new(debate.author).try(:profile_url)
         }
       end
 

--- a/decidim-debates/spec/services/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/services/decidim/debates/debate_serializer_spec.rb
@@ -25,14 +25,14 @@ module Decidim
           expect(serialized).to include(id: debate.id)
         end
 
-        it "serializes the author id" do
-          expect(serialized).to include(author_id: debate.author.id)
+        it "serializes the author profile url" do
+          expect(serialized[:author_url]).to match(%r{http.*/profiles})
         end
 
         context "when there is no author id" do
           it "serializes the author id with nilll" do
             debate.author = nil
-            expect(serialized).to include(author_id: nil)
+            expect(serialized).to include(author_url: "")
           end
         end
 
@@ -52,12 +52,35 @@ module Decidim
           expect(serialized).to include(created_at: debate.created_at)
         end
 
+        context "when start and end time are set" do
+          it "serializes the start and time" do
+            debate.start_time = 1.day.ago
+            debate.end_time = 1.day.from_now
+            expect(serialized).to include(start_time: debate.start_time)
+            expect(serialized).to include(end_time: debate.end_time)
+          end
+        end
+
+        context "when start and end time are not set" do
+          it "serializes the start and time as nilll" do
+            debate.start_time = nil
+            debate.end_time = nil
+            expect(serialized).to include(start_time: nil)
+            expect(serialized).to include(end_time: nil)
+          end
+        end
+
         it "serializes the url" do
           expect(serialized[:url]).to include("http", debate.id.to_s)
         end
 
         it "serializes the component" do
           expect(serialized[:component]).to include(id: debate.component.id)
+        end
+
+        it "serializes the participatory space" do
+          expect(serialized[:participatory_space]).to include(id: participatory_process.id)
+          expect(serialized[:participatory_space][:url]).to include("http", participatory_process.slug)
         end
       end
     end

--- a/decidim-debates/spec/shared/export_debates_examples.rb
+++ b/decidim-debates/spec/shared/export_debates_examples.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+shared_examples "export debates" do
+  let!(:debates) { create_list :debate, 3, component: current_component }
+
+  it "exports a CSV" do
+    find(".exports.dropdown").click
+    perform_enqueued_jobs { click_link "Debates as CSV" }
+
+    within ".callout.success" do
+      expect(page).to have_content("in progress")
+    end
+
+    expect(last_email.subject).to include("debates", "csv")
+    expect(last_email.attachments.length).to be_positive
+    expect(last_email.attachments.first.filename).to match(/^debates.*\.zip$/)
+  end
+
+  it "exports a JSON" do
+    find(".exports.dropdown").click
+    perform_enqueued_jobs { click_link "Debates as JSON" }
+
+    within ".callout.success" do
+      expect(page).to have_content("in progress")
+    end
+
+    expect(last_email.subject).to include("debates", "json")
+    expect(last_email.attachments.length).to be_positive
+    expect(last_email.attachments.first.filename).to match(/^debates.*\.zip$/)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Restore the Export feature on Debates component 

#### :pushpin: Related Issues
- Fixes #632

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
