### PR TITLE
BackMultitenant SMTP (#4698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Upgrade note:
 - **decidim-proposals** Lists are imported as a single proposal. [\#4801](https://github.com/decidim/decidim/pull/4801)
 - **decidim-proposals**: Add Participatory Text support for links in Markdown. [\#4801](https://github.com/decidim/decidim/pull/4801)
 - **decidim-proposals**: Add Participatory Text support for images in Markdown. [\#4801](https://github.com/decidim/decidim/pull/4801)
+- **decidim-system**: Add custom SMTP settings for multitenant [#4698](https://github.com/decidim/decidim/pull/4698)
 
 **Changed**:
 

--- a/decidim-accountability/config/locales/fi-pl.yml
+++ b/decidim-accountability/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:

--- a/decidim-accountability/config/locales/fr.yml
+++ b/decidim-accountability/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:

--- a/decidim-accountability/config/locales/hu.yml
+++ b/decidim-accountability/config/locales/hu.yml
@@ -206,7 +206,7 @@ hu:
         result_progress_updated:
           email_intro: 'A "%{resource_title}" eredmény, amely magában foglalja a "%{proposal_title}" javaslatot, most már %{progress}% -ban teljes. Láthatod ezt erről oldalról:'
           email_outro: Ezt az értesítést azért kaptad, mert "%{proposal_title}" -t követed, és ez a javaslat szerepel a "%{resource_title}" eredményben. Leállíthatoa az értesítések fogadását követve az előző linket.
-          email_subject: '%{resource_title} frissítése'
+          email_subject: "%{resource_title} frissítése"
           notification_title: Az eredmény <a href="%{resource_path}">%{resource_title}</a>, amely magában foglalja a <a href="%{proposal_path}">%{proposal_title}</a>javaslatot, most %{progress}%-ban teljes.
     metrics:
       results:

--- a/decidim-accountability/config/locales/id-ID.yml
+++ b/decidim-accountability/config/locales/id-ID.yml
@@ -1,224 +1,227 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       result:
         decidim_accountability_status_id: Status
-        decidim_category_id: Kategori
-        decidim_scope_id: Cakupan
-        description: Deskripsi
-        end_date: Tanggal akhir
-        progress: Kemajuan
-        project_ids: Termasuk proyek
-        proposals: Termasuk proposal
-        start_date: Mulai tanggal
-        title: Judul
-        updated_at: Diperbarui pada
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        end_date: End date
+        progress: Progress
+        project_ids: Included projects
+        proposals: Included proposals
+        start_date: Start date
+        title: Title
+        updated_at: Updated at
       status:
-        description: Deskripsi
-        key: Kunci
-        name: Nama
-        progress: Kemajuan
+        description: Description
+        key: Key
+        name: Name
+        progress: Progress
       timeline_entry:
-        description: Deskripsi
-        entry_date: Tanggal
+        description: Description
+        entry_date: Date
     models:
-      decidim/accountability/proposal_linked_event: Proposal termasuk dalam hasil
-      decidim/accountability/result_progress_updated_event: Kemajuan hasil diperbarui
+      decidim/accountability/proposal_linked_event: Proposal included in a result
+      decidim/accountability/result_progress_updated_event: Result progress updated
   activerecord:
     models:
       decidim/accountability/result:
-        other: Hasil
+        one: Result
+        other: Results
   decidim:
     accountability:
       actions:
-        confirm_destroy: Anda yakin ingin menghapus %{name}ini?
-        destroy: Menghapus
+        confirm_destroy: Are you sure you want to delete this %{name}?
+        destroy: Delete
         edit: Edit
-        new: Baru %{name}
-        preview: Pratinjau
-        timeline_entries: Evolusi proyek
-        title: Tindakan
+        new: New %{name}
+        preview: Preview
+        timeline_entries: Project evolution
+        title: Actions
       admin:
         exports:
-          results: Hasil
+          results: Results
         models:
           result:
-            name: Hasil
+            name: Result
           status:
             name: Status
           timeline_entry:
-            name: Entri waktu
+            name: Timeline entry
         results:
           create:
-            invalid: Terjadi masalah saat membuat hasil ini
-            success: Hasil berhasil dibuat
+            invalid: There's been a problem creating this result
+            success: Result successfully created
           destroy:
-            success: Hasilnya berhasil dihapus
+            success: Result successfully deleted
           edit:
-            title: Edit hasil
-            update: Perbarui hasil
+            title: Edit result
+            update: Update result
           form:
-            add_proposal: Tambahkan proposal
+            add_proposal: Add proposal
           index:
-            title: Hasil
+            title: Results
           new:
-            create: Buat hasil
-            title: Hasil baru
+            create: Create result
+            title: New result
           proposals:
-            close: Dekat
-            current_selection: Pilihan saat ini
-            select: Memilih
+            close: Close
+            current_selection: Current selection
+            select: Select
           update:
-            invalid: Terjadi masalah saat memperbarui hasil ini
-            success: Hasilnya berhasil diperbarui
+            invalid: There's been a problem updating this result
+            success: Result successfully updated
         shared:
           subnav:
-            statuses: Status
+            statuses: Statuses
         statuses:
           create:
-            invalid: Terjadi masalah saat membuat status ini
-            success: Status berhasil dibuat
+            invalid: There's been a problem creating this status
+            success: Status successfully created
           destroy:
-            success: Status berhasil dihapus
+            success: Status successfully deleted
           edit:
             title: Edit status
-            update: Memperbaharui status
+            update: Update status
           index:
-            title: Status
+            title: Statuses
           new:
-            create: Buat status
-            title: Status baru
+            create: Create status
+            title: New status
           update:
-            invalid: Terjadi masalah saat memperbarui status ini
-            success: Status berhasil diperbarui
+            invalid: There's been a problem updating this status
+            success: Status successfully updated
         timeline_entries:
           create:
-            invalid: Terjadi masalah saat membuat entri ini
-            success: Entri berhasil dibuat
+            invalid: There's been a problem creating this entry
+            success: Entry successfully created
           destroy:
-            success: Entri berhasil dihapus
+            success: Entry successfully deleted
           edit:
-            title: Edit entri
-            update: Perbarui entri
+            title: Edit entry
+            update: Update entry
           index:
-            title: Entri garis waktu proyek
+            title: Project timeline entries
           new:
-            create: Buat entri
-            title: Masukan baru
+            create: Create entry
+            title: New entry
           update:
-            invalid: Terjadi masalah saat memperbarui entri ini
-            success: Entri berhasil diperbarui
+            invalid: There's been a problem updating this entry
+            success: Entry successfully updated
       admin_log:
         result:
-          create: "%{user_name} hasil yang dibuat %{resource_name} dalam %{space_name}"
-          delete: "%{user_name} menghapus hasil %{resource_name} di %{space_name}"
-          update: "%{user_name} hasil pembaruan %{resource_name} dalam %{space_name}"
+          create: "%{user_name} created result %{resource_name} in %{space_name}"
+          delete: "%{user_name} deleted the %{resource_name} result in %{space_name}"
+          update: "%{user_name} updated result %{resource_name} in %{space_name}"
         value_types:
           parent_presenter:
-            not_found: 'Induk tidak ditemukan pada basis data (ID: %{id})'
+            not_found: 'The parent was not found on the database (ID: %{id})'
       last_activity:
-        new_result_at_html: "<span>Hasil baru di %{link}</span>"
+        new_result_at_html: "<span>New result at %{link}</span>"
       models:
         result:
           fields:
-            end_date: Tanggal akhir
-            progress: Kemajuan
-            start_date: Mulai tanggal
+            end_date: End date
+            progress: Progress
+            start_date: Start date
             status: Status
-            title: Judul
+            title: Title
         status:
           fields:
-            description: Deskripsi
-            key: Kunci
-            name: Nama
-            progress: Kemajuan
+            description: Description
+            key: Key
+            name: Name
+            progress: Progress
         timeline_entry:
           fields:
-            description: Deskripsi
-            entry_date: Tanggal
+            description: Description
+            entry_date: Date
       results:
         count:
           results_count:
-            other: "%{count} hasil"
+            one: 1 result
+            other: "%{count} results"
         filters:
-          all: Semua
-          scopes: Lingkup
+          all: All
+          scopes: Scopes
         home:
-          categories_label: Kategori
-          subcategories_label: Subkategori
+          categories_label: Categories
+          subcategories_label: Subcategories
         home_header:
-          global_status: Status eksekusi global
+          global_status: Global execution status
         nav_breadcrumb:
-          global: Eksekusi global
+          global: Global execution
         search:
-          search: Cari tindakan
+          search: Search for actions
         show:
           stats:
-            attendees: Hadirin
-            back_to_result: Kembali ke hasil
-            comments: Komentar
-            contributions: Kontribusi
-            last_edited_by: Terakhir diedit oleh
-            last_updated_at: Terakhir diperbarui pada
-            meetings: Rapat
-            number_of_versions: Versi
-            proposals: Proposal
-            show_all_versions: Tampilkan semua versi
-            version_author: Penulis versi
-            version_created_at: Versi dibuat di
-            version_number: Nomor versi
-            version_number_out_of_total: "%{current_version} dari %{total_count}"
-            votes: Mendukung
+            attendees: Attendees
+            back_to_result: Go back to result
+            comments: Comments
+            contributions: Contributions
+            last_edited_by: Last edited by
+            last_updated_at: Last updated at
+            meetings: Meetings
+            number_of_versions: Versions
+            proposals: Proposals
+            show_all_versions: Show all versions
+            version_author: Version author
+            version_created_at: Version created at
+            version_number: Version number
+            version_number_out_of_total: "%{current_version} out of %{total_count}"
+            votes: Supports
         timeline:
-          title: Evolusi proyek
+          title: Project evolution
       versions:
         index:
-          changes_at_title: Perubahan pada "%{title}"
-          title: Versi
+          changes_at_title: Changes at "%{title}"
+          title: Versions
         show:
-          changes_at_title: Perubahan pada "%{title}"
+          changes_at_title: Changes at "%{title}"
         version:
-          version_index: Versi %{index}
+          version_index: Version %{index}
     components:
       accountability:
-        name: Akuntabilitas
+        name: Accountability
         settings:
           global:
-            categories_label: Nama untuk "Kategori"
-            comments_enabled: Komentar diaktifkan
-            display_progress_enabled: Kemajuan tampilan
-            heading_leaf_level_results: Nama untuk "Proyek"
-            heading_parent_level_results: Nama untuk "Hasil"
+            categories_label: Name for "Categories"
+            comments_enabled: Comments enabled
+            display_progress_enabled: Display progress
+            heading_leaf_level_results: Name for "Projects"
+            heading_parent_level_results: Name for "Results"
             intro: Intro
-            subcategories_label: Nama untuk "Subkategori"
+            subcategories_label: Name for "Subcategories"
           step:
-            comments_blocked: Komentar diblokir
+            comments_blocked: Comments blocked
     events:
       accountability:
         proposal_linked:
-          email_intro: 'Proposal "%{proposal_title}" telah dimasukkan dalam hasil. Anda bisa melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{proposal_title}". Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Pembaruan ke %{proposal_title}
-          notification_title: Proposal <a href="%{proposal_path}">%{proposal_title}</a> telah dimasukkan dalam hasil <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: 'The proposal "%{proposal_title}" has been included in a result. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{proposal_title}
+          notification_title: The proposal <a href="%{proposal_path}">%{proposal_title}</a> has been included in the <a href="%{resource_path}">%{resource_title}</a> result.
         result_progress_updated:
-          email_intro: 'Hasil "%{resource_title}", yang termasuk proposal "%{proposal_title}", sekarang %{progress}% selesai. Anda bisa melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{proposal_title}", dan proposal ini termasuk dalam hasil "%{resource_title}". Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Pembaruan ke %{resource_title} berlanjut
-          notification_title: Hasilnya <a href="%{resource_path}">%{resource_title}</a>, yang termasuk proposal <a href="%{proposal_path}">%{proposal_title}</a>, sekarang %{progress}% selesai.
+          email_intro: 'The result "%{resource_title}", which includes the proposal "%{proposal_title}", is now %{progress}% complete. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}", and this proposal is included in the result "%{resource_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title} progress
+          notification_title: The result <a href="%{resource_path}">%{resource_title}</a>, which includes the proposal <a href="%{proposal_path}">%{proposal_title}</a>, is now %{progress}% complete.
     metrics:
       results:
-        description: Jumlah hasil yang dihasilkan
-        object: hasil
-        title: Hasil
+        description: Number of results generated
+        object: results
+        title: Results
     participatory_processes:
       participatory_process_groups:
         highlighted_results:
-          results: Hasil
+          results: Results
     participatory_spaces:
       highlighted_results:
-        see_all: Lihat semua (%{count})
+        see_all: See all (%{count})
     resource_links:
       included_projects:
-        result_project: Proyek termasuk dalam hasil ini
+        result_project: Projects included in this result
       included_proposals:
-        result_proposal: Proposal termasuk dalam hasil ini
+        result_proposal: Proposals included in this result

--- a/decidim-accountability/config/locales/tr-TR.yml
+++ b/decidim-accountability/config/locales/tr-TR.yml
@@ -1,226 +1,227 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       result:
-        decidim_accountability_status_id: durum
-        decidim_category_id: Kategori
-        decidim_scope_id: kapsam
-        description: Açıklama
-        end_date: Bitiş tarihi
-        progress: İlerleme
-        project_ids: Dahil edilen projeler
-        proposals: Dahil edilen teklifler
-        start_date: Başlangıç tarihi
-        title: Başlık
-        updated_at: Adresinde güncellendi
+        decidim_accountability_status_id: Status
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        end_date: End date
+        progress: Progress
+        project_ids: Included projects
+        proposals: Included proposals
+        start_date: Start date
+        title: Title
+        updated_at: Updated at
       status:
-        description: Açıklama
-        key: anahtar
-        name: isim
-        progress: İlerleme
+        description: Description
+        key: Key
+        name: Name
+        progress: Progress
       timeline_entry:
-        description: Açıklama
-        entry_date: tarih
+        description: Description
+        entry_date: Date
     models:
-      decidim/accountability/proposal_linked_event: Teklif bir sonuca dahil edildi
-      decidim/accountability/result_progress_updated_event: Sonuç ilerlemesi güncellendi
+      decidim/accountability/proposal_linked_event: Proposal included in a result
+      decidim/accountability/result_progress_updated_event: Result progress updated
   activerecord:
     models:
       decidim/accountability/result:
-        one: Sonuç
-        other: Sonuçlar
+        one: Result
+        other: Results
   decidim:
     accountability:
       actions:
-        confirm_destroy: Bu %{name}silmek istediğinize emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        new: Yeni %{name}
-        preview: Ön izleme
-        timeline_entries: Proje evrimi
-        title: Eylemler
+        confirm_destroy: Are you sure you want to delete this %{name}?
+        destroy: Delete
+        edit: Edit
+        new: New %{name}
+        preview: Preview
+        timeline_entries: Project evolution
+        title: Actions
       admin:
         exports:
-          results: Sonuçlar
+          results: Results
         models:
           result:
-            name: Sonuç
+            name: Result
           status:
-            name: durum
+            name: Status
           timeline_entry:
-            name: Zaman çizelgesi girişi
+            name: Timeline entry
         results:
           create:
-            invalid: Bu sonucu oluştururken bir sorun oluştu
-            success: Sonuç başarıyla oluşturuldu
+            invalid: There's been a problem creating this result
+            success: Result successfully created
           destroy:
-            success: Sonuç başarıyla silindi
+            success: Result successfully deleted
           edit:
-            title: Sonucu düzenle
-            update: Sonuç güncelle
+            title: Edit result
+            update: Update result
           form:
-            add_proposal: Teklif ekle
+            add_proposal: Add proposal
           index:
-            title: Sonuçlar
+            title: Results
           new:
-            create: Sonuç oluştur
-            title: Yeni sonuç
+            create: Create result
+            title: New result
           proposals:
-            close: Kapat
-            current_selection: Şu anki seçim
-            select: seçmek
+            close: Close
+            current_selection: Current selection
+            select: Select
           update:
-            invalid: Bu sonucu güncellerken bir sorun oluştu
-            success: Sonuç başarıyla güncellendi
+            invalid: There's been a problem updating this result
+            success: Result successfully updated
         shared:
           subnav:
-            statuses: durumlar
+            statuses: Statuses
         statuses:
           create:
-            invalid: Bu durumu oluştururken bir sorun oluştu
-            success: Durum başarıyla oluşturuldu
+            invalid: There's been a problem creating this status
+            success: Status successfully created
           destroy:
-            success: Durum başarıyla silindi
+            success: Status successfully deleted
           edit:
-            title: Durumu düzenle
-            update: Güncelleme durumu
+            title: Edit status
+            update: Update status
           index:
-            title: durumlar
+            title: Statuses
           new:
-            create: Durum oluştur
-            title: Yeni statü
+            create: Create status
+            title: New status
           update:
-            invalid: Bu durumu güncellerken bir sorun oluştu
-            success: Durum başarıyla güncellendi
+            invalid: There's been a problem updating this status
+            success: Status successfully updated
         timeline_entries:
           create:
-            invalid: Bu girişi oluştururken bir sorun oluştu
-            success: Giriş başarıyla oluşturuldu
+            invalid: There's been a problem creating this entry
+            success: Entry successfully created
           destroy:
-            success: Giriş başarıyla silindi
+            success: Entry successfully deleted
           edit:
-            title: Girişi düzenle
-            update: Girişi güncelle
+            title: Edit entry
+            update: Update entry
           index:
-            title: Proje zaman çizelgesi girişleri
+            title: Project timeline entries
           new:
-            create: Giriş oluştur
-            title: Yeni giriş
+            create: Create entry
+            title: New entry
           update:
-            invalid: Bu giriş güncellenirken bir sorun oluştu
-            success: Giriş başarıyla güncellendi
+            invalid: There's been a problem updating this entry
+            success: Entry successfully updated
       admin_log:
         result:
-          create: "%{user_name} sonuç yaratmıştır %{resource_name} içinde %{space_name}"
-          delete: "%{user_name} %{resource_name} sonuçtan %{space_name}sildi"
-          update: "%{user_name} güncellenen sonuç %{resource_name} in %{space_name}"
+          create: "%{user_name} created result %{resource_name} in %{space_name}"
+          delete: "%{user_name} deleted the %{resource_name} result in %{space_name}"
+          update: "%{user_name} updated result %{resource_name} in %{space_name}"
         value_types:
           parent_presenter:
-            not_found: 'Üst veritabanında bulunamadı (ID: %{id})'
+            not_found: 'The parent was not found on the database (ID: %{id})'
       last_activity:
-        new_result_at_html: "<span> %{link}</span>yeni sonuç"
+        new_result_at_html: "<span>New result at %{link}</span>"
       models:
         result:
           fields:
-            end_date: Bitiş tarihi
-            progress: İlerleme
-            start_date: Başlangıç tarihi
-            status: durum
-            title: Başlık
+            end_date: End date
+            progress: Progress
+            start_date: Start date
+            status: Status
+            title: Title
         status:
           fields:
-            description: Açıklama
-            key: anahtar
-            name: isim
-            progress: İlerleme
+            description: Description
+            key: Key
+            name: Name
+            progress: Progress
         timeline_entry:
           fields:
-            description: Açıklama
-            entry_date: tarih
+            description: Description
+            entry_date: Date
       results:
         count:
           results_count:
-            one: 1 sonuç
-            other: "%{count} sonuç"
+            one: 1 result
+            other: "%{count} results"
         filters:
-          all: Herşey
-          scopes: kapsamları
+          all: All
+          scopes: Scopes
         home:
-          categories_label: Kategoriler
-          subcategories_label: Alt Kategoriler
+          categories_label: Categories
+          subcategories_label: Subcategories
         home_header:
-          global_status: Genel yürütme durumu
+          global_status: Global execution status
         nav_breadcrumb:
-          global: Global yürütme
+          global: Global execution
         search:
-          search: İşlemleri ara
+          search: Search for actions
         show:
           stats:
-            attendees: Katılımcılar
-            back_to_result: Sonuca geri dön
-            comments: Yorumlar
-            contributions: Katılımlar
-            last_edited_by: Tarafından düzenlenmiş Son
-            last_updated_at: 'Son güncelleme tarihi:'
-            meetings: Toplantılar
-            number_of_versions: Sürümler
-            proposals: Teklif
-            show_all_versions: Tüm sürümleri göster
-            version_author: Sürüm yazarı
-            version_created_at: '''De oluşturulan sürüm'
-            version_number: Versiyon numarası
-            version_number_out_of_total: "%{current_version} üzerinden %{total_count}"
-            votes: Destekler
+            attendees: Attendees
+            back_to_result: Go back to result
+            comments: Comments
+            contributions: Contributions
+            last_edited_by: Last edited by
+            last_updated_at: Last updated at
+            meetings: Meetings
+            number_of_versions: Versions
+            proposals: Proposals
+            show_all_versions: Show all versions
+            version_author: Version author
+            version_created_at: Version created at
+            version_number: Version number
+            version_number_out_of_total: "%{current_version} out of %{total_count}"
+            votes: Supports
         timeline:
-          title: Proje evrimi
+          title: Project evolution
       versions:
         index:
-          changes_at_title: '"%{title}" daki değişiklikler'
-          title: Sürümler
+          changes_at_title: Changes at "%{title}"
+          title: Versions
         show:
-          changes_at_title: '"%{title}" daki değişiklikler'
+          changes_at_title: Changes at "%{title}"
         version:
-          version_index: Sürüm %{index}
+          version_index: Version %{index}
     components:
       accountability:
-        name: Hesap verebilirlik
+        name: Accountability
         settings:
           global:
-            categories_label: '"Kategoriler" için isim'
-            comments_enabled: Yorumlar etkin
-            display_progress_enabled: Ekran ilerleme
-            heading_leaf_level_results: '"Projelerin" Adı'
-            heading_parent_level_results: '"Sonuçların" Adı'
-            intro: giriş
-            subcategories_label: '"Alt kategoriler" için isim'
+            categories_label: Name for "Categories"
+            comments_enabled: Comments enabled
+            display_progress_enabled: Display progress
+            heading_leaf_level_results: Name for "Projects"
+            heading_parent_level_results: Name for "Results"
+            intro: Intro
+            subcategories_label: Name for "Subcategories"
           step:
-            comments_blocked: Yorumlar engellendi
+            comments_blocked: Comments blocked
     events:
       accountability:
         proposal_linked:
-          email_intro: '"%{proposal_title}" teklifi bir sonuca dahil edildi. Bu sayfadan görebilirsiniz:'
-          email_outro: Bu bildirimi aldınız çünkü "%{proposal_title}" u takip ediyorsun. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.
-          email_subject: '%{proposal_title}güncellemesi'
-          notification_title: <a href="%{proposal_path}">%{proposal_title}</a> teklifi <a href="%{resource_path}">%{resource_title}</a> sonucuna dahil edilmiştir.
+          email_intro: 'The proposal "%{proposal_title}" has been included in a result. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{proposal_title}
+          notification_title: The proposal <a href="%{proposal_path}">%{proposal_title}</a> has been included in the <a href="%{resource_path}">%{resource_title}</a> result.
         result_progress_updated:
-          email_intro: '"%{proposal_title}" önerisini içeren "%{resource_title}" sonucu şimdi% %{progress}tamamlandı. Bu sayfadan görebilirsiniz:'
-          email_outro: '"%{proposal_title}" izlemekte olduğunuz için bu bildirimi aldınız ve bu teklif "%{resource_title}" sonucuna dahil edildi. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-          email_subject: '%{resource_title} ilerleme için güncelleme'
-          notification_title: <a href="%{proposal_path}">%{proposal_title}</a>önerisini içeren sonuç%{resource_title}<a href="%{resource_path}"></a>, şimdi% %{progress}tamamlandı.
+          email_intro: 'The result "%{resource_title}", which includes the proposal "%{proposal_title}", is now %{progress}% complete. You can see it from this page:'
+          email_outro: You have received this notification because you are following "%{proposal_title}", and this proposal is included in the result "%{resource_title}". You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title} progress
+          notification_title: The result <a href="%{resource_path}">%{resource_title}</a>, which includes the proposal <a href="%{proposal_path}">%{proposal_title}</a>, is now %{progress}% complete.
     metrics:
       results:
-        description: Üretilen sonuç sayısı
-        object: Sonuçlar
-        title: Sonuçlar
+        description: Number of results generated
+        object: results
+        title: Results
     participatory_processes:
       participatory_process_groups:
         highlighted_results:
-          results: Sonuçlar
+          results: Results
     participatory_spaces:
       highlighted_results:
-        see_all: Tümünü gör (%{count})
+        see_all: See all (%{count})
     resource_links:
       included_projects:
-        result_project: Bu sonuca dahil edilen projeler
+        result_project: Projects included in this result
       included_proposals:
-        result_proposal: Bu sonuca dahil teklifler
+        result_proposal: Proposals included in this result

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -37,6 +37,8 @@ ca:
         organization_url: URL de l'organització
         redirect_uri: URL de redirecció
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Habilitar insígnies
         cta_button_path: URL del botó d'acció
         cta_button_text: Text del botó d'acció
@@ -45,6 +47,7 @@ ca:
         enable_omnipresent_banner: Mostrar banner omnipresent
         facebook_handler: Nom d'usuari de Facebook
         favicon: Icona
+        from: From email address
         github_handler: Nom d'usuari de GitHub
         header_snippets: Codi personalitzat a la capçalera
         highlighted_content_banner_action_subtitle: Subtítol del botó d'acció
@@ -63,11 +66,17 @@ ca:
         omnipresent_banner_short_description: Descripció breu
         omnipresent_banner_title: Títol
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefix de referència
+        secondary_color: Secondary
         show_statistics: Mostrar estadístiques
+        success_color: Success
         tos_version: Versió del Termes de Servei
         twitter_handler: Nom d'usuari de Twitter
         user_groups_enabled: Activar els grups d'usuaris
+        warning_color: Warning
         youtube_handler: Nom d'usuari de YouTube
       scope:
         code: Codi
@@ -103,9 +112,9 @@ ca:
               must_be_ssl: L'URL de redirecció ha de ser SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Fitxer d'imatge no vàlid
             official_img_footer:
+              allowed_file_content_types: Fitxer d'imatge no vàlid
+            official_img_header:
               allowed_file_content_types: Fitxer d'imatge no vàlid
   activerecord:
     attributes:
@@ -386,6 +395,7 @@ ca:
           fields:
             created_at: Creat el
             name: Nom
+          name: OAuth uygulaması
         participatory_space_private_user:
           name: Usuari privat de l'espai de participació
         scope:
@@ -410,6 +420,7 @@ ca:
             roles:
               admin: Administrador
               user_manager: Administrador d'usuaris
+          name: kullanıcı
         user_group:
           fields:
             actions: Accions
@@ -545,6 +556,7 @@ ca:
         edit:
           update: Actualitzar
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Pots sobreescriure a on enllaça el botó d''acció principal de la pàgina d''inici. Utilitza rutes parcials, no URLs completes aquí. Accepta lletres, números, guions i barres, i ha de començar amb una lletra. El botó d''acció principal es mostra a la pàgina d''inici entre el text de benvinguda i la descripció. Exemple: %{url}'
           cta_button_text_help: Pots sobreescriure el text del botó d'acció principal a la pàgina d'inici per cada idioma disponible a la teva organització. Si no s'omple, s'utilitzarà el valor predeterminat. El botó d'acció principal es mostra a la pàgina d'inici entre el text de benvinguda i la descripció.
           header_snippets_help: Utilitza aquest camp per afegir coses al head d'HTML. L'ús més habitual és integrar serveis de tercers que requereixen codi JavaScript o CSS addicional. A més, pots utilitzar-lo per afegir etiquetes meta addicionals a l'HTML. Tingues en compte que això només es mostrarà a les pàgines públiques, no a la secció d'administració.
@@ -716,12 +728,16 @@ ca:
         hide: Amagar
         not_hidden: No ocult
         title: Accions
+        unhide: Unhide
         unreport: Desfer denúncia
       admin:
         reportable:
           hide:
             invalid: Hi ha hagut un error en ocultar el contingut.
             success: Contingut amagat amb èxit.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Hi ha hagut un problema cancel·lant la denúncia.
             success: Denúncia cancel·lada correctament.

--- a/decidim-admin/config/locales/de.yml
+++ b/decidim-admin/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ de:
         organization_url: Organisations-URL
         redirect_uri: URI umleiten
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Abzeichen aktivieren
         cta_button_path: Call To Action Schaltfläche Pfad
         cta_button_text: Call To Action Schaltfläche Text
@@ -44,6 +47,7 @@ de:
         enable_omnipresent_banner: Zeige allgegenwärtige Banner
         facebook_handler: Facebook-Handler
         favicon: Symbol
+        from: From email address
         github_handler: GitHub-Handler
         header_snippets: Header-Snippets
         highlighted_content_banner_action_subtitle: Aktion Schaltfläche Untertitel
@@ -62,11 +66,17 @@ de:
         omnipresent_banner_short_description: Kurze Beschreibung
         omnipresent_banner_title: Titel
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Referenzpräfix
+        secondary_color: Secondary
         show_statistics: Zeige Statistiken
+        success_color: Success
         tos_version: Nutzungsbedingungen Version
         twitter_handler: Twitter-Handler
         user_groups_enabled: Benutzergruppen aktivieren
+        warning_color: Warning
         youtube_handler: YouTube-Handler
       scope:
         code: Code
@@ -102,9 +112,9 @@ de:
               must_be_ssl: Der Umleitungs-URI muss ein SSL-URI sein
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Ungültige Bilddatei
             official_img_footer:
+              allowed_file_content_types: Ungültige Bilddatei
+            official_img_header:
               allowed_file_content_types: Ungültige Bilddatei
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ de:
         browse: Durchsuche
         export: Export
         manage: Verwalten
-        new: Neu %{name}
         permissions: Berechtigungen
         reject: Ablehnen
         verify: Überprüfen
@@ -306,6 +315,11 @@ de:
         logs_list:
           no_logs_yet: Es gibt noch keine Protokolle
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Es ist ein Fehler aufgetreten, der den verwalteten Benutzer unterstützt.
           success: Der verwaltete Benutzer wurde erfolgreich hochgestuft.
@@ -325,6 +339,7 @@ de:
         help_sections: Hilfeabschnitte
         homepage: Startseite
         impersonations: Identitätswechsel
+        navbar_links: Navbar links
         newsletters: Newsletter
         oauth_applications: OAuth-Anwendungen
         participants: Teilnehmer
@@ -362,6 +377,13 @@ de:
             reason: Grund
             started_at: Fing an bei
             user: Benutzer
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Hergestellt in
@@ -416,6 +438,28 @@ de:
             does_not_belong: Gehört nicht
             offensive: Beleidigend
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Beim Erstellen dieses Newsletters ist ein Fehler aufgetreten.
@@ -445,6 +489,8 @@ de:
         update:
           error: Beim Aktualisieren dieses Newsletters ist ein Fehler aufgetreten.
           success: Newsletter erfolgreich aktualisiert. Bitte überprüfen Sie es vor dem Senden.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Beim Erstellen dieser Anwendung ist ein Fehler aufgetreten.
@@ -510,6 +556,7 @@ de:
         edit:
           update: Aktualisieren
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Sie können überschreiben, wo die Call To Action-Schaltfläche in der Homepage verlinkt ist. Verwenden Sie hier Teilpfade, nicht vollständige URLs. Akzeptiert Buchstaben, Zahlen, Bindestriche und Schrägstriche und muss mit einem Buchstaben beginnen. Die Call To Action-Schaltfläche wird auf der Startseite zwischen Begrüßungstext und Beschreibung angezeigt. Beispiel: %{url}'
           cta_button_text_help: Sie können den Text der Call To Action-Schaltfläche auf der Startseite für jede verfügbare Sprache in Ihrer Organisation überschreiben. Wenn nicht festgelegt, wird der Standardwert verwendet. Die Call To Action-Schaltfläche wird auf der Startseite zwischen Begrüßungstext und Beschreibung angezeigt.
           header_snippets_help: Verwenden Sie dieses Feld, um Dinge zum HTML-Kopf hinzuzufügen. Die häufigste Verwendung ist die Integration von Drittanbieterdiensten, für die zusätzliches JavaScript oder CSS erforderlich ist. Außerdem können Sie damit dem HTML zusätzliche Meta-Tags hinzufügen. Beachten Sie, dass dies nur auf öffentlichen Seiten und nicht im Admin-Bereich erfolgt.
@@ -617,12 +664,16 @@ de:
         dashboard: Instrumententafel
         impersonatable_users: Impersonable Benutzer
         impersonations: Identitätswechsel
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Benutzer
         scope_types: Bereichstypen
         scopes: Bereiche
         static_pages: Seiten
         user_groups: Benutzergruppen
         users: Benutzer
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Beim Lesen der CSV-Datei ist ein Fehler aufgetreten.
@@ -677,12 +728,16 @@ de:
         hide: verbergen
         not_hidden: Nicht versteckt
         title: Aktionen
+        unhide: Unhide
         unreport: Nicht melden
       admin:
         reportable:
           hide:
             invalid: Beim Verbergen der Ressource ist ein Problem aufgetreten.
             success: Ressource erfolgreich ausgeblendet
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Es ist ein Problem aufgetreten, die Ressource nicht zu melden.
             success: Die Ressource wurde erfolgreich nicht gemeldet.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -395,6 +395,7 @@ en:
           fields:
             created_at: Created at
             name: Name
+          name: OAuth uygulaması
         participatory_space_private_user:
           name: Participatory space private user
         scope:
@@ -419,6 +420,7 @@ en:
             roles:
               admin: Admin
               user_manager: User manager
+          name: kullanıcı
         user_group:
           fields:
             actions: Actions

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         organization_url: Organization URL
         redirect_uri: Redirect URI
       organization:
+        address: SMTP hostname
         alert_color: Alert
         badges_enabled: Enable badges
         cta_button_path: Call To Action button path
@@ -46,6 +47,7 @@ en:
         enable_omnipresent_banner: Show omnipresent banner
         facebook_handler: Facebook handler
         favicon: Icon
+        from: From email address
         github_handler: GitHub handler
         header_snippets: Header snippets
         highlighted_content_banner_action_subtitle: Action button subtitle
@@ -64,6 +66,8 @@ en:
         omnipresent_banner_short_description: Short description
         omnipresent_banner_title: Title
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
         primary_color: Primary
         reference_prefix: Reference prefix
         secondary_color: Secondary

--- a/decidim-admin/config/locales/es-PY.yml
+++ b/decidim-admin/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ es-PY:
         organization_url: URL de organización
         redirect_uri: Redirigir URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Habilitar insignias
         cta_button_path: Ruta del botón de acción principal
         cta_button_text: Texto del botón de acción principal
@@ -44,6 +47,7 @@ es-PY:
         enable_omnipresent_banner: Mostrar banner omnipresente
         facebook_handler: Nombre en Facebook
         favicon: Icono
+        from: From email address
         github_handler: Nombre en GitHub
         header_snippets: Snippets de encabezado
         highlighted_content_banner_action_subtitle: Subtítulo del botón de acción
@@ -62,11 +66,17 @@ es-PY:
         omnipresent_banner_short_description: Descripción breve
         omnipresent_banner_title: Título
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefijo de la referencia
+        secondary_color: Secondary
         show_statistics: Mostrar estadísticas
+        success_color: Success
         tos_version: Versión de los Términos de Servicio
         twitter_handler: Nombre de Twitter
         user_groups_enabled: Habilitar grupos de usuarios
+        warning_color: Warning
         youtube_handler: Nombre de YouTube
       scope:
         code: Código
@@ -102,9 +112,9 @@ es-PY:
               must_be_ssl: El URI de redirección debe ser un URI SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Archivo de imagen no válido
             official_img_footer:
+              allowed_file_content_types: Archivo de imagen no válido
+            official_img_header:
               allowed_file_content_types: Archivo de imagen no válido
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ es-PY:
         browse: Explorar
         export: Exportar
         manage: Gestionar
-        new: Nuevo %{name}
         permissions: Permisos
         reject: Rechazar
         verify: Verificar
@@ -306,6 +315,11 @@ es-PY:
         logs_list:
           no_logs_yet: Aún no hay ningún registro de actividad
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Se ha producido un error al promocionar el usuario gestionado.
           success: El usuario gestionado se ha promocionado correctamente.
@@ -325,6 +339,7 @@ es-PY:
         help_sections: Secciones de ayuda
         homepage: Página principal
         impersonations: Impersonaciones
+        navbar_links: Navbar links
         newsletters: Boletines
         oauth_applications: Aplicaciones OAuth
         participants: Participantes
@@ -362,6 +377,13 @@ es-PY:
             reason: Razón
             started_at: Empezó a las
             user: Usuario
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Fecha de creación
@@ -416,6 +438,28 @@ es-PY:
             does_not_belong: No pertenece
             offensive: Ofensiva
             spam: Contenido no deseado
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Se ha producido un error al crear este boletín.
@@ -432,19 +476,21 @@ es-PY:
         form:
           interpolations_hint: 'Sugerencia: Puede utilizar "%{name}" en cualquier parte del cuerpo o asunto y será reemplazado por el nombre del destinatario.'
         index:
-          confirm_delete: '¿Estás seguro de que quieres eliminar este boletín?'
+          confirm_delete: "¿Estás seguro de que quieres eliminar este boletín?"
           title: Boletines
         new:
           save: Guardar
           title: Nuevo boletín
         show:
-          confirm_deliver: '¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer.'
+          confirm_deliver: "¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer."
           deliver: Enviar boletín
           preview: Previsualizar
           subject: Asunto
         update:
           error: Se ha producido un error al actualizar este boletín.
           success: Boletín actualizado correctamente. Por favor revísalo antes de enviarlo.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Se ha producido un error al crear esta aplicación.
@@ -456,7 +502,7 @@ es-PY:
           save: Guardar
           title: Editar aplicación
         index:
-          confirm_delete: '¿Estás seguro que quieres eliminar esta aplicación?'
+          confirm_delete: "¿Estás seguro que quieres eliminar esta aplicación?"
           title: Aplicaciones OAuth
         new:
           save: Guardar
@@ -510,6 +556,7 @@ es-PY:
         edit:
           update: Actualizar
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Puedes sobrescribir el enlace al botón de acción principal en la página principal. Usa rutas parciales, no URLs completas aquí. Acepta letras, números, guiones y barras, y debe comenzar con una letra. El botón de acción principal se muestra en la página de inicio entre el texto de bienvenida y la descripción. Ejemplo: %{url}'
           cta_button_text_help: Puedes sobrescribir el texto del botón de acción principal en la página de inicio para cada idioma disponible en tu organización. Si no está configurado, se usará el valor predeterminado. El botón de acción principal se muestra en la página de inicio entre el texto de bienvenida y la descripción.
           header_snippets_help: Utiliza este campo para agregar cosas a la cabecera HTML. El uso más común es integrar servicios de terceros que requieran JavaScript o CSS adicionales. Además, puedes usarlo para agregar etiquetas HTML adicionales. Ten en cuenta que esto sólo se mostrará en las páginas públicas, no en la sección de administración.
@@ -617,12 +664,16 @@ es-PY:
         dashboard: Panel de control
         impersonatable_users: Usuarios impersonables
         impersonations: Impersonaciones
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Usuarios
         scope_types: Tipos de ámbito
         scopes: Ámbitos
         static_pages: Páginas
         user_groups: Grupos de usuarios
         users: Usuarios
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Se produjo un error al leer el archivo CSV.
@@ -677,12 +728,16 @@ es-PY:
         hide: Esconder
         not_hidden: No ocultas
         title: Acciones
+        unhide: Unhide
         unreport: Cancelar denuncia
       admin:
         reportable:
           hide:
             invalid: Ha habido un error al ocultar el contenido.
             success: Contenido ocultado con éxito.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Ha habido un problema cancelando la denuncia.
             success: Denuncia cancelada correctamente.

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ es:
         organization_url: URL de organización
         redirect_uri: Redirigir URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Habilitar insignias
         cta_button_path: Ruta del botón de acción principal
         cta_button_text: Texto del botón de acción principal
@@ -44,6 +47,7 @@ es:
         enable_omnipresent_banner: Mostrar banner omnipresente
         facebook_handler: Nombre en Facebook
         favicon: Icono
+        from: From email address
         github_handler: Nombre en GitHub
         header_snippets: Snippets de encabezado
         highlighted_content_banner_action_subtitle: Subtítulo del botón de acción
@@ -62,11 +66,17 @@ es:
         omnipresent_banner_short_description: Descripción breve
         omnipresent_banner_title: Título
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefijo de la referencia
+        secondary_color: Secondary
         show_statistics: Mostrar estadísticas
+        success_color: Success
         tos_version: Versión de los Términos de Servicio
         twitter_handler: Nombre de Twitter
         user_groups_enabled: Habilitar grupos de usuarios
+        warning_color: Warning
         youtube_handler: Nombre de YouTube
       scope:
         code: Código
@@ -102,9 +112,9 @@ es:
               must_be_ssl: El URI de redirección debe ser un URI SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Archivo de imagen no válido
             official_img_footer:
+              allowed_file_content_types: Archivo de imagen no válido
+            official_img_header:
               allowed_file_content_types: Archivo de imagen no válido
   activerecord:
     attributes:
@@ -306,6 +316,11 @@ es:
         logs_list:
           no_logs_yet: Aún no hay ningún registro de actividad
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Se ha producido un error al promocionar el usuario gestionado.
           success: El usuario gestionado se ha promocionado correctamente.
@@ -325,6 +340,7 @@ es:
         help_sections: Secciones de ayuda
         homepage: Página principal
         impersonations: Impersonaciones
+        navbar_links: Navbar links
         newsletters: Boletines
         oauth_applications: Aplicaciones OAuth
         participants: Participantes
@@ -362,6 +378,13 @@ es:
             reason: Razón
             started_at: Empezó a las
             user: Usuario
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Fecha de creación
@@ -416,6 +439,28 @@ es:
             does_not_belong: No pertenece
             offensive: Ofensiva
             spam: Contenido no deseado
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Se ha producido un error al crear este boletín.
@@ -432,19 +477,21 @@ es:
         form:
           interpolations_hint: 'Sugerencia: Puede utilizar "%{name}" en cualquier parte del cuerpo o asunto y será reemplazado por el nombre del destinatario.'
         index:
-          confirm_delete: '¿Estás seguro de que quieres eliminar este boletín?'
+          confirm_delete: "¿Estás seguro de que quieres eliminar este boletín?"
           title: Boletines
         new:
           save: Guardar
           title: Nuevo boletín
         show:
-          confirm_deliver: '¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer.'
+          confirm_deliver: "¿Estás seguro de que quieres enviar este boletín? Esta acción no se puede deshacer."
           deliver: Enviar boletín
           preview: Previsualizar
           subject: Asunto
         update:
           error: Se ha producido un error al actualizar este boletín.
           success: Boletín actualizado correctamente. Por favor revísalo antes de enviarlo.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Se ha producido un error al crear esta aplicación.
@@ -456,7 +503,7 @@ es:
           save: Guardar
           title: Editar aplicación
         index:
-          confirm_delete: '¿Estás seguro que quieres eliminar esta aplicación?'
+          confirm_delete: "¿Estás seguro que quieres eliminar esta aplicación?"
           title: Aplicaciones OAuth
         new:
           save: Guardar
@@ -510,6 +557,7 @@ es:
         edit:
           update: Actualizar
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Puedes sobrescribir el enlace al botón de acción principal en la página principal. Usa rutas parciales, no URLs completas aquí. Acepta letras, números, guiones y barras, y debe comenzar con una letra. El botón de acción principal se muestra en la página de inicio entre el texto de bienvenida y la descripción. Ejemplo: %{url}'
           cta_button_text_help: Puedes sobrescribir el texto del botón de acción principal en la página de inicio para cada idioma disponible en tu organización. Si no está configurado, se usará el valor predeterminado. El botón de acción principal se muestra en la página de inicio entre el texto de bienvenida y la descripción.
           header_snippets_help: Utiliza este campo para agregar cosas a la cabecera HTML. El uso más común es integrar servicios de terceros que requieran JavaScript o CSS adicionales. Además, puedes usarlo para agregar etiquetas HTML adicionales. Ten en cuenta que esto sólo se mostrará en las páginas públicas, no en la sección de administración.
@@ -617,12 +665,16 @@ es:
         dashboard: Panel de control
         impersonatable_users: Usuarios impersonables
         impersonations: Impersonaciones
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Participantes
         scope_types: Tipos de ámbito
         scopes: Ámbitos
         static_pages: Páginas
         user_groups: Grupos de usuarios
         users: Usuarios
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Se produjo un error al leer el archivo CSV.
@@ -677,12 +729,16 @@ es:
         hide: Esconder
         not_hidden: No ocultas
         title: Acciones
+        unhide: Unhide
         unreport: Cancelar denuncia
       admin:
         reportable:
           hide:
             invalid: Ha habido un error al ocultar el contenido.
             success: Contenido ocultado con éxito.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Ha habido un problema cancelando la denuncia.
             success: Denuncia cancelada correctamente.

--- a/decidim-admin/config/locales/eu.yml
+++ b/decidim-admin/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ eu:
         organization_url: Erakundearen URLa
         redirect_uri: Birbideratu URIa
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Gaitu txapak
         cta_button_path: Deitu ekintza botoiaren bideora
         cta_button_text: Deitu ekintza botoiaren testura
@@ -44,6 +47,7 @@ eu:
         enable_omnipresent_banner: Erakutsi omnipresent banner
         facebook_handler: Facebook kudeatzailea
         favicon: Ikonoa
+        from: From email address
         github_handler: GitHub kudeatzailea
         header_snippets: Goiburuko mozkinak
         highlighted_content_banner_action_subtitle: Ekintza botoia azpititulua
@@ -62,11 +66,17 @@ eu:
         omnipresent_banner_short_description: Deskribapen laburra
         omnipresent_banner_title: Izenburua
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Erreferentzia-aurrizkia
+        secondary_color: Secondary
         show_statistics: Erakutsi estatistikak
+        success_color: Success
         tos_version: Zerbitzu-baldintzak bertsioa
         twitter_handler: Twitter kudeatzailea
         user_groups_enabled: Gaitu erabiltzaileen taldeak
+        warning_color: Warning
         youtube_handler: YouTube kudeatzailea
       scope:
         code: Kodea
@@ -102,9 +112,9 @@ eu:
               must_be_ssl: Birbideratze URI SSL URI izan behar du
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Irudi fitxategi baliogabea
             official_img_footer:
+              allowed_file_content_types: Irudi fitxategi baliogabea
+            official_img_header:
               allowed_file_content_types: Irudi fitxategi baliogabea
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ eu:
         browse: Arakatu
         export: Esportatu
         manage: Kudeatu
-        new: '%{name}berria'
         permissions: Baimenak
         reject: Ukatu
         verify: Egiaztatu
@@ -306,6 +315,11 @@ eu:
         logs_list:
           no_logs_yet: Ez dago oraindik erregistroik
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Errorea gertatu da kudeatutako erabiltzailea mailaz igotzean.
           success: Kudeatutako erabiltzailea zuzen igo da mailaz.
@@ -325,6 +339,7 @@ eu:
         help_sections: Laguntza atalak
         homepage: Hasiera
         impersonations: impersonations
+        navbar_links: Navbar links
         newsletters: Buletinak
         oauth_applications: OAuth aplikazioak
         participants: Parte-hartzaileak
@@ -362,11 +377,18 @@ eu:
             reason: Arrazoia
             started_at: 'Hasiera-ordua:'
             user: Erabiltzailea
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Sortze-data
-            progress: ' Aurrerapena '
-            sent_at: ' Bidalketa-data: '
+            progress: " Aurrerapena "
+            sent_at: " Bidalketa-data: "
             subject: Gaia
           name: Buletina
         oauth_application:
@@ -410,15 +432,37 @@ eu:
             users_count: Erabiltzaile kopurua
       moderations:
         index:
-          title: ' Salaketak'
+          title: " Salaketak"
         report:
           reasons:
             does_not_belong: Ez du zer ikusirik
             offensive: Iraingarria
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
-          error: ' Errorea gertatu da buletin hau sortzean.'
+          error: " Errorea gertatu da buletin hau sortzean."
           success: Buletina ongi sortu da. Mesedez, berrikusi bidali baino lehen.
         deliver:
           error: Errorea gertatu da buletin hau entregatzean.
@@ -445,6 +489,8 @@ eu:
         update:
           error: Errorea gertatu da buletin hau eguneratzean.
           success: Buletina zuzen eguneratu da. Mesedez, berrikusi bidali baino lehen.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Errore bat gertatu da aplikazio hau sortzean.
@@ -510,6 +556,7 @@ eu:
         edit:
           update: Eguneratu
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Orrialde nagusira deitzeko dei-botoirako esteka gainidatzi dezakezu. Erabili bideak partzialak, ez URL osoak hemen. Letrak, zenbakiak, marrak eta barrak onartzen ditu eta gutun batekin hasi behar duzu. The Call To Action botoian hasierako orrian erakusten da ongietorri testua eta azalpena. Adibidea: %{url}'
           cta_button_text_help: Hasierako pantailako Call To Action botoian testua gainidatz dezakezu zure erakundeko hizkuntza bakoitzarentzat. Ezartzen bada, balio lehenetsia erabiliko da. The Call To Action botoian hasierako orrian erakusten da ongietorri testua eta azalpena.
           header_snippets_help: Erabili eremu hau HTML goiburuari gauzak gehitzeko. Erabilerarik ohikoena da JavaScript edo CSS gehigarriak behar dituzten hirugarrenen zerbitzuak txertatzea. Gainera, HTMLari meta-etiketa gehigarriak gehitzeko erabil dezakezu. Kontuan hartu orri publikoetan baino ez dela erakutsiko, ez administrazio atalean.
@@ -617,12 +664,16 @@ eu:
         dashboard: Kontrol-panela
         impersonatable_users: Erabiltzaile ustekabekoak
         impersonations: impersonations
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: erabiltzaileak
         scope_types: Esparru motak
         scopes: Esparruak
         static_pages: Orriak
         user_groups: Erabiltzaile-taldeak
         users: Erabiltzaileak
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Errore bat gertatu da CSV fitxategia irakurtzean.
@@ -673,16 +724,20 @@ eu:
           reason: Arrazoi bat eman behar duzu erabiltzaile ez kudeatzaile bat ordezkatuz
     moderations:
       actions:
-        hidden: ' Ezkutatuta'
+        hidden: " Ezkutatuta"
         hide: Ezkutatu
         not_hidden: Ezkutatu gabe
         title: Ekintzak
+        unhide: Unhide
         unreport: Ezeztatu salaketa
       admin:
         reportable:
           hide:
             invalid: Errorea gertatu da edukia ezkutatzean.
             success: Edukia zuzen ezkutatu da.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Arazo bat izan da salaketa ezeztatzean.
             success: Salaketa zuzen ezeztatu da.

--- a/decidim-admin/config/locales/fi-pl.yml
+++ b/decidim-admin/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ fi-pl:
         organization_url: Organisaation URL-osoite
         redirect_uri: Uudelleenohjauksen URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Ota kunniamerkit käyttöön
         cta_button_path: Call To Action -painikkeen polku
         cta_button_text: Call To Action -painikkeen teksti
@@ -44,6 +47,7 @@ fi-pl:
         enable_omnipresent_banner: Näytä kaikkialla näkyvä banneri
         facebook_handler: Facebook-käsittelijä
         favicon: ikoni
+        from: From email address
         github_handler: GitHub-käsittelijä
         header_snippets: Yläosion koodipätkät
         highlighted_content_banner_action_subtitle: Toimintapainikkeen alaotsikko
@@ -62,11 +66,17 @@ fi-pl:
         omnipresent_banner_short_description: Lyhyt kuvaus
         omnipresent_banner_title: Otsikko
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Viitteen etuliite
+        secondary_color: Secondary
         show_statistics: Näytä tilastot
+        success_color: Success
         tos_version: Käyttöehtojen versio
         twitter_handler: Twitter-käsittelijä
         user_groups_enabled: Ota käyttäjäryhmät käyttöön
+        warning_color: Warning
         youtube_handler: YouTube-käsittelijä
       scope:
         code: Koodi
@@ -102,9 +112,9 @@ fi-pl:
               must_be_ssl: Uudelleenohjausosoitteen (URI) on oltava SSL-protokollaa käyttävä URI
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Virheellinen kuvatiedosto
             official_img_footer:
+              allowed_file_content_types: Virheellinen kuvatiedosto
+            official_img_header:
               allowed_file_content_types: Virheellinen kuvatiedosto
   activerecord:
     attributes:
@@ -306,6 +316,11 @@ fi-pl:
         logs_list:
           no_logs_yet: Ei vielä lokitietoja
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Hallitun käyttäjän oikeuksien korotuksessa tapahtui virhe.
           success: Hallitun käyttäjän taso on onnistuneesti korotettu.
@@ -325,6 +340,7 @@ fi-pl:
         help_sections: Ohjeosiot
         homepage: Kotisivu
         impersonations: Esiintymiset toisena käyttäjänä
+        navbar_links: Navbar links
         newsletters: Uutiskirjeet
         oauth_applications: OAuth-sovellukset
         participants: Osallistujat
@@ -362,6 +378,13 @@ fi-pl:
             reason: Syy
             started_at: Aloitettu
             user: Käyttäjä
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Luonnin ajankohta
@@ -416,6 +439,28 @@ fi-pl:
             does_not_belong: Ei kuulu
             offensive: Loukkaava
             spam: Roskaposti
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Tämän uutiskirjeen luonnissa tapahtui virhe.
@@ -445,6 +490,8 @@ fi-pl:
         update:
           error: Tämän uutiskirjeen päivityksessä tapahtui virhe.
           success: Uutiskirje päivitetty onnistuneesti. Tarkasta se läpi ennen lähetystä.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Sovelluksen luonnissa tapahtui virhe.
@@ -510,6 +557,7 @@ fi-pl:
         edit:
           update: Päivitä
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Voit määrittää, mihin kotisivun toimintopainike (Call To Action) linkkaa. Käytä tässä osoitepolkuja, ei kokonaisia URL-osoitteita. Hyväksyy kirjaimet, numerot, viivat ja kauttaviivat. Arvon on alettava kirjaimella. Toimintopainike näytetään kotisivulla Tervetuloa-tekstin ja kuvauksen välissä. Esimerkki: %{url}'
           cta_button_text_help: Voit korvata toimintopainikkeen (Call to Action) tekstin kotisivulla jokaiselle organisaatiosi kielelle. Mikäli tätä ei ole asetettu, oletusarvoa käytetään. Toimintopainike näytetään kotisivulla Tervetuloa-tekstin ja kuvauksen välissä.
           header_snippets_help: Käytä tätä kenttää lisätäksesi HTML-koodia sivun alkuun. Yleisin käyttötarve on sellaisten kolmannen osapuolen palveluiden integrointi, jotka vaativat JavaScript- tai CSS-koodin lisäystä sivun HTML-koodiin. Huomioi, että tämä lisätään ainoastaan julkisille sivuille, ei hallinnointisivuille.
@@ -617,12 +665,16 @@ fi-pl:
         dashboard: Hallintapaneeli
         impersonatable_users: Käyttäjien puolesta tehdyt istunnot
         impersonations: Esiintymiset toisena käyttäjänä
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Käyttäjät
         scope_types: Teematyypit
         scopes: Teemat
         static_pages: Sivut
         user_groups: Käyttäjäryhmät
         users: Käyttäjät
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: CSV-tiedoston käsittelyssä tapahtui virhe.
@@ -677,12 +729,16 @@ fi-pl:
         hide: Piilota
         not_hidden: Näkyvillä
         title: Toiminnot
+        unhide: Unhide
         unreport: Poista ilmoitus
       admin:
         reportable:
           hide:
             invalid: Resurssin piilotuksessa tapahtui virhe.
             success: Resurssi piilotettu onnistuneesti.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Resurssin raportoinnin poistamisessa tapahtui virhe.
             success: Resurssin raportointi onnistuneesti poistettu.

--- a/decidim-admin/config/locales/fi.yml
+++ b/decidim-admin/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ fi:
         organization_url: Organisaation URL-osoite
         redirect_uri: Uudelleenohjauksen URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Ota kunniamerkit käyttöön
         cta_button_path: Call To Action -painikkeen polku
         cta_button_text: Call To Action -painikkeen teksti
@@ -44,6 +47,7 @@ fi:
         enable_omnipresent_banner: Näytä kaikkialla näkyvä banneri
         facebook_handler: Facebook-käsittelijä
         favicon: ikoni
+        from: From email address
         github_handler: GitHub-käsittelijä
         header_snippets: Yläosion koodipätkät
         highlighted_content_banner_action_subtitle: Toimintapainikkeen alaotsikko
@@ -62,11 +66,17 @@ fi:
         omnipresent_banner_short_description: Lyhyt kuvaus
         omnipresent_banner_title: Otsikko
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Viitteen etuliite
+        secondary_color: Secondary
         show_statistics: Näytä tilastot
+        success_color: Success
         tos_version: Käyttöehtojen versio
         twitter_handler: Twitter-käsittelijä
         user_groups_enabled: Ota käyttäjäryhmät käyttöön
+        warning_color: Warning
         youtube_handler: YouTube-käsittelijä
       scope:
         code: Koodi
@@ -102,9 +112,9 @@ fi:
               must_be_ssl: Uudelleenohjausosoitteen (URI) on oltava SSL-protokollaa käyttävä URI
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Virheellinen kuvatiedosto
             official_img_footer:
+              allowed_file_content_types: Virheellinen kuvatiedosto
+            official_img_header:
               allowed_file_content_types: Virheellinen kuvatiedosto
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ fi:
         browse: Selaa
         export: Vie
         manage: Hallitse
-        new: Uusi %{name}
         permissions: Oikeudet
         reject: Hylkää
         verify: Vahvista
@@ -306,6 +315,11 @@ fi:
         logs_list:
           no_logs_yet: Ei vielä lokitietoja
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Hallitun käyttäjän oikeuksien korotuksessa tapahtui virhe.
           success: Hallitun käyttäjän taso on onnistuneesti korotettu.
@@ -325,6 +339,7 @@ fi:
         help_sections: Ohjeosiot
         homepage: Kotisivu
         impersonations: Esiintymiset toisena käyttäjänä
+        navbar_links: Navbar links
         newsletters: Uutiskirjeet
         oauth_applications: OAuth-sovellukset
         participants: Osallistujat
@@ -362,6 +377,13 @@ fi:
             reason: Syy
             started_at: Aloitettu
             user: Käyttäjä
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Luonnin ajankohta
@@ -416,6 +438,28 @@ fi:
             does_not_belong: Ei kuulu
             offensive: Loukkaava
             spam: Roskaposti
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Tämän uutiskirjeen luonnissa tapahtui virhe.
@@ -445,6 +489,8 @@ fi:
         update:
           error: Tämän uutiskirjeen päivityksessä tapahtui virhe.
           success: Uutiskirjeen päivitys onnistui. Tarkasta se läpi ennen lähetystä.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Sovelluksen luonnissa tapahtui virhe.
@@ -510,6 +556,7 @@ fi:
         edit:
           update: Päivitä
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Voit määrittää, mihin kotisivun toimintopainike (Call To Action) linkkaa. Käytä tässä osoitepolkuja, ei kokonaisia URL-osoitteita. Hyväksyy kirjaimet, numerot, viivat ja kauttaviivat. Arvon on alettava kirjaimella. Toimintopainike näytetään kotisivulla Tervetuloa-tekstin ja kuvauksen välissä. Esimerkki: %{url}'
           cta_button_text_help: Voit korvata toimintopainikkeen (Call to Action) tekstin kotisivulla jokaiselle organisaatiosi kielelle. Mikäli tätä ei ole asetettu, oletusarvoa käytetään. Toimintopainike näytetään kotisivulla Tervetuloa-tekstin ja kuvauksen välissä.
           header_snippets_help: Käytä tätä kenttää lisätäksesi HTML-koodia sivun alkuun. Yleisin käyttötarve on sellaisten kolmannen osapuolen palveluiden integrointi, jotka vaativat JavaScript- tai CSS-koodin lisäystä sivun HTML-koodiin. Huomioi, että tämä lisätään ainoastaan julkisille sivuille, ei hallinnointisivuille.
@@ -617,12 +664,16 @@ fi:
         dashboard: Hallintapaneeli
         impersonatable_users: Hallittavat käyttäjät
         impersonations: Esiintymiset toisena käyttäjänä
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Käyttäjät
         scope_types: Teematyypit
         scopes: Teemat
         static_pages: Sivut
         user_groups: Käyttäjäryhmät
         users: Käyttäjät
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: CSV-tiedoston käsittelyssä tapahtui virhe.
@@ -677,12 +728,16 @@ fi:
         hide: Piilota
         not_hidden: Näkyvillä
         title: Toiminnot
+        unhide: Unhide
         unreport: Poista ilmoitus
       admin:
         reportable:
           hide:
             invalid: Resurssin piilotuksessa tapahtui virhe.
             success: Resurssin piilotus onnistui.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Resurssin raportoinnin poistamisessa tapahtui virhe.
             success: Resurssin ilmoituksen poisto onnistui.

--- a/decidim-admin/config/locales/fr.yml
+++ b/decidim-admin/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -36,6 +37,7 @@ fr:
         organization_url: URL de l'organisation
         redirect_uri: Rediriger l'URI
       organization:
+        address: SMTP hostname
         alert_color: Couleur d'alerte
         badges_enabled: Activer les Badges
         cta_button_path: Chemin du bouton d'appel à l'action
@@ -45,6 +47,7 @@ fr:
         enable_omnipresent_banner: Afficher une bannière d'actualités
         facebook_handler: Gestionnaire Facebook
         favicon: Favicon
+        from: From email address
         github_handler: Gestionnaire GitHub
         header_snippets: Éléments à ajouter entre les balises HTML
         highlighted_content_banner_action_subtitle: Sous-titre du bouton d'appel à l'action
@@ -63,6 +66,8 @@ fr:
         omnipresent_banner_short_description: Brève description
         omnipresent_banner_title: Titre
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
         primary_color: Couleur primaire
         reference_prefix: Préfixe de référence
         secondary_color: Couleur secondaire
@@ -390,6 +395,7 @@ fr:
           fields:
             created_at: Créée le
             name: Titre
+          name: OAuth uygulaması
         participatory_space_private_user:
           name: Utilisateur de l'espace participatif
         scope:
@@ -414,6 +420,7 @@ fr:
             roles:
               admin: Administrateur
               user_manager: Représentant de l'utilisateur
+          name: kullanıcı
         user_group:
           fields:
             actions: Actions
@@ -461,7 +468,7 @@ fr:
           error: Il y a eu une erreur lors de l'envoi de cette newsletter.
           success: Newsletter envoyée avec succès.
         destroy:
-          error_already_sent: 'Suppression impossible car la newsletter a déjà été envoyée.'
+          error_already_sent: Suppression impossible car la newsletter a déjà été envoyée.
           success: Newsletter supprimée avec succès.
         edit:
           save_and_preview: Enregistrer et prévisualiser

--- a/decidim-admin/config/locales/gl.yml
+++ b/decidim-admin/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ gl:
         organization_url: URL da organización
         redirect_uri: Redirixir URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Activar emblemas
         cta_button_path: Camiño do botón de chamada a acción
         cta_button_text: Texto do botón de chamada a acción
@@ -44,6 +47,7 @@ gl:
         enable_omnipresent_banner: Mostrar o banner omnipresente
         facebook_handler: Administrador de Facebook
         favicon: Ícona
+        from: From email address
         github_handler: Xestor de GitHub
         header_snippets: Fragmentos de cabeceira
         highlighted_content_banner_action_subtitle: Subtítulo do botón de acción
@@ -62,11 +66,17 @@ gl:
         omnipresent_banner_short_description: Descrición curta
         omnipresent_banner_title: Título
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefijo de referencia
+        secondary_color: Secondary
         show_statistics: Amosar estatísticas
+        success_color: Success
         tos_version: Versión de condicións de servizo
         twitter_handler: Xestor de Twitter
         user_groups_enabled: Activar grupos de usuarios
+        warning_color: Warning
         youtube_handler: Xestor de YouTube
       scope:
         code: Código
@@ -102,9 +112,9 @@ gl:
               must_be_ssl: O URI de redirección debe ser un URI de SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Ficheiro de imaxe non válido
             official_img_footer:
+              allowed_file_content_types: Ficheiro de imaxe non válido
+            official_img_header:
               allowed_file_content_types: Ficheiro de imaxe non válido
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ gl:
         browse: Buscar
         export: Exportar
         manage: Xestionar
-        new: Novo %{name}
         permissions: Permisos
         reject: Rexeitar
         verify: Verifique
@@ -306,6 +315,11 @@ gl:
         logs_list:
           no_logs_yet: Aínda non hai rexistros
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Produciuse un erro ao promover o usuario xestor.
           success: O usuario xestionado foi promovido con éxito.
@@ -325,6 +339,7 @@ gl:
         help_sections: Seccións de axuda
         homepage: Páxina de inicio
         impersonations: Impersonacións
+        navbar_links: Navbar links
         newsletters: Boletíns informativos
         oauth_applications: Aplicacións OAuth
         participants: Participantes
@@ -362,6 +377,13 @@ gl:
             reason: Motivo
             started_at: Comezou en
             user: Usuario
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Creado en
@@ -416,6 +438,28 @@ gl:
             does_not_belong: Non pertence
             offensive: Ofensivo
             spam: Correo non desexado
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Produciuse un erro ao crear este boletín informativo.
@@ -432,19 +476,21 @@ gl:
         form:
           interpolations_hint: 'Consello: podes usar "%{name}" en calquera parte do corpo ou asunto e será substituído polo nome do destinatario.'
         index:
-          confirm_delete: '¿Estás seguro de que queres eliminar este boletín informativo?'
+          confirm_delete: "¿Estás seguro de que queres eliminar este boletín informativo?"
           title: Boletíns informativos
         new:
           save: Gardar
           title: Novo boletín informativo
         show:
-          confirm_deliver: '¿Estás seguro de que desexas enviar este boletín informativo? Non se pode desfacer esta acción.'
+          confirm_deliver: "¿Estás seguro de que desexas enviar este boletín informativo? Non se pode desfacer esta acción."
           deliver: Enviar boletín informativo
           preview: Vista previa
           subject: Asunto
         update:
           error: Produciuse un erro ao actualizar este boletín informativo.
           success: Boletín informativo actualizado con éxito. Revisa isto antes de enviar.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Produciuse un erro ao crear esta aplicación.
@@ -510,6 +556,7 @@ gl:
         edit:
           update: Actualización
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Pode sobrescribir onde se enlaza o botón de chamada a acción na páxina de inicio. Use aquí rutas parciais, non URL completo. Acepta letras, números, guións e barras, e debe comezar cunha letra. O botón de chamada a acción amósase na páxina de inicio entre o texto de benvida ea descrición. Exemplo: %{url}'
           cta_button_text_help: Pode sobrescribir o texto do botón de chamada a acción na páxina de inicio para cada idioma dispoñible na súa organización. Se non se establece, empregarase o valor predeterminado. O botón de chamada a acción amósase na páxina de inicio entre o texto de benvida ea descrición.
           header_snippets_help: Use este campo para engadir cousas ao título HTML. O uso máis común é integrar servizos de terceiros que requiren algún JavaScript ou CSS adicional. Ademais, podes usalo para engadir etiquetas metais extra ao HTML. Ten en conta que isto só se renderá en páxinas públicas, non na sección de administración.
@@ -617,12 +664,16 @@ gl:
         dashboard: Taboleiro de instrumentos
         impersonatable_users: Usuarios privilexiados
         impersonations: Impersonacións
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Usuarios
         scope_types: Tipos de alcance
         scopes: Ámbitos
         static_pages: Páxinas
         user_groups: Grupos de usuarios
         users: Usuarios
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Produciuse un erro ao ler o ficheiro CSV.
@@ -677,12 +728,16 @@ gl:
         hide: Ocultar
         not_hidden: Non escondido
         title: Accións
+        unhide: Unhide
         unreport: Non informar
       admin:
         reportable:
           hide:
             invalid: Produciuse un problema ao ocultar o recurso.
             success: Recurso escondido con éxito.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Produciuse un problema ao non informar o recurso.
             success: Recurso non publicado correctamente.

--- a/decidim-admin/config/locales/hu.yml
+++ b/decidim-admin/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ hu:
         organization_url: Szervezet URL
         redirect_uri: Redirect URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Jelvények engedélyezése
         cta_button_path: Felhívás gomb elérési útvonala
         cta_button_text: Felhívás gomb szövege
@@ -44,6 +47,7 @@ hu:
         enable_omnipresent_banner: Mindenhol megjelenő banner mutatása
         facebook_handler: Facebook handler
         favicon: Ikon
+        from: From email address
         github_handler: GitHub handler
         header_snippets: Fejléc részletek
         highlighted_content_banner_action_subtitle: Felhívás gomb alcíme
@@ -62,11 +66,17 @@ hu:
         omnipresent_banner_short_description: Rövid leírás
         omnipresent_banner_title: Cím
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Hivatkozási előtag
+        secondary_color: Secondary
         show_statistics: Statisztikák megjelenítése
+        success_color: Success
         tos_version: Használati feltételek
         twitter_handler: Twitter handler
         user_groups_enabled: Felhasználói csoportok engedélyezése
+        warning_color: Warning
         youtube_handler: YouTube handler
       scope:
         code: Kód
@@ -102,9 +112,9 @@ hu:
               must_be_ssl: Az átirányítási URI-nak SSL URI-nak kell lennie
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Érvénytelen képfájl
             official_img_footer:
+              allowed_file_content_types: Érvénytelen képfájl
+            official_img_header:
               allowed_file_content_types: Érvénytelen képfájl
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ hu:
         browse: Böngészés
         export: Exportálás
         manage: Kezelés
-        new: Új %{name}
         permissions: Engedélyek
         reject: Elutasít
         verify: Ellenőrzés
@@ -248,7 +257,7 @@ hu:
             type: Elem típusa
         new:
           add: Elem hozzáadása
-          title: '%{name} nevű elem hozzáadása'
+          title: "%{name} nevű elem hozzáadása"
         publish:
           success: Az elem közzététele sikeres volt.
         title: Elemek
@@ -306,6 +315,11 @@ hu:
         logs_list:
           no_logs_yet: Még nincsenek naplók
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Hiba történt a felügyelt felhasználó előléptetése során.
           success: A felügyelt felhasználó előléptetése sikeres.
@@ -325,6 +339,7 @@ hu:
         help_sections: Súgó szakaszok
         homepage: Homepage
         impersonations: Felhatalmazások
+        navbar_links: Navbar links
         newsletters: Hírlevelek
         oauth_applications: OAuth alkalmazások
         participants: Résztvevők
@@ -362,6 +377,13 @@ hu:
             reason: Indok
             started_at: 'Kezdődik:'
             user: Felhasználó
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: 'Létrehozva:'
@@ -416,6 +438,28 @@ hu:
             does_not_belong: Nem tartozik hozzá
             offensive: Offenzív
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Hiba történt a hírlevél létrehozása során.
@@ -445,6 +489,8 @@ hu:
         update:
           error: Hiba történt a hírlevél frissítése során.
           success: Hírlevél frissítse sikeres volt. Ellenőrizd le, mielőtt elküldenéd.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Hiba történt az alkalmazás létrehozása során.
@@ -510,6 +556,7 @@ hu:
         edit:
           update: Frissítés
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Felülírhatod, hogy a kezdőlap felhívás gombja link hova mutasson. Részleges, ne pedig teljes URL címeket használj. A megengedett karakterek: betű, szám, kötőjel vagy perjel, de mindig betűvel kell kezdődnie. A felhívás gomb az üdvözlő szöveg és a leírás között jelenik meg a nyitólapon. Példa: %{url}'
           cta_button_text_help: A felhívás gomb szövegét a szervezethez tartozó minden egyes nyelven megjelenítheted. Amennyiben nincs beállítva, akkor akkor az alapértelmezett értéket fogja használni. A felhívás gomb az üdvözlő szöveg és a leírás között jelenik meg a nyitólapon.
           header_snippets_help: Ebben a mezőben a HTML fejlécet szerkesztheted. Ennek akkor van jelentősége, ha olyan külső szolgáltatásokat szeretnél intergálni, amelyekhez JavaScript vagy CSS szükséges. Sőt, metacímkéket is hozzáadhatsz. Ez az adminban nem, csak a nyilvános oldalakon jelenik majd meg.
@@ -617,12 +664,16 @@ hu:
         dashboard: Vezérlőpult
         impersonatable_users: Felhatalmazható felhasználók
         impersonations: Felhatalmazások
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: felhasználók
         scope_types: Hatáskör típusok
         scopes: Hatáskörök
         static_pages: Oldalak
         user_groups: Felhasználói csoportok
         users: Felhasználók
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Hiba történt a CSV fájl olvasásában.
@@ -677,12 +728,16 @@ hu:
         hide: Elrejt
         not_hidden: Nem rejtett
         title: Műveletek
+        unhide: Unhide
         unreport: Ne jelentse
       admin:
         reportable:
           hide:
             invalid: Probléma történt az erőforrás elrejtésekor.
             success: Erőforrás sikeresen elrejtve.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Probléma történt az erőforrás elrejtésének visszavonásakor.
             success: Erőforrás jelentésének visszavonása sikeres.

--- a/decidim-admin/config/locales/id-ID.yml
+++ b/decidim-admin/config/locales/id-ID.yml
@@ -1,709 +1,764 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       area:
-        area_type: Tipe area
-        name: Nama
-        organization: Organisasi
+        area_type: Area type
+        name: Name
+        organization: Organization
       area_type:
-        name: Nama
-        organization: Organisasi
-        plural: Jamak
+        name: Name
+        organization: Organization
+        plural: Plural
       attachment:
-        attachment_collection_id: Map
-        description: Deskripsi
-        file: Mengajukan
-        title: Judul
+        attachment_collection_id: Folder
+        description: Description
+        file: File
+        title: Title
       attachment_collection:
-        description: Deskripsi
-        name: Nama
+        description: Description
+        name: Name
       category:
-        description: Deskripsi
-        name: Nama
-        parent_id: Induk
+        description: Description
+        name: Name
+        parent_id: Parent
       component:
-        name: Nama
-        published_at: Diterbitkan di
-        weight: Berat
+        name: Name
+        published_at: Published at
+        weight: Weight
       id: ID
       newsletter:
-        body: Tubuh
-        subject: Subyek
+        body: Body
+        subject: Subject
       oauth_application:
-        name: Nama
-        organization_logo: Logo organisasi (persegi)
-        organization_name: Nama Organisasi
-        organization_url: URL Organisasi
-        redirect_uri: Alihkan URI
+        name: Name
+        organization_logo: Organization logo (square)
+        organization_name: Organization name
+        organization_url: Organization URL
+        redirect_uri: Redirect URI
       organization:
-        badges_enabled: Aktifkan lencana
-        cta_button_path: Jalur tombol Call To Action
-        cta_button_text: Teks tombol Call To Action
-        default_locale: Lokal default
-        description: Deskripsi
-        enable_omnipresent_banner: Tampilkan spanduk di mana-mana
-        facebook_handler: Penangan Facebook
-        favicon: Ikon
+        address: SMTP hostname
+        alert_color: Alert
+        badges_enabled: Enable badges
+        cta_button_path: Call To Action button path
+        cta_button_text: Call To Action button text
+        default_locale: Default locale
+        description: Description
+        enable_omnipresent_banner: Show omnipresent banner
+        facebook_handler: Facebook handler
+        favicon: Icon
+        from: From email address
         github_handler: GitHub handler
-        header_snippets: Cuplikan header
-        highlighted_content_banner_action_subtitle: Subjudul tombol tindakan
-        highlighted_content_banner_action_title: Judul tombol aksi
-        highlighted_content_banner_action_url: URL tombol tindakan
-        highlighted_content_banner_enabled: Tampilkan spanduk konten yang disorot
-        highlighted_content_banner_image: Gambar
-        highlighted_content_banner_short_description: Deskripsi Singkat
-        highlighted_content_banner_title: Judul
-        instagram_handler: Pengatur Instagram
+        header_snippets: Header snippets
+        highlighted_content_banner_action_subtitle: Action button subtitle
+        highlighted_content_banner_action_title: Action button title
+        highlighted_content_banner_action_url: Action button URL
+        highlighted_content_banner_enabled: Show the highlighted content banner
+        highlighted_content_banner_image: Image
+        highlighted_content_banner_short_description: Short description
+        highlighted_content_banner_title: Title
+        instagram_handler: Instagram handler
         logo: Logo
-        name: Nama
-        official_img_footer: Footer logo resmi
-        official_img_header: Tajuk logo resmi
-        official_url: URL organisasi resmi
-        omnipresent_banner_short_description: Deskripsi Singkat
-        omnipresent_banner_title: Judul
+        name: Name
+        official_img_footer: Official logo footer
+        official_img_header: Official logo header
+        official_url: Official organization URL
+        omnipresent_banner_short_description: Short description
+        omnipresent_banner_title: Title
         omnipresent_banner_url: URL
-        reference_prefix: Awalan referensi
-        show_statistics: Tampilkan statistik
-        tos_version: Versi persyaratan layanan
-        twitter_handler: Penangan Twitter
-        user_groups_enabled: Aktifkan grup pengguna
-        youtube_handler: Penangan YouTube
+        password: Password
+        port: Port
+        primary_color: Primary
+        reference_prefix: Reference prefix
+        secondary_color: Secondary
+        show_statistics: Show statistics
+        success_color: Success
+        tos_version: Terms of service version
+        twitter_handler: Twitter handler
+        user_groups_enabled: Enable user groups
+        warning_color: Warning
+        youtube_handler: YouTube handler
       scope:
-        code: Kode
-        name: Nama
-        organization: Organisasi
-        parent_id: Induk
-        scope_type: Tipe cakupan
-        scope_type_id: Tipe cakupan
+        code: Code
+        name: Name
+        organization: Organization
+        parent_id: Parent
+        scope_type: Scope type
+        scope_type_id: Scope type
       scope_type:
-        name: Nama
-        organization: Organisasi
-        plural: Jamak
+        name: Name
+        organization: Organization
+        plural: Plural
       static_page:
-        changed_notably: Ada perubahan nyata.
-        content: Konten
-        organization: Organisasi
-        show_in_footer: Tunjukkan di footer
-        slug: Siput URL
-        title: Judul
-        weight: Berat
+        changed_notably: There have been noticeable changes.
+        content: Content
+        organization: Organization
+        show_in_footer: Show in the footer
+        slug: URL slug
+        title: Title
+        weight: Weight
       static_page_topic:
-        description: Deskripsi
-        show_in_footer: Tunjukkan di footer
-        title: Judul
-        weight: Berat
+        description: Description
+        show_in_footer: Show in the footer
+        title: Title
+        weight: Weight
       user_group_csv_verification:
-        file: Mengajukan
+        file: File
     errors:
       models:
         oauth_application:
           attributes:
             redirect_uri:
-              must_be_ssl: URI pengalihan harus berupa URI SSL
+              must_be_ssl: The redirect URI must be a SSL URI
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: File gambar tidak valid
             official_img_footer:
-              allowed_file_content_types: File gambar tidak valid
+              allowed_file_content_types: Invalid image file
+            official_img_header:
+              allowed_file_content_types: Invalid image file
   activerecord:
     attributes:
       decidim/static_page:
-        content: Konten
-        slug: Siput URL
-        title: Judul
+        content: Content
+        slug: URL slug
+        title: Title
       doorkeeper/application:
-        authorize_url: Otorisasi URL
-        client_id: ID Klien
-        client_secret: Rahasia Klien
-        organization_name: Nama Organisasi
-        organization_url: URL Organisasi
-        redirect_uri: Alihkan URI
-        site: Situs web
+        authorize_url: Authorize URL
+        client_id: Client ID
+        client_secret: Client Secret
+        organization_name: Organization name
+        organization_url: Organization URL
+        redirect_uri: Redirect URI
+        site: Website
   decidim:
     admin:
       actions:
-        add: Menambahkan
-        browse: Jelajahi
-        export: Ekspor
-        manage: Mengelola
-        new: Baru %{name}
-        permissions: Izin
-        reject: Menolak
-        verify: Memeriksa
+        add: Add
+        browse: Browse
+        export: Export
+        manage: Manage
+        permissions: Permissions
+        reject: Reject
+        verify: Verify
       area_types:
         create:
-          error: Terjadi kesalahan saat membuat jenis area baru.
-          success: Tipe area berhasil dibuat.
+          error: There was an error creating a new area type.
+          success: Area type created successfully.
         destroy:
-          success: Tipe area berhasil dihancurkan
+          success: Area type successfully destroyed
         edit:
-          title: Edit jenis area
-          update: Memperbarui
+          title: Edit area type
+          update: Update
         new:
-          create: Buat tipe area
-          title: Tipe area baru
+          create: Create area type
+          title: New area type
         update:
-          error: Terjadi kesalahan saat memperbarui jenis area ini.
-          success: Tipe area berhasil diperbarui
+          error: There was an error when updating this area type.
+          success: Area type updated successfully
       areas:
         create:
-          error: Terjadi kesalahan saat membuat area baru.
-          success: Area berhasil dibuat.
+          error: There was an error creating a new area.
+          success: Area created successfully.
         destroy:
-          success: Area berhasil dihancurkan
+          success: Area successfully destroyed
         edit:
           title: Edit area
-          update: Memperbarui
+          update: Update
         new:
-          create: Buat area
-          title: Area baru
-        no_areas: Tanpa Area
+          create: Create area
+          title: New area
+        no_areas: No Areas
         update:
-          error: Ada kesalahan saat memperbarui area ini.
-          success: Area berhasil diperbarui
+          error: There was an error when updating this area.
+          success: Area updated successfully
       attachment_collections:
         create:
-          error: Ada kesalahan saat membuat folder baru.
-          success: Folder berhasil dibuat.
+          error: There was an error creating a new folder.
+          success: Folder created successfully.
         destroy:
-          success: Folder berhasil dihancurkan.
+          success: Folder destroyed successfully.
         edit:
           title: Edit folder
-          update: Memperbarui
+          update: Update
         index:
-          attachment_collection_used: Folder ini tidak dapat dihapus karena sedang digunakan.
-          attachment_collections_title: Folder lampiran
+          attachment_collection_used: This folder cannot be removed because it is in use.
+          attachment_collections_title: Attachment folders
         new:
-          create: Membuat
-          title: Folder baru
+          create: Create
+          title: New folder
         update:
-          error: Ada kesalahan saat memperbarui folder ini.
-          success: Folder berhasil diperbarui.
+          error: There was an error when updating this folder.
+          success: Folder updated successfully.
       attachments:
         create:
-          error: Terjadi kesalahan saat membuat lampiran baru.
-          success: Attachment berhasil dibuat.
+          error: There was an error creating a new attachment.
+          success: Attachment created successfully.
         destroy:
-          success: Lampiran berhasil dihancurkan.
+          success: Attachment destroyed successfully.
         edit:
-          title: Edit lampiran
-          update: Memperbarui
+          title: Edit attachment
+          update: Update
         index:
-          attachments_title: Lampiran
+          attachments_title: Attachments
         new:
-          create: Buat lampiran
-          title: Lampiran baru
+          create: Create attachment
+          title: New attachment
         update:
-          error: Ada kesalahan saat memperbarui lampiran ini.
-          success: Lampiran berhasil diperbarui.
+          error: There was an error when updating this attachment.
+          success: Attachment updated successfully.
       autocomplete:
-        no_results: Tidak ada hasil yang ditemukan
-        search_prompt: Ketik setidaknya tiga karakter untuk mencari
+        no_results: No results found
+        search_prompt: Type at least three characters to search
       categories:
         create:
-          error: Terjadi kesalahan saat membuat kategori ini.
-          success: Kategori berhasil dibuat.
+          error: There was an error creating this category.
+          success: Category created successfully.
         destroy:
-          error: Terjadi kesalahan saat menghapus kategori ini. Hapus subkategori terlebih dahulu, pastikan tidak ada entitas lain yang termasuk dalam kategori ini dan coba lagi.
-          success: Kategori berhasil dihapus.
+          error: There was an error deleting this category. Please delete any subcategory first, make sure no other entity belongs to this category and try again.
+          success: Category deleted successfully.
         edit:
-          title: Edit kategori
-          update: Memperbarui
+          title: Edit category
+          update: Update
         index:
-          categories_title: Kategori
-          category_used: Kategori ini tidak dapat dihapus karena sedang digunakan.
+          categories_title: Categories
+          category_used: This category cannot be removed because it is in use.
         new:
-          create: Buat kategori
-          title: Kategori baru
+          create: Create category
+          title: New category
         update:
-          error: Terjadi kesalahan saat memperbarui kategori ini.
-          success: Kategori berhasil diperbarui.
+          error: There was an error updating this category.
+          success: Category updated successfully.
       component_permissions:
         edit:
-          everyone: Semua orang
-          submit: Simpan izin
-          title: Edit izin
+          everyone: Everyone
+          submit: Save permissions
+          title: Edit permissions
         update:
-          success: Izin berhasil diperbarui.
+          success: Permissions updated successfully.
       components:
         create:
-          error: Terjadi kesalahan saat membuat komponen ini.
-          success: Komponen berhasil dibuat.
+          error: There was an error creating this component.
+          success: Component created successfully.
         destroy:
-          error: Terjadi kesalahan saat merusak komponen ini.
-          success: Komponen berhasil dihapus.
+          error: There has been an error destroying this component.
+          success: Component deleted successfully.
         edit:
-          title: Edit komponen
-          update: Memperbarui
+          title: Edit component
+          update: Update
         form:
-          default_step_settings: Pengaturan langkah default
-          global_settings: Pengaturan global
-          step_settings: Pengaturan langkah
+          default_step_settings: Default step settings
+          global_settings: Global settings
+          step_settings: Step settings
         index:
-          add: Tambahkan komponen
+          add: Add component
           headers:
-            actions: Tindakan
-            name: Nama komponen
-            type: Jenis komponen
+            actions: Actions
+            name: Component name
+            type: Component type
         new:
-          add: Tambahkan komponen
-          title: 'Tambahkan komponen: %{name}'
+          add: Add component
+          title: 'Add component: %{name}'
         publish:
-          success: Komponen telah berhasil dipublikasikan.
-        title: Komponen
+          success: The component has been successfully published.
+        title: Components
         unpublish:
-          success: Komponen telah berhasil tidak dipublikasikan.
+          success: The component has been successfully unpublished.
         update:
-          error: Terjadi kesalahan saat memperbarui komponen ini.
-          success: Komponen berhasil diperbarui.
+          error: There has been an error updating this component.
+          success: The component was updated successfully.
       dashboard:
         show:
-          view_more_logs: Lihat lebih banyak log
-          welcome: Selamat datang di Panel Admin Decidim.
+          view_more_logs: View more logs
+          welcome: Welcome to the Decidim Admin Panel.
       exports:
-        export_as: "%{name} sebagai %{export_format}"
-        notice: Ekspor Anda sedang dalam proses. Anda akan menerima email setelah selesai.
+        export_as: "%{name} as %{export_format}"
+        notice: Your export is currently in progress. You'll receive an email when it's complete.
       help_sections:
-        error: Terjadi kesalahan saat memperbarui bagian bantuan
+        error: There's been an error updating the help sections
         form:
-          save: Menyimpan
-        success: Bagian bantuan berhasil diperbarui
+          save: Save
+        success: Help sections updated successfully
       impersonatable_users:
         index:
           filter:
-            all: Semua
-            managed: Dikelola
-            not_managed: Tidak dikelola
-          filter_by: Filter berdasarkan
-          impersonate: Menirukan
-          impersonate_new_managed_user: Meniru pengguna yang dikelola baru
-          managed: Dikelola
-          name: Nama
-          needs_authorization_warning: Anda memerlukan setidaknya satu otorisasi diaktifkan untuk organisasi ini.
-          not_managed: Tidak dikelola
-          promote: Memajukan
-          search: Pencarian
+            all: All
+            managed: Managed
+            not_managed: Not managed
+          filter_by: Filter by
+          impersonate: Impersonate
+          impersonate_new_managed_user: Impersonate new managed user
+          managed: Managed
+          name: Name
+          needs_authorization_warning: You need at least one authorization enabled for this organization.
+          not_managed: Not managed
+          promote: Promote
+          search: Search
           status: Status
-          view_logs: Lihat log
+          view_logs: View logs
       impersonations:
         close_session:
-          error: Terjadi kesalahan saat menutup sesi peniruan saat ini.
-          success: Sesi peniruan saat ini telah berhasil berakhir.
+          error: There has been an error closing the current impersonation session.
+          success: The current impersonation session has been successfully ended.
         create:
-          error: Terjadi kesalahan saat meniru identitas pengguna.
-          success: Pengguna yang dikelola telah berhasil dibuat.
+          error: There has been an error impersonating the user.
+          success: The managed user has been successfully created.
         form:
-          authorization_method: Metode otorisasi
-          name: Nama
-          reason: Alasan
+          authorization_method: Authorization method
+          name: Name
+          reason: Reason
         new:
-          impersonate: Menirukan
-          impersonate_existing_managed_user: Meniru pengguna terkelola "%{name}"
-          impersonate_existing_user: Meniru pengguna "%{name}"
-          impersonate_new_managed_user: Meniru pengguna yang dikelola baru
+          impersonate: Impersonate
+          impersonate_existing_managed_user: Impersonate managed user "%{name}"
+          impersonate_existing_user: Impersonate user "%{name}"
+          impersonate_new_managed_user: Impersonate new managed user
       logs:
         logs_list:
-          no_logs_yet: Belum ada catatan
+          no_logs_yet: There are no logs yet
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
-          error: Terjadi kesalahan saat mempromosikan pengguna yang dikelola.
-          success: Pengguna yang dikelola telah berhasil dipromosikan.
+          error: There has been an error promoting the managed user.
+          success: The managed user has been successfully promoted.
         promotions:
           new:
-            explanation: Pengguna yang dikelola dapat dipromosikan ke pengguna standar. Ini berarti mereka akan diundang ke aplikasi dan Anda tidak akan dapat meniru mereka lagi. Pengguna yang diundang akan menerima email untuk menerima undangan Anda.
-            new_managed_user_promotion: Promosi pengguna terkelola baru
-            promote: Memajukan
+            explanation: Managed users can be promoted to standard users. It means they will be invited to the application and you will not be able to impersonate them again. The invited user will receive an email to accept your invitation.
+            new_managed_user_promotion: New managed user promotion
+            promote: Promote
       menu:
-        admin_log: Log aktivitas admin
-        admins: Admin
-        appearance: Penampilan
-        area_types: Tipe area
-        areas: Area
-        configuration: Konfigurasi
-        dashboard: Dasbor
-        help_sections: Bagian bantuan
+        admin_log: Admin activity log
+        admins: Admins
+        appearance: Appearance
+        area_types: Area types
+        areas: Areas
+        configuration: Configuration
+        dashboard: Dashboard
+        help_sections: Help sections
         homepage: Homepage
-        impersonations: Peniruan identitas
-        newsletters: Nawala
-        oauth_applications: Aplikasi OAuth
-        participants: Peserta
-        scope_types: Tipe lingkup
+        impersonations: Impersonations
+        navbar_links: Navbar links
+        newsletters: Newsletters
+        oauth_applications: OAuth applications
+        participants: Participants
+        scope_types: Scope types
         scopes: Scopes
-        settings: Pengaturan
-        static_pages: Halaman
-        user_groups: Grup Pengguna
-        users: Pengguna
+        settings: Settings
+        static_pages: Pages
+        user_groups: User groups
+        users: Users
       models:
         area:
           fields:
-            area_type: Tipe area
-            name: Nama
+            area_type: Area type
+            name: Name
         area_type:
           fields:
-            name: Nama
-            plural: Jamak
+            name: Name
+            plural: Plural
         attachment:
           fields:
-            collection: Map
-            content_type: Mengetik
-            file_size: Ukuran
-            title: Judul
-          name: Lampiran
+            collection: Folder
+            content_type: Type
+            file_size: Size
+            title: Title
+          name: Attachment
         attachment_collection:
-          name: Map
+          name: Folder
         category:
-          name: Kategori
+          name: Category
         impersonation_log:
           fields:
             admin: Admin
-            ended_at: Berakhir pada
-            expired_at: Kedaluwarsa pada
-            reason: Alasan
-            started_at: Dimulai pada
-            user: Pengguna
+            ended_at: Ended at
+            expired_at: Expired at
+            reason: Reason
+            started_at: Started at
+            user: User
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
-            created_at: Dibuat di
-            progress: Kemajuan
-            sent_at: Dikirim pada
-            subject: Subyek
+            created_at: Created at
+            progress: Progress
+            sent_at: Sent at
+            subject: Subject
           name: Newsletter
         oauth_application:
           fields:
-            created_at: Dibuat di
-            name: Nama
-          name: Aplikasi OAuth
+            created_at: Created at
+            name: Name
+          name: OAuth uygulaması
         participatory_space_private_user:
-          name: Ruang partisipatif pengguna pribadi
+          name: Participatory space private user
         scope:
           fields:
-            name: Nama
-            scope_type: Tipe cakupan
+            name: Name
+            scope_type: Scope type
         scope_type:
           fields:
-            name: Nama
-            plural: Jamak
+            name: Name
+            plural: Plural
         static_page:
           fields:
-            created_at: Dibuat di
-            title: Judul
+            created_at: Created at
+            title: Title
         user:
           fields:
-            created_at: Tanggal pembuatan
-            email: E-mail
-            last_sign_in_at: Tanggal masuk terakhir
-            name: Nama
-            role: Peran
+            created_at: Creation date
+            email: Email
+            last_sign_in_at: Last sign in date
+            name: Name
+            role: Role
             roles:
               admin: Admin
-              user_manager: Pengelola pengguna
-          name: Pengguna
+              user_manager: User manager
+          name: kullanıcı
         user_group:
           fields:
-            actions: Tindakan
-            created_at: Dibuat di
-            document_number: Nomor dokumen
-            name: Nama
-            phone: Telepon
-            state: Negara
-            users_count: Jumlah pengguna
+            actions: Actions
+            created_at: Created at
+            document_number: Document number
+            name: Name
+            phone: Phone
+            state: State
+            users_count: Users count
       moderations:
         index:
-          title: Moderasi
+          title: Moderations
         report:
           reasons:
-            does_not_belong: Bukan milik
-            offensive: Serangan
+            does_not_belong: Does not belong
+            offensive: Offensive
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
-          error: Terjadi kesalahan saat membuat buletin ini.
-          success: Newsletter berhasil dibuat. Silakan, tinjau sebelum mengirim.
+          error: There's been an error creating this newsletter.
+          success: Newsletter created successfully. Please, review it before sending.
         deliver:
-          error: Terjadi kesalahan saat mengirim buletin ini.
-          success: Nawala berhasil dikirim.
+          error: There's been an error delivering this newsletter.
+          success: Newsletter delivered successfully.
         destroy:
-          error_already_sent: 'Tidak dapat menghancurkan nawala: Sudah dikirim.'
-          success: Buletin berhasil dihancurkan.
+          error_already_sent: 'Can''t destroy newsletter: It has already been sent.'
+          success: Newsletter destroyed successfully.
         edit:
-          save_and_preview: Simpan dan pratinjau
-          title: Edit buletin
+          save_and_preview: Save and preview
+          title: Edit newsletter
         form:
-          interpolations_hint: 'Petunjuk: Anda dapat menggunakan "%{name}" di mana saja di dalam tubuh atau subjek dan itu akan diganti dengan nama penerima.'
+          interpolations_hint: 'Hint: You can use "%{name}" anywhere in the body or subject and it will be replaced by the recipient''s name.'
         index:
-          confirm_delete: Anda yakin ingin menghapus buletin ini?
-          title: Nawala
+          confirm_delete: Are you sure you want to delete this newsletter?
+          title: Newsletters
         new:
-          save: Menyimpan
-          title: Newsletter baru
+          save: Save
+          title: New newsletter
         show:
-          confirm_deliver: Anda yakin ingin menyampaikan buletin ini? Tindakan ini tidak bisa dibatalkan.
-          deliver: Kirimkan buletin
+          confirm_deliver: Are you sure you want to deliver this newsletter? This action cannot be undone.
+          deliver: Deliver newsletter
           preview: Preview
-          subject: Subyek
+          subject: Subject
         update:
-          error: Terjadi kesalahan saat memperbarui buletin ini.
-          success: Buletin berhasil diperbarui. Harap tinjau sebelum mengirim.
+          error: There's been an error updating this newsletter.
+          success: Newsletter updated successfully. Please review it before sending.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
-          error: Terjadi kesalahan saat membuat aplikasi ini.
-          success: Aplikasi berhasil dibuat.
+          error: There's been an error creating this application.
+          success: Application created successfully.
         destroy:
-          error: Terjadi kesalahan saat menghancurkan aplikasi ini.
-          success: Aplikasi berhasil dihancurkan.
+          error: There's been an error destroying this application.
+          success: Application destroyed successfully.
         edit:
-          save: Menyimpan
-          title: Edit aplikasi
+          save: Save
+          title: Edit application
         index:
-          confirm_delete: Anda yakin ingin menghapus aplikasi ini?
-          title: Aplikasi OAuth
+          confirm_delete: Are you sure you want to delete this application?
+          title: OAuth applications
         new:
-          save: Menyimpan
-          title: Aplikasi baru
+          save: Save
+          title: New application
         update:
-          error: Terjadi kesalahan saat memperbarui aplikasi ini.
-          success: Aplikasi berhasil diperbarui.
+          error: There's been an error updating this application.
+          success: Application updated successfully.
       officializations:
         create:
-          success: Pengguna resmi berhasil
+          success: User officialized successfully
         destroy:
-          success: Pengguna tidak resmi berhasil
+          success: User unofficialized successfully
         index:
-          actions: Tindakan
-          badge: Lencana
-          created_at: Dibuat di
+          actions: Actions
+          badge: Badge
+          created_at: Created At
           filter:
-            all: Semua
-            not_officialized: Tidak resmi
-            officialized: Diresmikan
-          filter_by: Filter berdasarkan
-          name: Nama
-          nickname: Nama panggilan
-          not_officialized: Tidak resmi
-          officialize: Resmi
-          officialized: Diresmikan
-          reofficialize: Lakukan pengesahan ulang
-          search: Pencarian
+            all: All
+            not_officialized: Not officialized
+            officialized: Officialized
+          filter_by: Filter by
+          name: Name
+          nickname: Nickname
+          not_officialized: Not officialized
+          officialize: Officialize
+          officialized: Officialized
+          reofficialize: Reofficialize
+          search: Search
           status: Status
-          unofficialize: Tidak resmi
+          unofficialize: Unofficialize
         new:
-          badge: Lencana resmi
-          officialize: Resmi
-          title: Beri otorisasi kepada pengguna "%{name}"
+          badge: Officialization badge
+          officialize: Officialize
+          title: Officialize user "%{name}"
       organization:
         edit:
-          title: Edit organisasi
-          update: Memperbarui
+          title: Edit organization
+          update: Update
         form:
           facebook: Facebook
           github: GitHub
           instagram: Instagram
-          social_handlers: Sosial
-          twitter: Kericau
+          social_handlers: Social
+          twitter: Twitter
           url: Url
-          youtube: Youtube
+          youtube: YouTube
         update:
-          error: Terjadi kesalahan saat memperbarui organisasi ini.
-          success: Organisasi berhasil diperbarui.
+          error: There was an error when updating this organization.
+          success: Organization updated successfully.
       organization_appearance:
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          cta_button_path_help: 'Anda dapat menimpa tempat tombol Ajakan Bertindak di tautan beranda ke. Gunakan jalur parsial, bukan URL lengkap di sini. Menerima surat, angka, tanda pisah dan garis miring, dan harus dimulai dengan huruf. Tombol Ajakan Bertindak ditampilkan di homepage antara teks selamat datang dan deskripsi. Contoh: %{url}'
-          cta_button_text_help: Anda dapat menimpa teks tombol Ajakan Bertindak di beranda untuk setiap bahasa yang tersedia di organisasi Anda. Jika tidak disetel, nilai default akan digunakan. Tombol Ajakan Bertindak ditampilkan di homepage antara teks selamat datang dan deskripsi.
-          header_snippets_help: Gunakan bidang ini untuk menambahkan sesuatu ke kepala HTML. Penggunaan yang paling umum adalah mengintegrasikan layanan pihak ketiga yang memerlukan beberapa JavaScript atau CSS tambahan. Juga, Anda dapat menggunakannya untuk menambahkan meta tag ekstra ke HTML. Perhatikan bahwa ini hanya akan ditampilkan di halaman publik, bukan di bagian admin.
-          homepage_appearance_title: Edit tampilan homepage
-          homepage_highlighted_content_banner_title: Spanduk konten berkecepatan tinggi
-          layout_appearance_title: Edit tampilan tata letak
-          omnipresent_banner_appearance_title: Edit spanduk yang ada di mana-mana
+          colors_title: Organization colors
+          cta_button_path_help: 'You can overwrite where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
+          cta_button_text_help: You can overwrite the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
+          header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
+          homepage_appearance_title: Edit homepage appearance
+          homepage_highlighted_content_banner_title: Highligted content banner
+          layout_appearance_title: Edit layout appearance
+          omnipresent_banner_appearance_title: Edit omnipresent banner
       organization_homepage:
         edit:
-          active_content_blocks: Blok konten aktif
-          inactive_content_blocks: Blok konten tidak aktif
+          active_content_blocks: Active content blocks
+          inactive_content_blocks: Inactive content blocks
       organization_homepage_content_blocks:
         edit:
-          update: Memperbarui
+          update: Update
       participatory_space_private_users:
         create:
-          error: Terjadi kesalahan saat menambahkan pengguna pribadi untuk ruang partisipatif ini.
-          success: Ruang partisipatif akses pengguna pribadi berhasil dibuat.
+          error: There was an error adding a private user for this participatory space.
+          success: Participatory space private user access created successfully.
         destroy:
-          error: Terjadi kesalahan saat menghapus pengguna pribadi untuk ruang partisipatif ini.
-          success: Akses pribadi pengguna ruang partisipatif berhasil dihancurkan.
+          error: There was an error deleting a private user for this participatory space.
+          success: Participatory space private user access destroyed successfully.
         index:
-          title: Ruang partisipatif pengguna pribadi
+          title: Participatory space private user
         new:
-          create: Membuat
-          title: Pengguna Pribadi Ruang Partisipatif Baru.
+          create: Create
+          title: New Participatory Space private user.
       scope_types:
         create:
-          error: Terjadi kesalahan saat membuat jenis cakupan baru.
-          success: Tipe lingkup berhasil dibuat.
+          error: There was an error creating a new scope type.
+          success: Scope type created successfully.
         destroy:
-          success: Tipe cakupan berhasil dihancurkan
+          success: Scope type successfully destroyed
         edit:
-          title: Edit jenis cakupan
-          update: Memperbarui
+          title: Edit scope type
+          update: Update
         new:
-          create: Buat jenis cakupan
-          title: Ruang lingkup baru
+          create: Create scope type
+          title: New scope
         update:
-          error: Ada kesalahan saat memperbarui jenis ruang lingkup ini.
-          success: Tipe lingkup berhasil diperbarui
+          error: There was an error when updating this scope type.
+          success: Scope type updated successfully
       scopes:
         create:
-          error: Terjadi kesalahan saat membuat cakupan baru.
-          success: Lingkup berhasil dibuat.
+          error: There was an error creating a new scope.
+          success: Scope created successfully.
         destroy:
-          success: Cakupan berhasil dihancurkan
+          success: Scope successfully destroyed
         edit:
-          title: Sunting cakupan
-          update: Memperbarui
+          title: Edit scope
+          update: Update
         new:
-          create: Buat cakupan
-          title: Ruang lingkup baru
-        no_scopes: Tidak ada cakupan pada level ini.
+          create: Create scope
+          title: New scope
+        no_scopes: No scopes at this level.
         update:
-          error: Ada kesalahan saat memperbarui ruang lingkup ini.
-          success: Lingkup berhasil diperbarui
+          error: There was an error when updating this scope.
+          success: Scope updated successfully
       static_page_topics:
         create:
-          error: Ada kesalahan saat membuat topik baru.
-          success: Topik berhasil dibuat.
+          error: There was an error creating a new topic.
+          success: Topic created successfully.
         destroy:
-          success: Topik berhasil dihancurkan
+          success: Topic successfully destroyed
         edit:
-          title: Edit topik
-          update: Perbarui topik
+          title: Edit topic
+          update: Update topic
         new:
-          create: Buat topik
-          title: Topik baru
+          create: Create topic
+          title: New topic
         update:
-          error: Ada kesalahan saat memperbarui topik ini.
-          success: Topik berhasil diperbarui
+          error: There was an error when updating this topic.
+          success: Topic updated successfully
       static_pages:
         actions:
-          view: Lihat halaman publik
+          view: View public page
         create:
-          error: Ada kesalahan saat membuat halaman baru.
-          success: Halaman berhasil dibuat.
+          error: There was an error creating a new page.
+          success: Page created successfully.
         destroy:
-          success: Halaman berhasil dihancurkan
+          success: Page successfully destroyed
         edit:
-          changed_notably_help: Jika dicentang, pengguna akan diberi tahu untuk menerima persyaratan dan ketentuan baru.
-          title: Edit halaman
-          update: Memperbarui
+          changed_notably_help: If checked, users will be notified to accept the new terms and conditions.
+          title: Edit page
+          update: Update
         form:
-          none: Tidak ada
+          none: None
         index:
-          last_notable_change: Perubahan penting terakhir
+          last_notable_change: Last notable change
         new:
-          create: Membuat halaman
-          title: Halaman baru
+          create: Create page
+          title: New page
         topic:
-          destroy: Hapus topik
-          edit: Edit topik
-          empty: Tidak ada halaman di bawah topik ini
-          without_topic: Halaman tanpa topik
+          destroy: Remove topic
+          edit: Edit topic
+          empty: There's no page under this topic
+          without_topic: Pages without topic
         update:
-          error: Terjadi kesalahan saat memperbarui halaman ini.
-          success: Halaman berhasil diperbarui
+          error: There was an error when updating this page.
+          success: Page updated successfully
       titles:
-        admin_log: Log admin
-        area_types: Tipe area
-        areas: Area
-        authorization_workflows: Metode verifikasi
-        dashboard: Dasbor
-        impersonatable_users: Pengguna yang tidak dapat disalahgunakan
-        impersonations: Peniruan identitas
-        participants: Pengguna
-        scope_types: Tipe lingkup
+        admin_log: Admin log
+        area_types: Area types
+        areas: Areas
+        authorization_workflows: Verification methods
+        dashboard: Dashboard
+        impersonatable_users: Manageable users
+        impersonations: Users management
+        managed_users: Managed users
+        navbar_links: Navbar links
+        participants: Users
+        scope_types: Scope types
         scopes: Scopes
-        static_pages: Halaman
-        user_groups: Grup Pengguna
-        users: Pengguna
+        static_pages: Pages
+        user_groups: User groups
+        users: Users
+      user:
+        new: New user
       user_group:
         csv_verify:
-          invalid: Ada kesalahan saat membaca file CSV.
-          success: File CSV berhasil diunggah, kami memverifikasi grup pengguna yang cocok dengan kriteria. Ini mungkin membutuhkan waktu beberapa saat.
+          invalid: There was an error reading the CSV file.
+          success: CSV file uploaded successfully, we're verifying the user groups matching the criteria. This might take a while.
         reject:
-          invalid: Ada kesalahan saat menolak grup pengguna ini.
-          success: Kelompok pengguna berhasil ditolak
+          invalid: There was an error when rejecting this user group.
+          success: User group rejected successfully
         verify:
-          invalid: Ada kesalahan saat memverifikasi grup pengguna ini.
-          success: Kelompok pengguna berhasil diverifikasi
+          invalid: There was an error when verifying this user group.
+          success: User group verified successfully
       user_groups:
         index:
           filter:
-            all: Semua
-            pending: Menunggu keputusan
-            rejected: Ditolak
-            verified: Diverifikasi
-          filter_by: Filter berdasarkan
-          search: Pencarian
+            all: All
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+          filter_by: Filter by
+          search: Search
           state:
-            pending: Menunggu keputusan
-            rejected: Ditolak
-            verified: Diverifikasi
-          verify_via_csv: Verifikasi melalui CSV
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+          verify_via_csv: Verify via CSV
       user_groups_csv_verifications:
         new:
-          explanation: Unggah file CSV Anda. Itu harus memiliki email resmi dari kelompok pengguna di organisasi Anda di kolom pertama file, tanpa header. Hanya grup pengguna yang telah mengkonfirmasi email mereka dan yang memiliki email yang muncul dalam file CSV akan divalidasi.
-          title: Unggah file CSV Anda
-          upload: Unggah
+          explanation: Upload your CSV file. It must have the official emails of the user groups in your organization in the first column of the file, without headers. Only user groups that have confirmed their email and that have an email appearing in the CSV file will be validated.
+          title: Upload your CSV file
+          upload: Upload
       users:
         create:
-          error: Terjadi kesalahan saat mengundang pengguna ini.
-          success: Pengguna berhasil diundang.
+          error: There was an error when inviting this user.
+          success: User invited successfully.
         destroy:
-          error: Terjadi kesalahan saat mencoba menghapus pengguna ini.
-          success: Pengguna bukan lagi administrator.
+          error: There was an error when trying to delete this user.
+          success: User is no longer an administrator.
         form:
-          email: E-mail
-          name: Nama
-          role: Peran
+          email: Email
+          name: Name
+          role: Role
         new:
-          create: Undang
-          title: Undang pengguna sebagai administrator
-      view_public_page: Lihat halaman publik
+          create: Invite
+          title: Invite user as administrator
+      view_public_page: View public page
     forms:
       errors:
         impersonate_user:
-          reason: Anda perlu memberikan alasan ketika meniru pengguna yang tidak dikelola
+          reason: You need to provide a reason when impersonating a non managed user
     moderations:
       actions:
-        hidden: Tersembunyi
-        hide: Menyembunyikan
-        not_hidden: tidak tersembunyi
-        title: Tindakan
+        hidden: Hidden
+        hide: Hide
+        not_hidden: Not hidden
+        title: Actions
+        unhide: Unhide
         unreport: Unreport
       admin:
         reportable:
           hide:
-            invalid: Ada masalah menyembunyikan sumber daya.
-            success: Sumber daya berhasil disembunyikan.
+            invalid: There's been a problem hiding the resource.
+            success: Resource successfully hidden.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
-            invalid: Sudah ada masalah yang tidak melaporkan sumber daya.
-            success: Sumber daya berhasil tidak dilaporkan.
+            invalid: There's been a problem unreporting the resource.
+            success: Resource successfully unreported.
       models:
         moderation:
           fields:
-            hidden_at: Tersembunyi di
-            report_count: Menghitung
-            reportable: Dapat dilaporkan
-            reported_content_url: URL konten yang dilaporkan
-            reports: Laporan
-            visit_url: Kunjungi URL
+            hidden_at: Hidden at
+            report_count: Count
+            reportable: Reportable
+            reported_content_url: Reported content URL
+            reports: Reports
+            visit_url: Visit URL
   errors:
     messages:
-      invalid_json: JSON tidak valid
+      invalid_json: Invalid JSON
   layouts:
     decidim:
       admin:
         newsletters:
-          title: Nawala
+          title: Newsletters
         settings:
-          title: Pengaturan
+          title: Settings
         users:
-          title: Pengguna
+          title: Users

--- a/decidim-admin/config/locales/it.yml
+++ b/decidim-admin/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ it:
         organization_url: URL dell'organizzazione
         redirect_uri: Reindirizza URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Abilita badge
         cta_button_path: Percorso del pulsante Call To Action
         cta_button_text: Testo del pulsante Chiamata all'azione
@@ -44,6 +47,7 @@ it:
         enable_omnipresent_banner: Mostra banner onnipresente
         facebook_handler: Gestore di Facebook
         favicon: Icona
+        from: From email address
         github_handler: Gestore di GitHub
         header_snippets: Frammenti di intestazione
         highlighted_content_banner_action_subtitle: Sottotitolo del pulsante di azione
@@ -62,11 +66,17 @@ it:
         omnipresent_banner_short_description: Breve descrizione
         omnipresent_banner_title: Titolo
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefisso
+        secondary_color: Secondary
         show_statistics: Mostra statistiche
+        success_color: Success
         tos_version: Termini di versione del servizio
         twitter_handler: Gestore di Twitter
         user_groups_enabled: Abilita gruppi di utenti
+        warning_color: Warning
         youtube_handler: Gestore di YouTube
       scope:
         code: Codice
@@ -102,9 +112,9 @@ it:
               must_be_ssl: L'URI di reindirizzamento deve essere un URI SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: File immagine non valido
             official_img_footer:
+              allowed_file_content_types: File immagine non valido
+            official_img_header:
               allowed_file_content_types: File immagine non valido
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ it:
         browse: Naviga
         export: Esporta
         manage: Gestisci
-        new: Nuovo %{name}
         permissions: Permessi
         reject: Rifiutare
         verify: Verifica
@@ -306,6 +315,11 @@ it:
         logs_list:
           no_logs_yet: Non ci sono ancora i log
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Si è verificato un errore che ha promosso l'utente gestito.
           success: L'utente gestito è stato promosso con successo.
@@ -325,6 +339,7 @@ it:
         help_sections: Aiuto sezioni
         homepage: Homepage
         impersonations: impersonations
+        navbar_links: Navbar links
         newsletters: Newsletters
         oauth_applications: Applicazioni OAuth
         participants: I partecipanti
@@ -362,6 +377,13 @@ it:
             reason: Ragionare
             started_at: Ha iniziato a
             user: Utente
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Creato il
@@ -416,6 +438,28 @@ it:
             does_not_belong: Non appartiene
             offensive: Offensivo
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Si è verificato un errore durante la creazione di questa newsletter.
@@ -445,6 +489,8 @@ it:
         update:
           error: Si è verificato un errore durante l'aggiornamento di questa newsletter.
           success: OK, la Newsletter è stata aggiornata. Conviene controllarla prima di inviarla.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Si è verificato un errore durante la creazione di questa applicazione.
@@ -510,6 +556,7 @@ it:
         edit:
           update: Modifica
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Puoi sovrascrivere dove il pulsante Call To Action nella home page è collegato. Utilizza i percorsi parziali e non gli URL completi qui. Accetta lettere, numeri, trattini e barre, e deve iniziare con una lettera. Il pulsante Chiamata all''azione è mostrato nella homepage tra il testo di benvenuto e la descrizione. Esempio: %{url}'
           cta_button_text_help: Puoi sovrascrivere il testo del pulsante Chiamata a azione nella home page per ogni lingua disponibile nell'organizzazione. Se non è impostato, verrà utilizzato il valore predefinito. Il pulsante Chiamata all'azione è mostrato nella homepage tra il testo di benvenuto e la descrizione.
           header_snippets_help: Utilizza questo campo per aggiungere le cose alla testa HTML. L'uso più comune è quello di integrare i servizi di terze parti che richiedono JavaScript o CSS extra. Inoltre, è possibile utilizzarlo per aggiungere meta tag extra all'HTML. Tieni presente che questo sarà reso solo nelle pagine pubbliche, non nella sezione admin.
@@ -617,12 +664,16 @@ it:
         dashboard: Cruscotto (Dashboard)
         impersonatable_users: Utenti impersonabili
         impersonations: impersonations
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: utenti
         scope_types: Tipi di ambito
         scopes: Ambiti
         static_pages: Pagine
         user_groups: Gruppi di utenti
         users: Utenti
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Si è verificato un errore durante la lettura del file CSV.
@@ -677,12 +728,16 @@ it:
         hide: Nascondi
         not_hidden: Non nascosto
         title: Azioni
+        unhide: Unhide
         unreport: Non inserire
       admin:
         reportable:
           hide:
             invalid: Si è verificato un problema cercando di nascondere la risorsa.
             success: OK, la risorsa è stata nascosta.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Si è verificato un problema cercando di visualizzare la risorsa .
             success: OK, la risorda è visualizzabile.

--- a/decidim-admin/config/locales/nl.yml
+++ b/decidim-admin/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ nl:
         organization_url: URL van de organisatie
         redirect_uri: URI doorsturen
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Schakel badges in
         cta_button_path: actieknop pad
         cta_button_text: actieknop tekst
@@ -44,6 +47,7 @@ nl:
         enable_omnipresent_banner: Toon header
         facebook_handler: Facebook naam
         favicon: Pictogram
+        from: From email address
         github_handler: GitHub gebruikersnaam
         header_snippets: Elementen om toe te voegen tussen HTML-tags
         highlighted_content_banner_action_subtitle: Ondertitel actieknop
@@ -62,11 +66,17 @@ nl:
         omnipresent_banner_short_description: Korte omschrijving
         omnipresent_banner_title: Titel
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Referentievoorvoegsel
+        secondary_color: Secondary
         show_statistics: Toon statistieken
+        success_color: Success
         tos_version: Servicevoorwaarden versie
         twitter_handler: Twitter gebruikersnaam
         user_groups_enabled: Schakel gebruikersgroepen in
+        warning_color: Warning
         youtube_handler: YouTube gebruikersnaam
       scope:
         code: Code
@@ -102,9 +112,9 @@ nl:
               must_be_ssl: De omleidings-URI moet een SSL-URI zijn
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Ongeldig afbeeldingsbestand
             official_img_footer:
+              allowed_file_content_types: Ongeldig afbeeldingsbestand
+            official_img_header:
               allowed_file_content_types: Ongeldig afbeeldingsbestand
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ nl:
         browse: Browsen
         export: Exporteren
         manage: Beheer
-        new: Nieuwe %{name}
         permissions: Permissies
         reject: Weigeren
         verify: Verifiëren
@@ -306,6 +315,11 @@ nl:
         logs_list:
           no_logs_yet: Er zijn nog geen logs
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Er is een fout opgetreden bij het promoten van de beheerde gebruiker.
           success: De beheerde gebruiker is succesvol gepromoveerd.
@@ -325,6 +339,7 @@ nl:
         help_sections: Help secties
         homepage: Startpagina
         impersonations: Zich voordoen als
+        navbar_links: Navbar links
         newsletters: Nieuwsbrieven
         oauth_applications: OAuth-toepassingen
         participants: Deelnemers
@@ -362,6 +377,13 @@ nl:
             reason: Reden
             started_at: Gestart op
             user: Gebruiker
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Aangemaakt op
@@ -416,6 +438,28 @@ nl:
             does_not_belong: Hoort niet
             offensive: Aanvallend
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Er is een fout opgetreden bij het maken van deze nieuwsbrief.
@@ -445,6 +489,8 @@ nl:
         update:
           error: Er is een fout opgetreden bij het bijwerken van deze nieuwsbrief.
           success: Nieuwsbrief is succesvol bijgewerkt. Controleer het voordat u verzendt.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Er is een fout opgetreden bij het maken van deze toepassing.
@@ -481,7 +527,9 @@ nl:
           name: Naam
           nickname: Gebruikersnaam
           not_officialized: Niet gevalideerd
-          officialize: "Valideren\n"
+          officialize: 'Valideren
+
+'
           officialized: Gevalideerd
           reofficialize: Hervalideren
           search: Zoeken
@@ -510,6 +558,7 @@ nl:
         edit:
           update: Bijwerken
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'U kunt de verwijzing van de knop "Call to Action" overschrijven. Gebruik hier gedeeltelijke paden, niet volledige URL''s. Aanvaardt letters, cijfers, streepjes en streepjes en moet beginnen met een brief. De knop "Call to Action" wordt weergegeven op de homepage tussen de welkomsttekst en de omschrijving. Voorbeeld: %{url}'
           cta_button_text_help: U kunt de tekst voor "Call To Action" overschrijven op de homepage voor elke beschikbare taal in uw organisatie. Indien niet ingesteld, wordt de standaardwaarde gebruikt. De knop Call to Action wordt weergegeven op de homepage tussen de welkomsttekst en de omschrijving.
           header_snippets_help: Gebruik dit veld om dingen toe te voegen aan de HTML-kop. Het meest voorkomende gebruik is het integreren van diensten van derden die extra JavaScript of CSS nodig hebben. U kunt het ook gebruiken om extra metatags toe te voegen aan de HTML. Houd er rekening mee dat dit alleen op openbare pagina's wordt weergegeven, niet in de beheerdersafdeling.
@@ -617,12 +666,16 @@ nl:
         dashboard: Dashboard
         impersonatable_users: Niet-personaliseerbare gebruikers
         impersonations: Zich voordoen als
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: gebruikers
         scope_types: Scope types
         scopes: Scopes
         static_pages: Pagina's
         user_groups: Gebruikersgroepen
         users: Gebruikers
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Er is een fout opgetreden bij het lezen van het CSV-bestand.
@@ -677,12 +730,16 @@ nl:
         hide: Verbergen
         not_hidden: niet verstopt
         title: Acties
+        unhide: Unhide
         unreport: Onreporteren
       admin:
         reportable:
           hide:
             invalid: Er is een probleem geweest om de bron te verbergen.
             success: Resource succesvol verborgen.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Er is een probleem geweest om de bron niet te rapporteren.
             success: Bron succesvol ontmeld.

--- a/decidim-admin/config/locales/pl.yml
+++ b/decidim-admin/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ pl:
         organization_url: Adres organizacji
         redirect_uri: Przekierowanie URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Włącz odznaki
         cta_button_path: Ścieżka przycisku wezwania do działania
         cta_button_text: Tekst przycisku wezwania do działania
@@ -44,6 +47,7 @@ pl:
         enable_omnipresent_banner: Pokaż wszechobecny baner
         facebook_handler: Handler Facebooka
         favicon: Ikona
+        from: From email address
         github_handler: Obsługa programu GitHub
         header_snippets: Fragmenty nagłówków
         highlighted_content_banner_action_subtitle: Podtytuł przycisku czynności
@@ -62,11 +66,17 @@ pl:
         omnipresent_banner_short_description: Krótki opis
         omnipresent_banner_title: Tytuł
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefiks referencyjny
+        secondary_color: Secondary
         show_statistics: Pokaż statystyki
+        success_color: Success
         tos_version: Warunki korzystania z usługi
         twitter_handler: Obsługa Twittera
         user_groups_enabled: Włącz grupy użytkowników
+        warning_color: Warning
         youtube_handler: Poradnik YouTube
       scope:
         code: Kod
@@ -102,9 +112,9 @@ pl:
               must_be_ssl: Identyfikator URI przekierowania musi być identyfikatorem URI protokołu SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Nieprawidłowy plik obrazu
             official_img_footer:
+              allowed_file_content_types: Nieprawidłowy plik obrazu
+            official_img_header:
               allowed_file_content_types: Nieprawidłowy plik obrazu
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ pl:
         browse: Paść się
         export: Eksport
         manage: Zarządzanie
-        new: Nowe %{name}
         permissions: Uprawnienia
         reject: Odrzucać
         verify: Zweryfikować
@@ -306,6 +315,11 @@ pl:
         logs_list:
           no_logs_yet: Nie ma jeszcze dzienników
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Podczas promowania zarządzanego użytkownika wystąpił błąd.
           success: Zarządzany użytkownik został pomyślnie awansowany.
@@ -325,6 +339,7 @@ pl:
         help_sections: Sekcje pomocy
         homepage: Strona główna
         impersonations: Podszywanie się pod inne osoby
+        navbar_links: Navbar links
         newsletters: Biuletyny
         oauth_applications: Aplikacje OAuth
         participants: Uczestnicy
@@ -362,6 +377,13 @@ pl:
             reason: Powód
             started_at: Zaczęło się od
             user: Użytkownik
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Utworzono w
@@ -416,6 +438,28 @@ pl:
             does_not_belong: Nie należy
             offensive: Ofensywa
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Podczas tworzenia biuletynu wystąpił błąd.
@@ -445,6 +489,8 @@ pl:
         update:
           error: Podczas aktualizowania tego biuletynu wystąpił błąd.
           success: Biuletyn został zaktualizowany. Przeczytaj ją przed wysłaniem.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Wystąpił błąd podczas tworzenia tej aplikacji.
@@ -510,6 +556,7 @@ pl:
         edit:
           update: Aktualizuj
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Możesz zastąpić lokalizację, w której przycisk Do połączenia z działaniem na łącza do strony głównej. Użyj częściowych ścieżek, a nie pełnych adresów URL. Akceptuje litery, liczby, myślniki i ukośniki, i muszą zaczynać się od litery. Przycisk Zadzwoń do Działania zostanie wyświetlony na stronie głównej między tekstem powitalnym a opisem. Przykład: %{url}'
           cta_button_text_help: Można zastąpić tekst przycisku Żądanie do działania na stronie głównej dla każdego dostępnego języka w organizacji. Jeśli nie zostanie ustawiona, zostanie użyta wartość domyślna. Przycisk Zadzwoń do Działania zostanie wyświetlony na stronie głównej między tekstem powitalnym a opisem.
           header_snippets_help: Użyj tego pola, aby dodać elementy do głowicy HTML. Najczęstszym sposobem jest zintegrowanie usług innych firm, które wymagają dodatkowego kodu JavaScript lub CSS. Można również użyć go do dodawania dodatkowych znaczników meta do HTML. Należy zauważyć, że będzie to widoczne tylko na stronach publicznych, a nie w sekcji administracyjnej.
@@ -617,12 +664,16 @@ pl:
         dashboard: Deska rozdzielcza
         impersonatable_users: Niekodowalni użytkownicy
         impersonations: Podszywanie się pod inne osoby
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Użytkownicy
         scope_types: Typy zakresów
         scopes: Zakresy
         static_pages: Strony
         user_groups: Grupy użytkowników
         users: Użytkownicy
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Wystąpił błąd podczas odczytu pliku CSV.
@@ -677,12 +728,16 @@ pl:
         hide: Ukryć
         not_hidden: Nie ukryty
         title: działania
+        unhide: Unhide
         unreport: Brak oceny
       admin:
         reportable:
           hide:
             invalid: Wystąpił problem z ukryciem zasobu.
             success: Zasób został ukryty.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Wystąpił problem z niewykorzystaniem zasobów.
             success: Zasób został pomyślnie nieudokumentowany.

--- a/decidim-admin/config/locales/pt-BR.yml
+++ b/decidim-admin/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ pt-BR:
         organization_url: URL da organização
         redirect_uri: Redirecionar URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Ativar emblemas
         cta_button_path: Caminho do botão Chamar para Ação
         cta_button_text: Texto do botão Chamar para Ação
@@ -44,6 +47,7 @@ pt-BR:
         enable_omnipresent_banner: Mostrar bandeira omnipresente
         facebook_handler: Manipulador do Facebook
         favicon: Ícone
+        from: From email address
         github_handler: Manipulador GitHub
         header_snippets: Snippets de cabeçalho
         highlighted_content_banner_action_subtitle: Legenda do botão de ação
@@ -62,11 +66,17 @@ pt-BR:
         omnipresent_banner_short_description: Descrição curta
         omnipresent_banner_title: Título
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefixo de referência
+        secondary_color: Secondary
         show_statistics: Exibir estatisticas
+        success_color: Success
         tos_version: Versão dos termos de serviço
         twitter_handler: Manipulador do Twitter
         user_groups_enabled: Ativar grupos de usuários
+        warning_color: Warning
         youtube_handler: Manipulador do YouTube
       scope:
         code: Código
@@ -102,9 +112,9 @@ pt-BR:
               must_be_ssl: O URI de redirecionamento deve ser um URI de SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Arquivo de imagem inválido
             official_img_footer:
+              allowed_file_content_types: Arquivo de imagem inválido
+            official_img_header:
               allowed_file_content_types: Arquivo de imagem inválido
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ pt-BR:
         browse: Navegar
         export: Exportar
         manage: Gerenciar
-        new: Nova %{name}
         permissions: Permissões
         reject: Negar
         verify: Verificar
@@ -306,6 +315,11 @@ pt-BR:
         logs_list:
           no_logs_yet: Ainda não há registros
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Ocorreu um erro ao promover o usuário gerenciado.
           success: O usuário gerenciado foi promovido com sucesso.
@@ -325,6 +339,7 @@ pt-BR:
         help_sections: Seções de ajuda
         homepage: Pagina inicial
         impersonations: Imitações
+        navbar_links: Navbar links
         newsletters: Newsletters
         oauth_applications: Aplicações OAuth
         participants: Participantes
@@ -362,6 +377,13 @@ pt-BR:
             reason: Motivo
             started_at: Começou em
             user: Usuário
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Criado em
@@ -416,6 +438,28 @@ pt-BR:
             does_not_belong: Não pertence
             offensive: Ofensivo
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Ocorreu um erro ao criar este boletim informativo.
@@ -445,6 +489,8 @@ pt-BR:
         update:
           error: Ocorreu um erro ao atualizar este boletim informativo.
           success: Newsletter atualizada com sucesso. Por favor, reveja-o antes de enviar.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Houve um erro ao criar este aplicativo.
@@ -510,6 +556,7 @@ pt-BR:
         edit:
           update: Atualizar
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Você pode substituir onde o botão Chamar para Ação na página inicial liga. Use caminhos parciais, não URLs completos aqui. Aceita letras, números, traços e barras, e deve começar com uma letra. O botão Chamar para Ação é exibido na página inicial entre o texto de boas-vindas e a descrição. Exemplo: %{url}'
           cta_button_text_help: Você pode substituir o texto do botão Chamar para Ação na página inicial para cada idioma disponível em sua organização. Se não for definido, o valor padrão será usado. O botão Chamar para Ação é exibido na página inicial entre o texto de boas-vindas e a descrição.
           header_snippets_help: Use este campo para adicionar coisas ao cabeçalho HTML. O uso mais comum é integrar serviços de terceiros que exigem algum JavaScript ou CSS extra. Além disso, você pode usá-lo para adicionar meta tags adicionais ao HTML. Observe que isso só será exibido em páginas públicas, não na seção de administração.
@@ -617,12 +664,16 @@ pt-BR:
         dashboard: painel de controle
         impersonatable_users: Usuários impersonáveis
         impersonations: Imitações
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Comercial
         scope_types: Tipos de âmbito
         scopes: Âmbitos
         static_pages: Páginas
         user_groups: Grupos de usuários
         users: Usuários
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Ocorreu um erro ao ler o arquivo CSV.
@@ -677,12 +728,16 @@ pt-BR:
         hide: Ocultar
         not_hidden: Não oculto
         title: Ações
+        unhide: Unhide
         unreport: Anular denúncia
       admin:
         reportable:
           hide:
             invalid: Ocorreu um problema ao ocultar o recurso.
             success: O recurso foi ocultado com sucesso.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Tem havido um problema não relatando o recurso.
             success: O recurso não foi relatado com sucesso.

--- a/decidim-admin/config/locales/pt.yml
+++ b/decidim-admin/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ pt:
         organization_url: URL da organização
         redirect_uri: URI de redirecionamento
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Ativar emblemas
         cta_button_path: Caminho do botão Chamar para Ação
         cta_button_text: Texto do botão Chamar para Ação
@@ -44,6 +47,7 @@ pt:
         enable_omnipresent_banner: Mostrar bandeira omnipresente
         facebook_handler: Manipulador do Facebook
         favicon: Ícone
+        from: From email address
         github_handler: GitHub handler
         header_snippets: Snippets de cabeçalho
         highlighted_content_banner_action_subtitle: Legenda do botão de ação
@@ -62,11 +66,17 @@ pt:
         omnipresent_banner_short_description: Pequena descrição
         omnipresent_banner_title: Título
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Prefixo de referência
+        secondary_color: Secondary
         show_statistics: Mostre estatisticas
+        success_color: Success
         tos_version: Termos de versão do serviço
         twitter_handler: Manipulador do Twitter
         user_groups_enabled: Ativar grupos de usuários
+        warning_color: Warning
         youtube_handler: Manipulador do YouTube
       scope:
         code: Código
@@ -102,9 +112,9 @@ pt:
               must_be_ssl: O URI de redirecionamento deve ser um URI de SSL
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Arquivo de imagem inválido
             official_img_footer:
+              allowed_file_content_types: Arquivo de imagem inválido
+            official_img_header:
               allowed_file_content_types: Arquivo de imagem inválido
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ pt:
         browse: Explorar
         export: Exportar
         manage: Gerir
-        new: Novo %{name}
         permissions: Permissões
         reject: Rejeitar
         verify: Verificar
@@ -306,6 +315,11 @@ pt:
         logs_list:
           no_logs_yet: Ainda não há logs
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Ocorreu um erro ao promover o usuário gerenciado.
           success: O usuário gerenciado foi promovido com sucesso.
@@ -325,6 +339,7 @@ pt:
         help_sections: Seções de ajuda
         homepage: Pagina inicial
         impersonations: Imitações
+        navbar_links: Navbar links
         newsletters: Boletins informativos
         oauth_applications: Aplicações OAuth
         participants: Participantes
@@ -362,6 +377,13 @@ pt:
             reason: Razão
             started_at: Começou em
             user: Do utilizador
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Criado em
@@ -416,6 +438,28 @@ pt:
             does_not_belong: Não pertence
             offensive: Ofensiva
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Ocorreu um erro ao criar este boletim informativo.
@@ -445,6 +489,8 @@ pt:
         update:
           error: Ocorreu um erro ao atualizar este boletim informativo.
           success: Newsletter atualizada com sucesso. Por favor, reveja-o antes de enviar.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Houve um erro ao criar este aplicativo.
@@ -510,6 +556,7 @@ pt:
         edit:
           update: Actualizar
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Você pode substituir onde o botão Chamar para Ação na página inicial liga. Use caminhos parciais, não URLs completos aqui. Aceita letras, números, traços e barras, e deve começar com uma letra. O botão Chamar para Ação é exibido na página inicial entre o texto de boas-vindas e a descrição. Exemplo: %{url}'
           cta_button_text_help: Você pode substituir o texto do botão Chamar para Ação na página inicial para cada idioma disponível em sua organização. Se não for definido, o valor padrão será usado. O botão Chamar para Ação é exibido na página inicial entre o texto de boas-vindas e a descrição.
           header_snippets_help: Use este campo para adicionar coisas ao cabeçalho HTML. O uso mais comum é integrar serviços de terceiros que exigem algum JavaScript ou CSS extra. Além disso, você pode usá-lo para adicionar meta tags adicionais ao HTML. Observe que isso só será exibido em páginas públicas, não na seção de administração.
@@ -617,12 +664,16 @@ pt:
         dashboard: painel de controle
         impersonatable_users: Usuários impersonáveis
         impersonations: Imitações
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: Comercial
         scope_types: Tipos de âmbito
         scopes: Âmbitos
         static_pages: Páginas
         user_groups: Grupos de usuários
         users: Utilizadores
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Ocorreu um erro ao ler o arquivo CSV.
@@ -677,12 +728,16 @@ pt:
         hide: ocultar
         not_hidden: Não oculto
         title: Ações
+        unhide: Unhide
         unreport: Unreport
       admin:
         reportable:
           hide:
             invalid: Ocorreu um problema ao ocultar o recurso.
             success: O recurso foi ocultado com sucesso.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Tem havido um problema não relatando o recurso.
             success: O recurso não foi relatado com sucesso.

--- a/decidim-admin/config/locales/ru.yml
+++ b/decidim-admin/config/locales/ru.yml
@@ -37,6 +37,8 @@ ru:
         organization_url: Веб-адрес организации
         redirect_uri: URI перенаправления
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Enable badges
         cta_button_path: Путь кнопки "Призвать к действию"
         cta_button_text: Текст кнопки «Призвать к действию»
@@ -45,6 +47,7 @@ ru:
         enable_omnipresent_banner: Показывать вездесущий баннер
         facebook_handler: Обработчик Facebook
         favicon: Значок
+        from: From email address
         github_handler: Обработчик GitHub
         header_snippets: Сниппеты для гипертекстовых заголовков страниц сайта
         highlighted_content_banner_action_subtitle: Подзаголовок кнопки действия
@@ -63,10 +66,17 @@ ru:
         omnipresent_banner_short_description: Краткое описание
         omnipresent_banner_title: Заголовок
         omnipresent_banner_url: Веб-адрес
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Справочный префикс
+        secondary_color: Secondary
         show_statistics: Показывать статистику
+        success_color: Success
         tos_version: Версия условий участия
         twitter_handler: Обработчик Twitter
+        user_groups_enabled: Enable user groups
+        warning_color: Warning
         youtube_handler: Обработчик YouTube
       scope:
         code: Код
@@ -385,6 +395,7 @@ ru:
           fields:
             created_at: 'Создано:'
             name: Имя
+          name: OAuth uygulaması
         participatory_space_private_user:
           name: Частный участник пространства соучастия
         scope:
@@ -409,6 +420,7 @@ ru:
             roles:
               admin: Администратор
               user_manager: Распорядитель участников
+          name: kullanıcı
         user_group:
           fields:
             actions: Действия
@@ -544,6 +556,7 @@ ru:
         edit:
           update: Обновить
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Вы можете изменить то, куда ведет нажатие кнопки «Призвать к действию» на главной странице. Используйте здесь частичные пути, а не полные веб-адреса. В них допустимы буквы, цифры, тире и косые черты, и они должны начинаться с буквы. Кнопка «Призвать к действию» отображается на главной странице между приветственным текстом и описанием. Пример: %{url}'
           cta_button_text_help: Вы можете изменить текст кнопки «Призвать к действию» на главной странице для каждого доступного в вашей организации языка. Если вы не зададите текст, будет использоваться значение по умолчанию. Кнопка «Призвать к действию» отображается на главной странице между приветственным текстом и описанием.
           header_snippets_help: Используйте это поле, чтобы добавлять что-либо в HTML-заголовок. Чаще всего это делается для включения сторонних служб, для которых требуется дополнительный JavaScript или CSS. Кроме того, вы можете использовать это для добавления дополнительных метатегов в HTML. Обратите внимание, что это будет отображаться только на общедоступных страницах, а не в разделе администратора.
@@ -715,12 +728,16 @@ ru:
         hide: Скрыть
         not_hidden: Не скрыт
         title: Действия
+        unhide: Unhide
         unreport: Отменить жалобу
       admin:
         reportable:
           hide:
             invalid: При попытке скрыть ресурс произошла ошибка.
             success: Ресурс успешно скрыт.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: При отмене жалобы на ресурс произошла ошибка.
             success: Жалоба на ресурс успешно отменена.

--- a/decidim-admin/config/locales/sv.yml
+++ b/decidim-admin/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -36,6 +37,8 @@ sv:
         organization_url: Organisationens hemsida
         redirect_uri: Omdirigerings-URI
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Aktivera märken
         cta_button_path: Knappsökväg till Uppmaning till Handing
         cta_button_text: Knapptext för Uppmaning till Handling
@@ -44,6 +47,7 @@ sv:
         enable_omnipresent_banner: Visa allestädes närvarande banner
         facebook_handler: Facebook-hanterare
         favicon: Ikon
+        from: From email address
         github_handler: GitHub-hanterare
         header_snippets: Rubriksnuttar
         highlighted_content_banner_action_subtitle: Undertitel för Åtgärdsknapp
@@ -62,11 +66,17 @@ sv:
         omnipresent_banner_short_description: Kort beskrivning
         omnipresent_banner_title: Titel
         omnipresent_banner_url: URL
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Referensprefix
+        secondary_color: Secondary
         show_statistics: Visa statistik
+        success_color: Success
         tos_version: Version på användarvillkor
         twitter_handler: Twitter-hanterare
         user_groups_enabled: Aktivera användargrupper
+        warning_color: Warning
         youtube_handler: YouTube-hanterare
       scope:
         code: Kod
@@ -102,9 +112,9 @@ sv:
               must_be_ssl: Omdirigerings-URI måste vara en SSL URI
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Ogiltig bildfil
             official_img_footer:
+              allowed_file_content_types: Ogiltig bildfil
+            official_img_header:
               allowed_file_content_types: Ogiltig bildfil
   activerecord:
     attributes:
@@ -127,7 +137,6 @@ sv:
         browse: Bläddra
         export: Exportera
         manage: Hantera
-        new: Ny %{name}
         permissions: Behörigheter
         reject: Avvisa
         verify: Kontrollera
@@ -306,6 +315,11 @@ sv:
         logs_list:
           no_logs_yet: Det finns inga loggar än
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
           error: Det har inträffat ett fel som främjar den hanterade användaren.
           success: Den hanterade användaren har framgångsrikt marknadsförts.
@@ -325,6 +339,7 @@ sv:
         help_sections: Hjälpavsnitt
         homepage: Hemsida
         impersonations: impersonations
+        navbar_links: Navbar links
         newsletters: Nyhetsbrev
         oauth_applications: OAuth applikationer
         participants: Deltagarna
@@ -362,6 +377,13 @@ sv:
             reason: Anledning
             started_at: Börjat vid
             user: Användare
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
             created_at: Skapad vid
@@ -416,6 +438,28 @@ sv:
             does_not_belong: Hör inte hemma
             offensive: Offensiv
             spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
           error: Det har varit ett fel att skapa detta nyhetsbrev.
@@ -445,6 +489,8 @@ sv:
         update:
           error: Det har inträffat ett fel vid uppdatering av detta nyhetsbrev.
           success: Nyhetsbrev uppdateras framgångsrikt. Kontrollera det innan du skickar.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
           error: Det har uppstått ett fel vid skapandet av den här applikationen.
@@ -510,6 +556,7 @@ sv:
         edit:
           update: Uppdatera
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Du kan skriva över var knappen Kalla till handling på hemsidan länkar till. Använd partiella sökvägar, inte fullständiga webbadresser här. Accepterar bokstäver, siffror, bindestreck och snedstreck, och måste börja med ett brev. Knappen Ring till handling visas på hemsidan mellan välkomsttexten och beskrivningen. Exempel: %{url}'
           cta_button_text_help: Du kan skriva över textknappen Ring till handling på hemsidan för varje tillgängligt språk i din organisation. Om den inte är inställd kommer standardvärdet att användas. Knappen Ring till handling visas på hemsidan mellan välkomsttexten och beskrivningen.
           header_snippets_help: Använd det här fältet för att lägga till saker i HTML-huvudet. Den vanligaste användningen är att integrera tjänster från tredje part som kräver lite extra JavaScript eller CSS. Du kan också använda den för att lägga till extra metataggar i HTML-koden. Observera att detta endast kommer att göras på offentliga sidor, inte i administratörsdelen.
@@ -617,12 +664,16 @@ sv:
         dashboard: Kontrollpanel
         impersonatable_users: Impersonatable användare
         impersonations: impersonations
+        managed_users: Managed users
+        navbar_links: Navbar links
         participants: användare
         scope_types: Omfattningstyper
         scopes: Omfattningar
         static_pages: Sidor
         user_groups: Användargrupper
         users: Användare
+      user:
+        new: New user
       user_group:
         csv_verify:
           invalid: Det gick inte att läsa CSV-filen.
@@ -677,12 +728,16 @@ sv:
         hide: Dölj
         not_hidden: Inte dolt
         title: Handlingar
+        unhide: Unhide
         unreport: Unreport
       admin:
         reportable:
           hide:
             invalid: Det har varit ett problem att dölja resursen.
             success: Resurs framgångsrikt dold.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: Det har varit ett problem att rapportera resursen.
             success: Resurs framgångsrikt orapporterad.

--- a/decidim-admin/config/locales/tr-TR.yml
+++ b/decidim-admin/config/locales/tr-TR.yml
@@ -1,709 +1,764 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       area:
-        area_type: Alan Türü
-        name: Adı
-        organization: Kuruluş
+        area_type: Area type
+        name: Name
+        organization: Organization
       area_type:
-        name: Adı
-        organization: Kuruluş
-        plural: Çoğul
+        name: Name
+        organization: Organization
+        plural: Plural
       attachment:
-        attachment_collection_id: Klasör
-        description: Açıklama
-        file: Dosya
-        title: Başlık
+        attachment_collection_id: Folder
+        description: Description
+        file: File
+        title: Title
       attachment_collection:
-        description: Açıklama
-        name: isim
+        description: Description
+        name: Name
       category:
-        description: Açıklama
-        name: isim
-        parent_id: ebeveyn
+        description: Description
+        name: Name
+        parent_id: Parent
       component:
-        name: isim
-        published_at: Yayınlandı
-        weight: Ağırlık
-      id: İD
+        name: Name
+        published_at: Published at
+        weight: Weight
+      id: ID
       newsletter:
-        body: Vücut
-        subject: konu
+        body: Body
+        subject: Subject
       oauth_application:
-        name: isim
-        organization_logo: Organizasyon logosu (kare)
-        organization_name: Kuruluş Adı
-        organization_url: Kuruluş URL'si
-        redirect_uri: Yönlendiren URI
+        name: Name
+        organization_logo: Organization logo (square)
+        organization_name: Organization name
+        organization_url: Organization URL
+        redirect_uri: Redirect URI
       organization:
-        badges_enabled: Rozetleri etkinleştir
-        cta_button_path: Harekete Geçirici Mesaj düğmesi yolu
-        cta_button_text: Harekete Geçirici Mesaj metni
-        default_locale: Varsayılan yerel ayar
-        description: Açıklama
-        enable_omnipresent_banner: Her yerde banner göster
-        facebook_handler: Facebook işleyicisi
-        favicon: ikon
-        github_handler: GitHub işleyicisi
-        header_snippets: Üstbilgi snippet'leri
-        highlighted_content_banner_action_subtitle: Eylem düğmesi altyazısı
-        highlighted_content_banner_action_title: Eylem düğmesi başlığı
-        highlighted_content_banner_action_url: Eylem düğmesi URL'si
-        highlighted_content_banner_enabled: Vurgulanan içerik afişini göster
-        highlighted_content_banner_image: görüntü
-        highlighted_content_banner_short_description: Kısa Açıklama
-        highlighted_content_banner_title: Başlık
-        instagram_handler: Instagram işleyicisi
+        address: SMTP hostname
+        alert_color: Alert
+        badges_enabled: Enable badges
+        cta_button_path: Call To Action button path
+        cta_button_text: Call To Action button text
+        default_locale: Default locale
+        description: Description
+        enable_omnipresent_banner: Show omnipresent banner
+        facebook_handler: Facebook handler
+        favicon: Icon
+        from: From email address
+        github_handler: GitHub handler
+        header_snippets: Header snippets
+        highlighted_content_banner_action_subtitle: Action button subtitle
+        highlighted_content_banner_action_title: Action button title
+        highlighted_content_banner_action_url: Action button URL
+        highlighted_content_banner_enabled: Show the highlighted content banner
+        highlighted_content_banner_image: Image
+        highlighted_content_banner_short_description: Short description
+        highlighted_content_banner_title: Title
+        instagram_handler: Instagram handler
         logo: Logo
-        name: isim
-        official_img_footer: Resmi logo altbilgisi
-        official_img_header: Resmi logo başlığı
-        official_url: Resmi kuruluş URL'si
-        omnipresent_banner_short_description: Kısa Açıklama
-        omnipresent_banner_title: Başlık
+        name: Name
+        official_img_footer: Official logo footer
+        official_img_header: Official logo header
+        official_url: Official organization URL
+        omnipresent_banner_short_description: Short description
+        omnipresent_banner_title: Title
         omnipresent_banner_url: URL
-        reference_prefix: Referans öneki
-        show_statistics: İstatistikleri göster
-        tos_version: Hizmet sürümü şartları
-        twitter_handler: Twitter işleyicisi
-        user_groups_enabled: Kullanıcı gruplarını etkinleştir
-        youtube_handler: YouTube işleyici
+        password: Password
+        port: Port
+        primary_color: Primary
+        reference_prefix: Reference prefix
+        secondary_color: Secondary
+        show_statistics: Show statistics
+        success_color: Success
+        tos_version: Terms of service version
+        twitter_handler: Twitter handler
+        user_groups_enabled: Enable user groups
+        warning_color: Warning
+        youtube_handler: YouTube handler
       scope:
-        code: kod
-        name: isim
-        organization: organizasyon
-        parent_id: ebeveyn
-        scope_type: Kapsam türü
-        scope_type_id: Kapsam türü
+        code: Code
+        name: Name
+        organization: Organization
+        parent_id: Parent
+        scope_type: Scope type
+        scope_type_id: Scope type
       scope_type:
-        name: isim
-        organization: organizasyon
-        plural: Çoğul
+        name: Name
+        organization: Organization
+        plural: Plural
       static_page:
-        changed_notably: Gözle görülür değişiklikler oldu.
-        content: içerik
-        organization: organizasyon
-        show_in_footer: Altbilgiyi göster
-        slug: URL sümüklü böcek
-        title: Başlık
-        weight: Ağırlık
+        changed_notably: There have been noticeable changes.
+        content: Content
+        organization: Organization
+        show_in_footer: Show in the footer
+        slug: URL slug
+        title: Title
+        weight: Weight
       static_page_topic:
-        description: Açıklama
-        show_in_footer: Altbilgiyi göster
-        title: Başlık
-        weight: Ağırlık
+        description: Description
+        show_in_footer: Show in the footer
+        title: Title
+        weight: Weight
       user_group_csv_verification:
-        file: Dosya
+        file: File
     errors:
       models:
         oauth_application:
           attributes:
             redirect_uri:
-              must_be_ssl: Yönlendirme URI bir SSL URI'sı olmalıdır
+              must_be_ssl: The redirect URI must be a SSL URI
         organization:
           attributes:
-            official_img_header:
-              allowed_file_content_types: Geçersiz resim dosyası
             official_img_footer:
-              allowed_file_content_types: Geçersiz resim dosyası
+              allowed_file_content_types: Invalid image file
+            official_img_header:
+              allowed_file_content_types: Invalid image file
   activerecord:
     attributes:
       decidim/static_page:
-        content: içerik
-        slug: URL sümüklü böcek
-        title: Başlık
+        content: Content
+        slug: URL slug
+        title: Title
       doorkeeper/application:
-        authorize_url: URL'yi yetkilendir
-        client_id: Müşteri Kimliği
-        client_secret: Müşteri sırrı
-        organization_name: Kuruluş Adı
-        organization_url: Kuruluş URL'si
-        redirect_uri: Yönlendiren URI
-        site: Web sitesi
+        authorize_url: Authorize URL
+        client_id: Client ID
+        client_secret: Client Secret
+        organization_name: Organization name
+        organization_url: Organization URL
+        redirect_uri: Redirect URI
+        site: Website
   decidim:
     admin:
       actions:
-        add: Eklemek
-        browse: Araştır
-        export: ihracat
-        manage: yönetme
-        new: Yeni %{name}
-        permissions: İzinler
-        reject: reddetmek
-        verify: DOĞRULAYIN
+        add: Add
+        browse: Browse
+        export: Export
+        manage: Manage
+        permissions: Permissions
+        reject: Reject
+        verify: Verify
       area_types:
         create:
-          error: Yeni alan türü oluştururken bir hata oluştu.
-          success: Alan türü başarıyla oluşturuldu.
+          error: There was an error creating a new area type.
+          success: Area type created successfully.
         destroy:
-          success: Alan tipi başarıyla yok edildi
+          success: Area type successfully destroyed
         edit:
-          title: Alan türünü düzenle
-          update: Güncelleştirme
+          title: Edit area type
+          update: Update
         new:
-          create: Alan türü oluştur
-          title: Yeni alan tipi
+          create: Create area type
+          title: New area type
         update:
-          error: Bu alan türünü güncellerken bir hata oluştu.
-          success: Alan türü başarıyla güncellendi
+          error: There was an error when updating this area type.
+          success: Area type updated successfully
       areas:
         create:
-          error: Yeni bir alan oluştururken bir hata oluştu.
-          success: Alan başarıyla oluşturuldu.
+          error: There was an error creating a new area.
+          success: Area created successfully.
         destroy:
-          success: Alan başarıyla yok edildi
+          success: Area successfully destroyed
         edit:
-          title: Alanı düzenle
-          update: Güncelleştirme
+          title: Edit area
+          update: Update
         new:
-          create: Alan oluştur
-          title: Yeni alan
-        no_areas: Alan Yok
+          create: Create area
+          title: New area
+        no_areas: No Areas
         update:
-          error: Bu alanı güncellerken bir hata oluştu.
-          success: Alan başarıyla güncellendi
+          error: There was an error when updating this area.
+          success: Area updated successfully
       attachment_collections:
         create:
-          error: Yeni bir klasör oluştururken bir hata oluştu.
-          success: Klasör başarıyla oluşturuldu.
+          error: There was an error creating a new folder.
+          success: Folder created successfully.
         destroy:
-          success: Klasör başarıyla yok edildi.
+          success: Folder destroyed successfully.
         edit:
-          title: Klasörü düzenle
-          update: Güncelleştirme
+          title: Edit folder
+          update: Update
         index:
-          attachment_collection_used: Bu klasör kullanımda olduğundan kaldırılamaz.
-          attachment_collections_title: Ek klasörleri
+          attachment_collection_used: This folder cannot be removed because it is in use.
+          attachment_collections_title: Attachment folders
         new:
-          create: yaratmak
-          title: Yeni dosya
+          create: Create
+          title: New folder
         update:
-          error: Bu klasör güncellenirken bir hata oluştu.
-          success: Klasör başarıyla güncellendi.
+          error: There was an error when updating this folder.
+          success: Folder updated successfully.
       attachments:
         create:
-          error: Yeni bir ek oluştururken bir hata oluştu.
-          success: Ek başarıyla oluşturuldu.
+          error: There was an error creating a new attachment.
+          success: Attachment created successfully.
         destroy:
-          success: Ek başarıyla başarılı bir şekilde yok edildi.
+          success: Attachment destroyed successfully.
         edit:
-          title: Eki düzenle
-          update: Güncelleştirme
+          title: Edit attachment
+          update: Update
         index:
-          attachments_title: Ekler
+          attachments_title: Attachments
         new:
-          create: Ek oluştur
-          title: Yeni ek
+          create: Create attachment
+          title: New attachment
         update:
-          error: Bu eki güncellerken bir hata oluştu.
-          success: Ek başarıyla güncellendi.
+          error: There was an error when updating this attachment.
+          success: Attachment updated successfully.
       autocomplete:
-        no_results: Sonuç bulunamadı
-        search_prompt: Aramak için en az üç karakter girin
+        no_results: No results found
+        search_prompt: Type at least three characters to search
       categories:
         create:
-          error: Bu kategori oluşturulurken bir hata oluştu.
-          success: Kategori başarıyla oluşturuldu.
+          error: There was an error creating this category.
+          success: Category created successfully.
         destroy:
-          error: Bu kategoriyi silerken bir hata oluştu. Lütfen önce herhangi bir alt kategoriyi silin, başka bir varlığın bu kategoriye ait olmadığından emin olun ve tekrar deneyin.
-          success: Kategori başarıyla silindi.
+          error: There was an error deleting this category. Please delete any subcategory first, make sure no other entity belongs to this category and try again.
+          success: Category deleted successfully.
         edit:
-          title: Kategoriyi düzenle
-          update: Güncelleştirme
+          title: Edit category
+          update: Update
         index:
-          categories_title: Kategoriler
-          category_used: Bu kategori kullanımda olduğu için kaldırılamaz.
+          categories_title: Categories
+          category_used: This category cannot be removed because it is in use.
         new:
-          create: Kategori oluştur
-          title: Yeni kategori
+          create: Create category
+          title: New category
         update:
-          error: Bu kategori güncellenirken bir hata oluştu.
-          success: Kategori başarıyla güncellendi.
+          error: There was an error updating this category.
+          success: Category updated successfully.
       component_permissions:
         edit:
-          everyone: Herkes
-          submit: İzinleri kaydet
-          title: İzinleri düzenle
+          everyone: Everyone
+          submit: Save permissions
+          title: Edit permissions
         update:
-          success: İzinler başarıyla güncellendi.
+          success: Permissions updated successfully.
       components:
         create:
-          error: Bu bileşeni oluştururken bir hata oluştu.
-          success: Bileşen başarıyla oluşturuldu.
+          error: There was an error creating this component.
+          success: Component created successfully.
         destroy:
-          error: Bu bileşeni yok eden bir hata oluştu.
-          success: Bileşen başarıyla silindi.
+          error: There has been an error destroying this component.
+          success: Component deleted successfully.
         edit:
-          title: Bileşeni düzenle
-          update: Güncelleştirme
+          title: Edit component
+          update: Update
         form:
-          default_step_settings: Varsayılan adım ayarları
-          global_settings: Genel Ayarlar
-          step_settings: Adım ayarları
+          default_step_settings: Default step settings
+          global_settings: Global settings
+          step_settings: Step settings
         index:
-          add: Bileşen ekle
+          add: Add component
           headers:
-            actions: Eylemler
-            name: Bileşen Adı
-            type: Bileşen tipi
+            actions: Actions
+            name: Component name
+            type: Component type
         new:
-          add: Bileşen ekle
-          title: 'Bileşen ekle: %{name}'
+          add: Add component
+          title: 'Add component: %{name}'
         publish:
-          success: Bileşen başarıyla yayınlandı.
-        title: Bileşenler
+          success: The component has been successfully published.
+        title: Components
         unpublish:
-          success: Bileşen başarıyla yayından kaldırıldı.
+          success: The component has been successfully unpublished.
         update:
-          error: Bu bileşeni güncellerken bir hata oluştu.
-          success: Bileşen başarıyla güncellendi.
+          error: There has been an error updating this component.
+          success: The component was updated successfully.
       dashboard:
         show:
-          view_more_logs: Daha fazla günlükleri görüntüle
-          welcome: Decidim Yönetici Paneline hoş geldiniz.
+          view_more_logs: View more logs
+          welcome: Welcome to the Decidim Admin Panel.
       exports:
-        export_as: "%{name} olarak %{export_format}"
-        notice: İhracatınız şu anda devam ediyor. Tamamlandığında bir e-posta alacaksınız.
+        export_as: "%{name} as %{export_format}"
+        notice: Your export is currently in progress. You'll receive an email when it's complete.
       help_sections:
-        error: Yardım bölümleri güncellenirken bir hata oluştu
+        error: There's been an error updating the help sections
         form:
-          save: Kayıt etmek
-        success: Bölümler başarıyla güncellenmiş Yardım
+          save: Save
+        success: Help sections updated successfully
       impersonatable_users:
         index:
           filter:
-            all: Herşey
-            managed: Yönetilen
-            not_managed: Yönetilmeyen
-          filter_by: Tarafından filtre
-          impersonate: taklit etmek
-          impersonate_new_managed_user: Yeni yönetilen kullanıcıyı taklit et
-          managed: Yönetilen
-          name: isim
-          needs_authorization_warning: Bu kuruluş için etkinleştirilen en az bir yetkilendirmeye ihtiyacınız var.
-          not_managed: Yönetilmeyen
-          promote: Desteklemek
-          search: Arama
-          status: durum
-          view_logs: Günlükleri görüntüle
+            all: All
+            managed: Managed
+            not_managed: Not managed
+          filter_by: Filter by
+          impersonate: Impersonate
+          impersonate_new_managed_user: Impersonate new managed user
+          managed: Managed
+          name: Name
+          needs_authorization_warning: You need at least one authorization enabled for this organization.
+          not_managed: Not managed
+          promote: Promote
+          search: Search
+          status: Status
+          view_logs: View logs
       impersonations:
         close_session:
-          error: Mevcut kimliğe bürünme oturumunu kapatırken bir hata oluştu.
-          success: Geçerli kimliğe bürünme oturumu başarıyla sona ermiştir.
+          error: There has been an error closing the current impersonation session.
+          success: The current impersonation session has been successfully ended.
         create:
-          error: Kullanıcıyı taklit eden bir hata oluştu.
-          success: Yönetilen kullanıcı başarıyla oluşturuldu.
+          error: There has been an error impersonating the user.
+          success: The managed user has been successfully created.
         form:
-          authorization_method: Yetkilendirme yöntemi
-          name: isim
-          reason: neden
+          authorization_method: Authorization method
+          name: Name
+          reason: Reason
         new:
-          impersonate: taklit etmek
-          impersonate_existing_managed_user: Yönetilen kullanıcı "%{name}" kimliğine bürün
-          impersonate_existing_user: '"%{name}" kullanıcı kimliğine bürün'
-          impersonate_new_managed_user: Yeni yönetilen kullanıcıyı taklit et
+          impersonate: Impersonate
+          impersonate_existing_managed_user: Impersonate managed user "%{name}"
+          impersonate_existing_user: Impersonate user "%{name}"
+          impersonate_new_managed_user: Impersonate new managed user
       logs:
         logs_list:
-          no_logs_yet: Henüz kayıt yok
+          no_logs_yet: There are no logs yet
       managed_users:
+        index:
+          impersonate: Impersonate
+          needs_authoriation_warning: Needs authoriation warning
+          promote: Promote
+          view_logs: View logs
         promotion:
-          error: Yönetilen kullanıcıyı tanıtan bir hata oluştu.
-          success: Yönetilen kullanıcı başarıyla tanıtıldı.
+          error: There has been an error promoting the managed user.
+          success: The managed user has been successfully promoted.
         promotions:
           new:
-            explanation: Yönetilen kullanıcılar standart kullanıcılara yükseltilebilir. Bu, uygulamaya davet edilecekleri anlamına gelir ve onları tekrar taklit edemezsiniz. Davet edilen kullanıcı davetinizi kabul etmek için bir e-posta alacak.
-            new_managed_user_promotion: Yeni yönetilen kullanıcı tanıtımı
-            promote: Desteklemek
+            explanation: Managed users can be promoted to standard users. It means they will be invited to the application and you will not be able to impersonate them again. The invited user will receive an email to accept your invitation.
+            new_managed_user_promotion: New managed user promotion
+            promote: Promote
       menu:
-        admin_log: Yönetici etkinlik günlüğü
-        admins: Yöneticiler
-        appearance: Görünüm
-        area_types: Alan türleri
-        areas: alanlar
-        configuration: Yapılandırma
-        dashboard: gösterge paneli
-        help_sections: Yardım bölümleri
-        homepage: Anasayfa
-        impersonations: impersonations
-        newsletters: Haber bültenleri
-        oauth_applications: OAuth uygulamaları
-        participants: Katılımcılar
-        scope_types: Kapsam türleri
-        scopes: kapsamları
-        settings: Ayarlar
-        static_pages: Sayfalar
-        user_groups: Kullanıcı Grupları
-        users: Kullanıcılar
+        admin_log: Admin activity log
+        admins: Admins
+        appearance: Appearance
+        area_types: Area types
+        areas: Areas
+        configuration: Configuration
+        dashboard: Dashboard
+        help_sections: Help sections
+        homepage: Homepage
+        impersonations: Impersonations
+        navbar_links: Navbar links
+        newsletters: Newsletters
+        oauth_applications: OAuth applications
+        participants: Participants
+        scope_types: Scope types
+        scopes: Scopes
+        settings: Settings
+        static_pages: Pages
+        user_groups: User groups
+        users: Users
       models:
         area:
           fields:
-            area_type: Alan türü
-            name: isim
+            area_type: Area type
+            name: Name
         area_type:
           fields:
-            name: isim
-            plural: Çoğul
+            name: Name
+            plural: Plural
         attachment:
           fields:
-            collection: Klasör
-            content_type: tip
-            file_size: Boyut
-            title: Başlık
-          name: Ek dosya
+            collection: Folder
+            content_type: Type
+            file_size: Size
+            title: Title
+          name: Attachment
         attachment_collection:
-          name: Klasör
+          name: Folder
         category:
-          name: Kategori
+          name: Category
         impersonation_log:
           fields:
-            admin: yönetim
-            ended_at: İle bitti
-            expired_at: Süresi doldu
-            reason: neden
-            started_at: Başlangıç
-            user: kullanıcı
+            admin: Admin
+            ended_at: Ended at
+            expired_at: Expired at
+            reason: Reason
+            started_at: Started at
+            user: User
+        managed_user:
+          name: Name
+        navbar_link:
+          fields:
+            link: Link
+            title: Title
+            weight: Weight
         newsletter:
           fields:
-            created_at: Düzenlendi
-            progress: İlerleme
-            sent_at: Adresine gönderildi
-            subject: konu
-          name: Bülten
+            created_at: Created at
+            progress: Progress
+            sent_at: Sent at
+            subject: Subject
+          name: Newsletter
         oauth_application:
           fields:
-            created_at: Düzenlendi
-            name: isim
+            created_at: Created at
+            name: Name
           name: OAuth uygulaması
         participatory_space_private_user:
-          name: Katılımcı alan özel kullanıcısı
+          name: Participatory space private user
         scope:
           fields:
-            name: isim
-            scope_type: Kapsam türü
+            name: Name
+            scope_type: Scope type
         scope_type:
           fields:
-            name: isim
-            plural: Çoğul
+            name: Name
+            plural: Plural
         static_page:
           fields:
-            created_at: Düzenlendi
-            title: Başlık
+            created_at: Created at
+            title: Title
         user:
           fields:
-            created_at: Oluşturulma tarihi
-            email: E-posta
-            last_sign_in_at: Son giriş tarihi
-            name: isim
-            role: rol
+            created_at: Creation date
+            email: Email
+            last_sign_in_at: Last sign in date
+            name: Name
+            role: Role
             roles:
-              admin: yönetim
-              user_manager: Kullanıcı yöneticisi
+              admin: Admin
+              user_manager: User manager
           name: kullanıcı
         user_group:
           fields:
-            actions: Eylemler
-            created_at: Düzenlendi
-            document_number: Belge Numarası
-            name: isim
-            phone: Telefon
-            state: Belirtmek, bildirmek
-            users_count: Kullanıcılar
+            actions: Actions
+            created_at: Created at
+            document_number: Document number
+            name: Name
+            phone: Phone
+            state: State
+            users_count: Users count
       moderations:
         index:
-          title: Denetimler
+          title: Moderations
         report:
           reasons:
-            does_not_belong: Ait değil
-            offensive: saldırgan
-            spam: İstenmeyen e
+            does_not_belong: Does not belong
+            offensive: Offensive
+            spam: Spam
+      navbar_links:
+        create:
+          error: There was an error when creating this link.
+          success: Link created successfully
+        destroy:
+          success: Link successfully destroyed
+        edit:
+          title: Edit navbar link
+          update: Update
+        form:
+          link: Link
+          new_tab: Open in a new tab
+          same_tab: Open in the same tab
+          title: Title
+          weight: Weight
+        new:
+          create: Create
+          title: New navbar link
+        no_links: No links created
+        update:
+          error: There was an error when updating this link.
+          success: Link updated successfully
       newsletters:
         create:
-          error: Bu bülteni oluştururken bir hata oluştu.
-          success: Bülten başarıyla oluşturuldu. Lütfen göndermeden önce gözden geçirin.
+          error: There's been an error creating this newsletter.
+          success: Newsletter created successfully. Please, review it before sending.
         deliver:
-          error: Bu bülteni veren bir hata oluştu.
-          success: Bülten başarıyla teslim edildi.
+          error: There's been an error delivering this newsletter.
+          success: Newsletter delivered successfully.
         destroy:
-          error_already_sent: 'Haber bülteni yok edilemez: Zaten gönderilmiş.'
-          success: Bülten başarıyla imha edildi.
+          error_already_sent: 'Can''t destroy newsletter: It has already been sent.'
+          success: Newsletter destroyed successfully.
         edit:
-          save_and_preview: Kaydet ve önizle
-          title: Bülten düzenle
+          save_and_preview: Save and preview
+          title: Edit newsletter
         form:
-          interpolations_hint: 'İpucu: Gövde veya nesnenin herhangi bir yerinde "%{name}" kullanabilir ve alıcının adıyla değiştirilir.'
+          interpolations_hint: 'Hint: You can use "%{name}" anywhere in the body or subject and it will be replaced by the recipient''s name.'
         index:
-          confirm_delete: Bu bülteni silmek istediğinizden emin misiniz?
-          title: Haber bültenleri
+          confirm_delete: Are you sure you want to delete this newsletter?
+          title: Newsletters
         new:
-          save: Kayıt etmek
-          title: Yeni bülten
+          save: Save
+          title: New newsletter
         show:
-          confirm_deliver: Bu bülteni sunmak istediğinizden emin misiniz? Bu işlem geri alınamaz.
-          deliver: Bülten sunun
-          preview: Ön izleme
-          subject: konu
+          confirm_deliver: Are you sure you want to deliver this newsletter? This action cannot be undone.
+          deliver: Deliver newsletter
+          preview: Preview
+          subject: Subject
         update:
-          error: Bu bülteni güncellerken bir hata oluştu.
-          success: Bülten başarıyla güncellendi. Lütfen göndermeden önce gözden geçirin.
+          error: There's been an error updating this newsletter.
+          success: Newsletter updated successfully. Please review it before sending.
+      oauth_application:
+        new: New Oauth application
       oauth_applications:
         create:
-          error: Bu uygulama oluşturulurken bir hata oluştu.
-          success: Uygulama başarıyla oluşturuldu.
+          error: There's been an error creating this application.
+          success: Application created successfully.
         destroy:
-          error: Bu uygulamayı yok eden bir hata oluştu.
-          success: Uygulama başarıyla yok edildi.
+          error: There's been an error destroying this application.
+          success: Application destroyed successfully.
         edit:
-          save: Kayıt etmek
-          title: Uygulamayı düzenle
+          save: Save
+          title: Edit application
         index:
-          confirm_delete: Bu uygulamayı silmek istediğinizden emin misiniz?
-          title: OAuth uygulamaları
+          confirm_delete: Are you sure you want to delete this application?
+          title: OAuth applications
         new:
-          save: Kayıt etmek
-          title: Yeni uygulama
+          save: Save
+          title: New application
         update:
-          error: Bu uygulama güncellenirken bir hata oluştu.
-          success: Uygulama başarıyla güncellendi.
+          error: There's been an error updating this application.
+          success: Application updated successfully.
       officializations:
         create:
-          success: Kullanıcı başarıyla onaylandı
+          success: User officialized successfully
         destroy:
-          success: Kullanıcı başarıyla gayri resmi
+          success: User unofficialized successfully
         index:
-          actions: Eylemler
-          badge: rozet
-          created_at: At düzenlendi
+          actions: Actions
+          badge: Badge
+          created_at: Created At
           filter:
-            all: Herşey
-            not_officialized: Resmi değil
-            officialized: resmileştirilmiş
-          filter_by: Tarafından filtre
-          name: isim
-          nickname: Takma ad
-          not_officialized: Resmi değil
-          officialize: ', resmiyete'
-          officialized: resmileştirilmiş
+            all: All
+            not_officialized: Not officialized
+            officialized: Officialized
+          filter_by: Filter by
+          name: Name
+          nickname: Nickname
+          not_officialized: Not officialized
+          officialize: Officialize
+          officialized: Officialized
           reofficialize: Reofficialize
-          search: Arama
-          status: durum
+          search: Search
+          status: Status
           unofficialize: Unofficialize
         new:
-          badge: Resmi görevlendirme rozeti
-          officialize: ', resmiyete'
-          title: '"%{name}" kullanıcısını resmi olarak yetkilendir'
+          badge: Officialization badge
+          officialize: Officialize
+          title: Officialize user "%{name}"
       organization:
         edit:
-          title: Kuruluş düzenle
-          update: Güncelleştirme
+          title: Edit organization
+          update: Update
         form:
           facebook: Facebook
           github: GitHub
           instagram: Instagram
-          social_handlers: Sosyal
-          twitter: heyecan
-          url: URL
-          youtube: Youtube
+          social_handlers: Social
+          twitter: Twitter
+          url: Url
+          youtube: YouTube
         update:
-          error: Bu kuruluşu güncellerken bir hata oluştu.
-          success: Kuruluş başarıyla güncellendi.
+          error: There was an error when updating this organization.
+          success: Organization updated successfully.
       organization_appearance:
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          cta_button_path_help: 'Ana sayfadaki Harekete Geçirici Mesaj düğmesinin nereye bağlanacağı üzerine yazabilirsiniz. Tam URL’leri değil kısmi yolları kullanın. Harfleri, sayıları, kısa çizgileri ve eğik çizgileri kabul eder ve bir harfle başlamalıdır. Karşılama metni ve açıklama arasındaki ana sayfada Eylem Çağrısı düğmesi görüntülenir. Örnek: %{url}'
-          cta_button_text_help: Kuruluşunuzdaki mevcut her dil için ana sayfada Harekete Geçirici Mesaj düğmesinin üzerine yazabilirsiniz. Ayarlanmazsa, varsayılan değer kullanılır. Karşılama metni ve açıklama arasındaki ana sayfada Eylem Çağrısı düğmesi görüntülenir.
-          header_snippets_help: HTML kafasına bir şeyler eklemek için bu alanı kullanın. En yaygın kullanım, bazı ekstra JavaScript veya CSS gerektiren üçüncü taraf hizmetleri entegre etmektir. Ayrıca, HTML'ye fazladan meta etiketler eklemek için de kullanabilirsiniz. Bunun yalnızca yönetici bölümünde değil, herkese açık sayfalarda gösterileceğini unutmayın.
-          homepage_appearance_title: Ana sayfa görünümünü düzenle
-          homepage_highlighted_content_banner_title: Yüksek içerikli banner
-          layout_appearance_title: Düzen görünümünü düzenle
-          omnipresent_banner_appearance_title: Her yerde bulunan banner'ı düzenle
+          colors_title: Organization colors
+          cta_button_path_help: 'You can overwrite where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
+          cta_button_text_help: You can overwrite the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
+          header_snippets_help: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section.
+          homepage_appearance_title: Edit homepage appearance
+          homepage_highlighted_content_banner_title: Highligted content banner
+          layout_appearance_title: Edit layout appearance
+          omnipresent_banner_appearance_title: Edit omnipresent banner
       organization_homepage:
         edit:
-          active_content_blocks: Aktif içerik blokları
-          inactive_content_blocks: Etkin olmayan içerik blokları
+          active_content_blocks: Active content blocks
+          inactive_content_blocks: Inactive content blocks
       organization_homepage_content_blocks:
         edit:
-          update: Güncelleştirme
+          update: Update
       participatory_space_private_users:
         create:
-          error: Bu katılımcı alan için özel bir kullanıcı eklenirken bir hata oluştu.
-          success: Katılımcı alan özel kullanıcı erişimi başarıyla oluşturuldu.
+          error: There was an error adding a private user for this participatory space.
+          success: Participatory space private user access created successfully.
         destroy:
-          error: Bu katılımcı alan için özel bir kullanıcı silinirken bir hata oluştu.
-          success: Katılımcı alan özel kullanıcı erişimi başarıyla yok edildi.
+          error: There was an error deleting a private user for this participatory space.
+          success: Participatory space private user access destroyed successfully.
         index:
-          title: Katılımcı alan özel kullanıcısı
+          title: Participatory space private user
         new:
-          create: yaratmak
-          title: Yeni Katılımcı Uzay özel kullanıcısı.
+          create: Create
+          title: New Participatory Space private user.
       scope_types:
         create:
-          error: Yeni kapsam türü oluştururken bir hata oluştu.
-          success: Kapsam türü başarıyla oluşturuldu.
+          error: There was an error creating a new scope type.
+          success: Scope type created successfully.
         destroy:
-          success: Kapsam türü başarıyla yok edildi
+          success: Scope type successfully destroyed
         edit:
-          title: Kapsam türünü düzenle
-          update: Güncelleştirme
+          title: Edit scope type
+          update: Update
         new:
-          create: Kapsam türü oluştur
-          title: Yeni kapsam
+          create: Create scope type
+          title: New scope
         update:
-          error: Bu kapsam türünü güncellerken bir hata oluştu.
-          success: Kapsam türü başarıyla güncellendi
+          error: There was an error when updating this scope type.
+          success: Scope type updated successfully
       scopes:
         create:
-          error: Yeni kapsam oluştururken bir hata oluştu.
-          success: Kapsam başarıyla oluşturuldu.
+          error: There was an error creating a new scope.
+          success: Scope created successfully.
         destroy:
-          success: Kapsam başarıyla yok edildi
+          success: Scope successfully destroyed
         edit:
-          title: Kapsamı düzenle
-          update: Güncelleştirme
+          title: Edit scope
+          update: Update
         new:
-          create: Kapsam oluştur
-          title: Yeni kapsam
-        no_scopes: Bu seviyede hiçbir kapsam yok.
+          create: Create scope
+          title: New scope
+        no_scopes: No scopes at this level.
         update:
-          error: Bu kapsamı güncellerken bir hata oluştu.
-          success: Kapsam başarıyla güncellendi
+          error: There was an error when updating this scope.
+          success: Scope updated successfully
       static_page_topics:
         create:
-          error: Yeni bir konu oluştururken bir hata oluştu.
-          success: Konu başarıyla oluşturuldu.
+          error: There was an error creating a new topic.
+          success: Topic created successfully.
         destroy:
-          success: Konu başarıyla yok edildi
+          success: Topic successfully destroyed
         edit:
-          title: Konuyu düzenle
-          update: Konuyu güncelle
+          title: Edit topic
+          update: Update topic
         new:
-          create: Konu oluştur
-          title: Yeni Konu
+          create: Create topic
+          title: New topic
         update:
-          error: Bu konu güncellenirken bir hata oluştu.
-          success: Konu başarıyla güncellendi
+          error: There was an error when updating this topic.
+          success: Topic updated successfully
       static_pages:
         actions:
-          view: Genel sayfayı görüntüle
+          view: View public page
         create:
-          error: Yeni bir sayfa oluşturulurken bir hata oluştu.
-          success: Sayfa başarıyla oluşturuldu.
+          error: There was an error creating a new page.
+          success: Page created successfully.
         destroy:
-          success: Sayfa başarıyla yok edildi
+          success: Page successfully destroyed
         edit:
-          changed_notably_help: İşaretlenirse, kullanıcılar yeni şartlar ve koşulları kabul etmek için bilgilendirileceklerdir.
-          title: Sayfayı düzenle
-          update: Güncelleştirme
+          changed_notably_help: If checked, users will be notified to accept the new terms and conditions.
+          title: Edit page
+          update: Update
         form:
-          none: Yok
+          none: None
         index:
-          last_notable_change: Son önemli değişiklik
+          last_notable_change: Last notable change
         new:
-          create: Sayfa oluştur
-          title: Yeni sayfa
+          create: Create page
+          title: New page
         topic:
-          destroy: Konuyu kaldır
-          edit: Konuyu düzenle
-          empty: Bu konunun altında sayfa yok
-          without_topic: Konu olmayan sayfalar
+          destroy: Remove topic
+          edit: Edit topic
+          empty: There's no page under this topic
+          without_topic: Pages without topic
         update:
-          error: Bu sayfa güncellenirken bir hata oluştu.
-          success: Sayfa başarıyla güncellendi
+          error: There was an error when updating this page.
+          success: Page updated successfully
       titles:
-        admin_log: Yönetici günlüğü
-        area_types: Alan türleri
-        areas: alanlar
-        authorization_workflows: Doğrulama yöntemleri
-        dashboard: gösterge paneli
-        impersonatable_users: Impersonatable kullanıcılar
-        impersonations: impersonations
-        participants: Kullanıcılar
-        scope_types: Kapsam türleri
-        scopes: kapsamları
-        static_pages: Sayfalar
-        user_groups: Kullanıcı Grupları
-        users: Kullanıcılar
+        admin_log: Admin log
+        area_types: Area types
+        areas: Areas
+        authorization_workflows: Verification methods
+        dashboard: Dashboard
+        impersonatable_users: Manageable users
+        impersonations: Users management
+        managed_users: Managed users
+        navbar_links: Navbar links
+        participants: Users
+        scope_types: Scope types
+        scopes: Scopes
+        static_pages: Pages
+        user_groups: User groups
+        users: Users
+      user:
+        new: New user
       user_group:
         csv_verify:
-          invalid: CSV dosyasını okurken bir hata oluştu.
-          success: CSV dosyası başarıyla yüklendi, kriterleri karşılayan kullanıcı gruplarını doğrularız. Bu biraz zaman alabilir.
+          invalid: There was an error reading the CSV file.
+          success: CSV file uploaded successfully, we're verifying the user groups matching the criteria. This might take a while.
         reject:
-          invalid: Bu kullanıcı grubunu reddederken bir hata oluştu.
-          success: Kullanıcı grubu başarıyla reddedildi
+          invalid: There was an error when rejecting this user group.
+          success: User group rejected successfully
         verify:
-          invalid: Bu kullanıcı grubunu doğrularken bir hata oluştu.
-          success: Kullanıcı grubu başarıyla doğrulandı
+          invalid: There was an error when verifying this user group.
+          success: User group verified successfully
       user_groups:
         index:
           filter:
-            all: Herşey
-            pending: kadar
-            rejected: Reddedilen
-            verified: Doğrulanmış
-          filter_by: Tarafından filtre
-          search: Arama
+            all: All
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+          filter_by: Filter by
+          search: Search
           state:
-            pending: kadar
-            rejected: Reddedilen
-            verified: Doğrulanmış
-          verify_via_csv: CSV ile doğrulayın
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
+          verify_via_csv: Verify via CSV
       user_groups_csv_verifications:
         new:
-          explanation: CSV dosyanızı yükleyin. Dosyanın ilk sütunundaki kullanıcı gruplarının resmi e-postalarının, başlıksız olarak olması gerekir. Sadece e-postalarını onaylayan ve CSV dosyasında görünen bir e-postaya sahip olan kullanıcı grupları doğrulanacaktır.
-          title: CSV dosyanızı yükleyin
-          upload: Yükleme
+          explanation: Upload your CSV file. It must have the official emails of the user groups in your organization in the first column of the file, without headers. Only user groups that have confirmed their email and that have an email appearing in the CSV file will be validated.
+          title: Upload your CSV file
+          upload: Upload
       users:
         create:
-          error: Bu kullanıcıyı davet ederken bir hata oluştu.
-          success: Kullanıcı başarıyla davet edildi.
+          error: There was an error when inviting this user.
+          success: User invited successfully.
         destroy:
-          error: Bu kullanıcıyı silmeye çalışırken bir hata oluştu.
-          success: Kullanıcı artık yönetici değil.
+          error: There was an error when trying to delete this user.
+          success: User is no longer an administrator.
         form:
-          email: E-posta
-          name: isim
-          role: rol
+          email: Email
+          name: Name
+          role: Role
         new:
-          create: Davet et
-          title: Kullanıcıyı yönetici olarak davet et
-      view_public_page: Genel sayfayı görüntüle
+          create: Invite
+          title: Invite user as administrator
+      view_public_page: View public page
     forms:
       errors:
         impersonate_user:
-          reason: Yönetilmeyen bir kullanıcıyı taklit ederken bir neden belirtmeniz gerekir
+          reason: You need to provide a reason when impersonating a non managed user
     moderations:
       actions:
-        hidden: Gizli
-        hide: Saklamak
-        not_hidden: Gizli değil
-        title: Eylemler
-        unreport: Bildir
+        hidden: Hidden
+        hide: Hide
+        not_hidden: Not hidden
+        title: Actions
+        unhide: Unhide
+        unreport: Unreport
       admin:
         reportable:
           hide:
-            invalid: Kaynağı gizleyen bir sorun oluştu.
-            success: Kaynak başarıyla gizlendi.
+            invalid: There's been a problem hiding the resource.
+            success: Resource successfully hidden.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
-            invalid: Kaynağı bildirmeyen bir sorun oluştu.
-            success: Kaynak başarıyla bildirilmedi.
+            invalid: There's been a problem unreporting the resource.
+            success: Resource successfully unreported.
       models:
         moderation:
           fields:
-            hidden_at: Gizli
-            report_count: saymak
-            reportable: bildirilmesi zorunlu
-            reported_content_url: Raporlanan içerik URL'si
-            reports: Raporlar
-            visit_url: URL'yi ziyaret et
+            hidden_at: Hidden at
+            report_count: Count
+            reportable: Reportable
+            reported_content_url: Reported content URL
+            reports: Reports
+            visit_url: Visit URL
   errors:
     messages:
-      invalid_json: Geçersiz JSON
+      invalid_json: Invalid JSON
   layouts:
     decidim:
       admin:
         newsletters:
-          title: Haber bültenleri
+          title: Newsletters
         settings:
-          title: Ayarlar
+          title: Settings
         users:
-          title: Kullanıcılar
+          title: Users

--- a/decidim-admin/config/locales/uk.yml
+++ b/decidim-admin/config/locales/uk.yml
@@ -37,6 +37,8 @@ uk:
         organization_url: Адреса сайту організації
         redirect_uri: URI перенаправлення
       organization:
+        address: SMTP hostname
+        alert_color: Alert
         badges_enabled: Enable badges
         cta_button_path: Шлях до кнопки "Закликати до дії"
         cta_button_text: Текст кнопки "Закликати до дії"
@@ -45,6 +47,7 @@ uk:
         enable_omnipresent_banner: Показувати всюдисущий банер
         facebook_handler: Адреса Facebook
         favicon: Значок
+        from: From email address
         github_handler: Адреса GitHub
         header_snippets: Сніпети для гіпертекстових заголовків сторінок сайту
         highlighted_content_banner_action_subtitle: Підзаголовок кнопки дії
@@ -63,10 +66,17 @@ uk:
         omnipresent_banner_short_description: Стислий опис
         omnipresent_banner_title: Заголовок
         omnipresent_banner_url: Веб-адреса
+        password: Password
+        port: Port
+        primary_color: Primary
         reference_prefix: Довідковий префікс
+        secondary_color: Secondary
         show_statistics: Показувати статистику
+        success_color: Success
         tos_version: Версія умов участі
         twitter_handler: Адреса Twitter
+        user_groups_enabled: Enable user groups
+        warning_color: Warning
         youtube_handler: Адреса YouTube
       scope:
         code: Код
@@ -385,6 +395,7 @@ uk:
           fields:
             created_at: 'Створено:'
             name: Ім'я
+          name: OAuth uygulaması
         participatory_space_private_user:
           name: Приватний учасник простору співучасті
         scope:
@@ -409,6 +420,7 @@ uk:
             roles:
               admin: Адміністратор
               user_manager: Розпорядник учасників
+          name: kullanıcı
         user_group:
           fields:
             actions: Дії
@@ -544,6 +556,7 @@ uk:
         edit:
           update: Оновити
         form:
+          colors_title: Organization colors
           cta_button_path_help: 'Ви можете змінити те, куди веде натискання кнопки "Закликати до дії" на головній сторінці. Використовуйте тут часткові шляхи, а не повні веб-адреси. Прийнятні літери, цифри, дефіс та скісна риска. Першою має бути літера. Кнопка "Закликати до дії" відображається на головній сторінці між привітальним текстом та описом. Приклад: %{url}'
           cta_button_text_help: Ви можете змінити текст кнопки "Закликати до дії" на головній сторінці для кожної доступної мови вашої організації. Якщо ви не задасте цей текст, буде використане значення за замовчуванням. Кнопка "Закликати до дії" відображається на домашній сторінці між привітальним текстом та описом.
           header_snippets_help: Використовуйте це поле, щоб додавати щось до заголовку HTML. Найпоширенішим використанням є інтеграція сторонніх служб, які потребують додаткового JavaScript або CSS. Також ви можете використовувати його для додавання додаткових метатегів до HTML. Зверніть увагу, що це буде показано лише на загальнодоступних сторінках, а не в розділі адміністратора.
@@ -715,12 +728,16 @@ uk:
         hide: Приховати
         not_hidden: Не приховано
         title: Дії
+        unhide: Unhide
         unreport: Скасувати скаргу
       admin:
         reportable:
           hide:
             invalid: При спробі приховати ресурс сталася помилка.
             success: Ресурс успішно приховано.
+          unhide:
+            invalid: There's been a problem unhiding the resource.
+            success: Resource successfully unhidden.
           unreport:
             invalid: При спробі скасувати скаргу щодо ресурсу сталася помилка.
             success: Скаргу на ресурс успішно скасовано.

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -16,7 +16,14 @@ describe "Admin invite", type: :system do
       organization_admin_email: "f.laguardia@gotham.gov",
       available_locales: ["en"],
       default_locale: "en",
-      users_registration_mode: "enabled"
+      users_registration_mode: "enabled",
+      smtp_settings: {
+        "address" => "decide.lvh.me",
+        "port" => "25",
+        "user_name" => "f.laguardia",
+        "password" => Decidim::AttributeEncryptor.encrypt("password"),
+        "from" => "no-reply@decide.lvh.me"
+      }
     }
   end
 

--- a/decidim-assemblies/config/locales/ca.yml
+++ b/decidim-assemblies/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/de.yml
+++ b/decidim-assemblies/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/es-PY.yml
+++ b/decidim-assemblies/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -334,7 +335,7 @@ es-PY:
         assemblies:
           contextual: "<p>Una asamblea es un grupo de miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un área o alcance específico de la organización.</p> <p>asambleas celebran reuniones, algunas son privadas y otras están abiertas. Si están abiertos, es posible participar en ellos (por ejemplo: asistir si la capacidad lo permite, agregar puntos a la agenda o comentar sobre las propuestas y decisiones tomadas por este órgano).</p> <p>Ejemplos: una asamblea general (que se reúne una vez al año para definir las principales líneas de acción de la organización, así como sus órganos ejecutivos por voto), un consejo asesor de igualdad (que se reúne cada dos meses para hacer propuestas sobre cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para supervisar un proceso) o un organismo de garantía (que recopila incidentes, abusos o propuestas para mejorar los procedimientos de toma de decisiones) son ejemplos de asambleas.</p>\n"
           page: "<p>Una asamblea es un grupo de miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un área o alcance específico de la organización.</p> <p>asambleas celebran reuniones, algunas son privadas y otras están abiertas. Si están abiertos, es posible participar en ellos (por ejemplo: asistir si la capacidad lo permite, agregar puntos a la agenda o comentar sobre las propuestas y decisiones tomadas por este órgano).</p> <p>Ejemplos: una asamblea general (que se reúne una vez al año para definir las principales líneas de acción de la organización, así como sus órganos ejecutivos por voto), un consejo asesor de igualdad (que se reúne cada dos meses para hacer propuestas sobre cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para supervisar un proceso) o un organismo de garantía (que recopila incidentes, abusos o propuestas para mejorar los procedimientos de toma de decisiones) son ejemplos de asambleas.</p>\n"
-          title: '¿Qué son las asambleas?'
+          title: "¿Qué son las asambleas?"
     log:
       value_types:
         assembly_presenter:

--- a/decidim-assemblies/config/locales/es.yml
+++ b/decidim-assemblies/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -334,7 +335,7 @@ es:
         assemblies:
           contextual: "<p>Una asamblea es un grupo formado por miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un ámbito o área específica de la misma.</p> <p>Las asambleas realizan encuentros, algunas son privadas y otras son abiertas. Si son abiertas se puede participar en ellas (por ejemplo: asistiendo si el aforo lo permite, añadiendo puntos al orden del día, o comentando las propuestas y decisiones tomadas por dicho órgano).</p> <p>Ejemplos: Una asamblea general (que se reúne una vez al año para definir las líneas principales de acción de la organización así como a sus órganos ejecutivos por votación), una consejo asesor de igualdad (que se reúne cada dos meses para realizar propuestas de cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para realizar el seguimiento de un proceso) o una órgano de garantías (que recoge las incidencias, abusos o propuestas de mejora de los procedimientos de toma de decisiones) son todo ejemplos de asambleas.</p>\n"
           page: "<p>Una asamblea es un grupo formado por miembros de una organización que se reúnen periódicamente para tomar decisiones sobre un ámbito o área específica de la misma.</p> <p>Las asambleas realizan encuentros, algunas son privadas y otras son abiertas. Si son abiertas se puede participar en ellas (por ejemplo: asistiendo si el aforo lo permite, añadiendo puntos al orden del día, o comentando las propuestas y decisiones tomadas por dicho órgano).</p> <p>Ejemplos: Una asamblea general (que se reúne una vez al año para definir las líneas principales de acción de la organización así como a sus órganos ejecutivos por votación), una consejo asesor de igualdad (que se reúne cada dos meses para realizar propuestas de cómo mejorar las relaciones de género en la organización), una comisión de evaluación (que se reúne cada mes para realizar el seguimiento de un proceso) o una órgano de garantías (que recoge las incidencias, abusos o propuestas de mejora de los procedimientos de toma de decisiones) son todo ejemplos de asambleas.</p>\n"
-          title: '¿Qué son las asambleas?'
+          title: "¿Qué son las asambleas?"
     log:
       value_types:
         assembly_presenter:

--- a/decidim-assemblies/config/locales/eu.yml
+++ b/decidim-assemblies/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/fi-pl.yml
+++ b/decidim-assemblies/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/fi.yml
+++ b/decidim-assemblies/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/fr.yml
+++ b/decidim-assemblies/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -61,7 +62,7 @@ fr:
         position: Rôle
       assembly_user_role:
         email: email
-        name: Nom 
+        name: Nom
         role: Fonction
   activerecord:
     models:
@@ -263,9 +264,8 @@ fr:
         consultative_advisory: Consultatif/Consultatif
         executive: Exécutif
         government: Gouvernement
-        help: 'Afficher :'
+        help: 'Montrer :'
         label: 'Afficher :'
-        help: "Montrer :"
         others: Autres
         participatory: Participatif
         placeholder: Filtrer par type

--- a/decidim-assemblies/config/locales/gl.yml
+++ b/decidim-assemblies/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -360,8 +361,8 @@ gl:
           reset_chart: Restablecer
         order_by_assemblies:
           assemblies:
-            one: "Asemblea %{count}"
-            other: "Asembleas %{count}"
+            one: Asemblea %{count}
+            other: Asembleas %{count}
         promoted_assembly:
           more_info: Máis información
           take_part: Tomar parte en

--- a/decidim-assemblies/config/locales/hu.yml
+++ b/decidim-assemblies/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/id-ID.yml
+++ b/decidim-assemblies/config/locales/id-ID.yml
@@ -1,369 +1,374 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       assembly:
-        area_id: Daerah
-        assembly_type: Tipe perakitan
-        assembly_type_other: Jenis perakitan lainnya
-        banner_image: Gambar spanduk
-        closing_date: Tanggal Penutupan
-        closing_date_reason: Alasan tanggal penutupan
-        composition: Komposisi
-        copy_categories: Salin kategori
-        copy_components: Salin komponen
-        copy_features: Salin fitur
-        created_by: Dibuat oleh
-        created_by_other: Dibuat oleh lainnya
-        creation_date: Tanggal Diciptakan
-        decidim_area_id: Daerah
-        decidim_scope_id: Cakupan
-        description: Deskripsi
-        developer_group: Grup promotor
+        area_id: Area
+        assembly_type: Assembly type
+        assembly_type_other: Assembly type other
+        banner_image: Banner image
+        closing_date: Closing date
+        closing_date_reason: Closing date reason
+        composition: Composition
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_features: Copy features
+        created_by: Created by
+        created_by_other: Created by other
+        creation_date: Date created
+        decidim_area_id: Area
+        decidim_scope_id: Scope
+        description: Description
+        developer_group: Promoter group
         domain: Domain
-        duration: Lamanya
+        duration: Duration
         facebook: Facebook
         github: GitHub
-        hashtag: Tanda pagar
-        hero_image: Gambar rumah
-        included_at: Termasuk di
+        hashtag: Hashtag
+        hero_image: Home image
+        included_at: Included at
         instagram: Instagram
-        internal_organisation: Organisasi internal
-        is_transparent: Transparan
-        local_area: Area organisasi
-        meta_scope: Ruang lingkup metadata
-        parent_id: Perakitan orang tua
-        participatory_processes_ids: Proses Partisipatif Terkait
-        participatory_scope: Apa yang diputuskan
-        participatory_structure: Bagaimana cara memutuskannya
-        private_space: Ruang pribadi
-        promoted: Dipromosikan
-        published_at: Diterbitkan di
-        purpose_of_action: Tujuan tindakan
-        scope_id: Cakupan
-        scopes_enabled: Lingkup diaktifkan
-        short_description: Deskripsi Singkat
-        show_statistics: Tampilkan statistik
-        slug: Siput URL
-        special_features: Fitur spesial
+        internal_organisation: Internal organisation
+        is_transparent: Is transparent
+        local_area: Organization area
+        meta_scope: Scope metadata
+        parent_id: Parent assembly
+        participatory_processes_ids: Related Participatory processes
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: Private space
+        promoted: Promoted
+        published_at: Published at
+        purpose_of_action: Purpose of action
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
+        slug: URL slug
+        special_features: Special features
         subtitle: Subtitle
-        target: Yang berpartisipasi
-        title: Judul
-        twitter: Kericau
-        youtube: Youtube
+        target: Who participates
+        title: Title
+        twitter: Twitter
+        youtube: YouTube
       assembly_member:
-        birthday: Ulang tahun
-        birthplace: Tempat lahir
-        ceased_date: Tanggal berhenti
-        designation_date: Tanggal penunjukan
-        designation_mode: Mode penunjukan
-        full_name: Nama lengkap
-        gender: Jenis kelamin
-        position: Posisi
+        birthday: Birthday
+        birthplace: Birthplace
+        ceased_date: Ceased date
+        designation_date: Designation date
+        designation_mode: Designation mode
+        full_name: Full name
+        gender: Gender
+        position: Position
       assembly_user_role:
-        email: E-mail
-        name: Nama
-        role: Peran
+        email: Email
+        name: Name
+        role: Role
   activerecord:
     models:
       decidim/assembly:
+        one: Assembly
         other: Assemblies
       decidim/assembly_member:
-        other: Anggota dewan
+        one: Assembly member
+        other: Assembly members
       decidim/assembly_user_role:
-        other: Perakitan peran pengguna
+        one: Assembly user role
+        other: Assembly user roles
   decidim:
     admin:
       actions:
-        new_assembly: Perakitan baru
+        new_assembly: New assembly
       assemblies:
         create:
-          error: Ada kesalahan saat membuat perakitan baru.
-          success: Majelis berhasil dibuat.
+          error: There was an error creating a new assembly.
+          success: Assembly created successfully.
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          title: Informasi Umum
+          title: General Information
         index:
-          not_published: Tidak diterbitkan
-          private: Pribadi
-          public: Publik
-          published: Diterbitkan
+          not_published: Not published
+          private: Private
+          public: Public
+          published: Published
         new:
-          create: Membuat
-          title: Perakitan baru
+          create: Create
+          title: New assembly
         update:
-          error: Ada kesalahan saat memperbarui perakitan ini.
-          success: Majelis berhasil diperbarui.
+          error: There was an error when updating this assembly.
+          success: Assembly updated successfully.
       assemblies_copies:
         create:
-          error: Ada kesalahan saat menduplikasi majelis ini.
-          success: Majelis berhasil digandakan.
+          error: There was an error when duplicating this assembly.
+          success: Assembly duplicated successfully.
       assembly_copies:
         new:
-          copy: Salinan
-          select: Pilih data mana yang ingin Anda gandakan
-          title: Rakitan duplikat
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate assembly
       assembly_members:
         create:
-          error: Terjadi kesalahan saat menambahkan anggota untuk majelis ini.
-          success: Anggota berhasil dibuat untuk perakitan ini.
+          error: There was an error adding a member for this assembly.
+          success: Member created successfully for this assembly.
         destroy:
-          success: Anggota berhasil dihapus untuk perakitan ini.
+          success: Member deleted successfully for this assembly.
         edit:
-          title: Perbarui anggota majelis.
-          update: Memperbarui
+          title: Update assembly member.
+          update: Update
         index:
-          assembly_members_title: Anggota dewan
+          assembly_members_title: Assembly members
         new:
-          create: Membuat
-          title: Anggota majelis baru.
+          create: Create
+          title: New assembly member.
         update:
-          error: Terjadi kesalahan saat memperbarui anggota untuk perakitan ini.
-          success: Anggota berhasil diperbarui untuk perakitan ini.
+          error: There was an error updating the member for this assembly.
+          success: Member updated successfully for this assembly.
       assembly_publications:
         create:
-          error: Terjadi kesalahan saat mempublikasikan perakitan ini.
-          success: Majelis berhasil diterbitkan.
+          error: There was an error publishing this assembly.
+          success: Assembly published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi rakitan ini.
-          success: Majelis tidak berhasil diterbitkan.
+          error: There was an error unpublishing this assembly.
+          success: Assembly unpublished successfully.
       assembly_user_roles:
         create:
-          error: Terjadi kesalahan saat menambahkan pengguna untuk perakitan ini.
-          success: Pengguna berhasil ditambahkan ke majelis ini.
+          error: There was an error adding a user for this assembly.
+          success: User added successfully to this assembly.
         destroy:
-          success: Pengguna berhasil dihapus dari rakitan ini.
+          success: User removed successfully from this assembly.
         edit:
-          title: Perbarui pengguna perakitan.
-          update: Memperbarui
+          title: Update assembly user.
+          update: Update
         index:
-          assembly_admins_title: Pengguna majelis
+          assembly_admins_title: Assembly users
         new:
-          create: Membuat
-          title: Pengguna perakitan baru.
+          create: Create
+          title: New assembly user.
         update:
-          error: Terjadi kesalahan saat memperbarui pengguna untuk perakitan ini.
-          success: Pengguna berhasil diperbarui untuk perakitan ini.
+          error: There was an error updated a user for this assembly.
+          success: User updated successfully for this assembly.
       menu:
         assemblies: Assemblies
         assemblies_submenu:
-          assembly_admins: Pengguna majelis
-          assembly_members: Anggota
-          attachment_collections: Folder
-          attachment_files: File
-          attachments: Lampiran
-          categories: Kategori
-          components: Komponen
+          assembly_admins: Assembly users
+          assembly_members: Members
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
           info: Info
-          moderations: Moderasi
-          private_users: Pengguna pribadi
+          moderations: Moderations
+          private_users: Private users
       models:
         assembly:
           fields:
-            created_at: Dibuat di
-            private: Pribadi
-            promoted: Disorot
-            published: Diterbitkan
-            title: Judul
-          name: Majelis
+            created_at: Created at
+            private: Private
+            promoted: Highlighted
+            published: Published
+            title: Title
+          name: Assembly
         assembly_member:
           fields:
-            ceased_date: Tanggal berhenti
-            designation_date: Tanggal penunjukan
-            full_name: Nama
-            position: Posisi
-          name: Anggota
+            ceased_date: Ceased date
+            designation_date: Designation date
+            full_name: Name
+            position: Position
+          name: Member
           positions:
-            other: Lain
-            president: Presiden
-            secretary: Sekretaris
-            vice_president: Wakil Presiden
+            other: Other
+            president: President
+            secretary: Secretary
+            vice_president: Vice president
         assembly_user_role:
           fields:
-            email: E-mail
-            name: Nama
-            role: Peran
-          name: Pengguna Majelis
+            email: Email
+            name: Name
+            role: Role
+          name: Assembly User
           roles:
             admin: Administrator
-            collaborator: Kolaborator
+            collaborator: Collaborator
             moderator: Moderator
       titles:
         assemblies: Assemblies
     admin_log:
       assembly:
-        create: "%{user_name} menciptakan perakitan %{resource_name}"
-        publish: "%{user_name} mempublikasikan %{resource_name} perakitan"
-        unpublish: "%{user_name} tidak mempublikasikan %{resource_name} perakitan"
-        update: "%{user_name} memperbarui perakitan %{resource_name}"
+        create: "%{user_name} created the %{resource_name} assembly"
+        publish: "%{user_name} published the %{resource_name} assembly"
+        unpublish: "%{user_name} unpublished the %{resource_name} assembly"
+        update: "%{user_name} updated the %{resource_name} assembly"
       assembly_member:
-        create: "%{user_name} membuat %{resource_name} anggota dalam %{space_name} perakitan"
-        delete: "%{user_name} mengeluarkan %{resource_name} anggota dari %{space_name} rakitan"
-        update: "%{user_name} memperbarui %{resource_name} anggota dalam %{space_name} perakitan"
+        create: "%{user_name} created the %{resource_name} member in the %{space_name} assembly"
+        delete: "%{user_name} removed the %{resource_name} member from the %{space_name} assembly"
+        update: "%{user_name} updated the %{resource_name} member in the %{space_name} assembly"
       assembly_user_role:
-        create: "%{user_name} diundang %{resource_name} ke majelis %{space_name}"
-        delete: "%{user_name} mengeluarkan pengguna %{resource_name} dari %{space_name} rakitan"
-        update: "%{user_name} mengubah peran %{resource_name} dalam %{space_name} perakitan"
+        create: "%{user_name} invited %{resource_name} to the %{space_name} assembly"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} assembly"
+        update: "%{user_name} changed the role of %{resource_name} in the %{space_name} assembly"
     assemblies:
       admin:
         assemblies:
           form:
-            duration_help: Jika durasi rakitan ini terbatas, pilih tanggal akhir. Jika tidak, itu akan muncul sebagai tidak terbatas.
-            included_at_help: Pilih tanggal saat perakitan ini ditambahkan ke Decidim. Tidak harus sama dengan tanggal pembuatan.
-            select_a_created_by: Pilih yang dibuat oleh
-            select_an_area: Pilih Area
-            select_an_assembly_type: Pilih jenis perakitan
-            select_parent_assembly: Pilih perakitan induk
-            slug_help: 'Slug URL digunakan untuk menghasilkan URL yang mengarah ke rakitan ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
-            social_handlers: Sosial
+            duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
+            included_at_help: Select the date when this assembly was added to Decidim. It does not necessarily have to be the same as the creation date.
+            select_a_created_by: Select a created by
+            select_an_area: Select an Area
+            select_an_assembly_type: Select an assembly type
+            select_parent_assembly: Select parent assembly
+            slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+            social_handlers: Social
         assembly_copies:
           form:
-            slug_help: 'Slug URL digunakan untuk menghasilkan URL yang mengarah ke rakitan ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         assembly_members:
           form:
-            existing_user: Pengguna yang sudah ada
-            non_user: Non-pengguna
-            select_a_position: Pilih posisi
-            select_user: Pilih seorang pengguna
-            user_type: Tipe Pengguna
+            existing_user: Existing user
+            non_user: Non user
+            select_a_position: Select a position
+            select_user: Select an user
+            user_type: User type
           index:
             filter:
-              all: Semua
-              ceased: Hentikan
-              not_ceased: Tidak berhenti
-            filter_by: Filter berdasarkan
-            search: Pencarian
+              all: All
+              ceased: Ceased
+              not_ceased: Not ceased
+            filter_by: Filter by
+            search: Search
         content_blocks:
           highlighted_assemblies:
-            max_results: Jumlah maksimum elemen untuk ditampilkan
+            max_results: Maximum amount of elements to show
       assembly_members:
         index:
-          members: Anggota
+          members: Members
       assembly_types:
-        commission: Komisi
-        consultative_advisory: Konsultatif / Penasihat
-        executive: Eksekutif
-        government: Pemerintah
-        others: Lainnya
-        participatory: Partisipatif
-        working_group: Kelompok kerja
+        commission: Comission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        others: Others
+        participatory: Participatory
+        working_group: Working group
       content_blocks:
         highlighted_assemblies:
-          name: Majelis yang disorot
+          name: Highlighted assemblies
       created_by:
-        city_council: Dewan Kota
-        others: Lainnya
-        public: Publik
+        city_council: City Council
+        others: Others
+        public: Public
       filter:
-        all: Semua
-        commission: Komisi
-        consultative_advisory: Konsultatif / Penasihat
-        executive: Eksekutif
-        government: Pemerintah
-        help: 'Menunjukkan:'
-        label: 'Menunjukkan:'
-        others: Lainnya
-        participatory: Partisipatif
-        placeholder: Filter berdasarkan jenis
-        working_group: Kelompok kerja
+        all: All
+        commission: Commission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        help: 'Show:'
+        label: 'Show:'
+        others: Others
+        participatory: Participatory
+        placeholder: Filter by type
+        working_group: Working group
       index:
         title: Assemblies
       last_activity:
-        new_assembly: Perakitan baru
+        new_assembly: New assembly
       pages:
         home:
           highlighted_assemblies:
-            active_assemblies: Majelis aktif
-            see_all_assemblies: Lihat semua majelis
+            active_assemblies: Active assemblies
+            see_all_assemblies: See all assemblies
         user_profile:
           member_of:
-            member_of: Anggota dari
+            member_of: Member of
       show:
-        area: Daerah
-        assembly_type: Tipe perakitan
+        area: Area
+        assembly_type: Assembly type
         children: Assemblies
-        closing_date: Tanggal Penutupan
-        composition: Komposisi
-        created_by: Dibuat oleh
-        creation_date: Tanggal Diciptakan
-        developer_group: Grup promotor
-        duration: Lamanya
-        included_at: Termasuk di
-        indefinite_duration: Tak terbatas
-        internal_organisation: Organisasi internal
+        closing_date: Closing date
+        composition: Composition
+        created_by: Created by
+        creation_date: Date created
+        developer_group: Promoter group
+        duration: Duration
+        included_at: Included at
+        indefinite_duration: Indefinite
+        internal_organisation: Internal organisation
         is_transparent:
-          'false': buram
-          'true': transparan
-        local_area: Area organisasi
-        participatory_scope: Apa yang diputuskan
-        participatory_structure: Bagaimana cara memutuskannya
-        private_space: Ini adalah pertemuan pribadi
-        purpose_of_action: Tujuan tindakan
-        read_less: Baca lebih sedikit
-        read_more: Baca lebih lajut
-        related_participatory_processes: Proses partisipatif terkait
-        scope: Cakupan
-        social_networks: Jaringan sosial
-        target: Yang berpartisipasi
+          'false': opaque
+          'true': transparent
+        local_area: Organization area
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: This is a private assembly
+        purpose_of_action: Purpose of action
+        read_less: Read less
+        read_more: Read more
+        related_participatory_processes: Related participatory processes
+        scope: Scope
+        social_networks: Social Networks
+        target: Who participates
       statistics:
-        answers_count: Jawaban
+        answers_count: Answers
         assemblies_count: Assemblies
-        comments_count: Komentar
-        debates_count: Perdebatan
-        endorsements_count: Endorsemen
-        headline: Aktivitas
-        meetings_count: Rapat
-        orders_count: Suara
-        pages_count: Halaman
-        projects_count: Proyek
-        proposals_count: Proposal
-        results_count: Hasil
-        surveys_count: Survei
-        users_count: Peserta
-        votes_count: Suara
+        comments_count: Comments
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
     assembly_members:
       assembly_member:
-        designated_on: Ditunjuk pada
+        designated_on: Designated on
       index:
-        title: Anggota
+        title: Members
     help:
       participatory_spaces:
         assemblies:
-          contextual: "<p>Sebuah perakitan adalah sekelompok anggota organisasi yang bertemu secara berkala untuk membuat keputusan tentang area tertentu atau ruang lingkup organisasi.</p> <p>Majelis mengadakan pertemuan, beberapa bersifat pribadi dan beberapa terbuka. Jika mereka terbuka, adalah mungkin untuk berpartisipasi di dalamnya (misalnya: menghadiri jika kapasitas memungkinkan, menambahkan poin ke agenda, atau mengomentari proposal dan keputusan yang diambil oleh organ ini).</p> <p>Contoh: Sebuah majelis umum (yang bertemu setahun sekali untuk menentukan garis-garis tindakan utama organisasi serta badan eksekutifnya melalui pemungutan suara), dewan penasihat persamaan (yang bertemu setiap dua bulan untuk membuat proposal tentang cara meningkatkan hubungan gender dalam organisasi), komisi evaluasi (yang bertemu setiap bulan untuk memantau suatu proses) atau badan jaminan (yang mengumpulkan insiden, pelanggaran atau proposal untuk memperbaiki prosedur pengambilan keputusan) adalah semua contoh majelis.</p>\n"
-          page: "<p>Sebuah perakitan adalah sekelompok anggota organisasi yang bertemu secara berkala untuk membuat keputusan tentang area tertentu atau ruang lingkup organisasi.</p> <p>Majelis mengadakan pertemuan, beberapa bersifat pribadi dan beberapa terbuka. Jika mereka terbuka, adalah mungkin untuk berpartisipasi di dalamnya (misalnya: menghadiri jika kapasitas memungkinkan, menambahkan poin ke agenda, atau mengomentari proposal dan keputusan yang diambil oleh organ ini).</p> <p>Contoh: Sebuah majelis umum (yang bertemu setahun sekali untuk menentukan garis-garis tindakan utama organisasi serta badan eksekutifnya melalui pemungutan suara), dewan penasihat persamaan (yang bertemu setiap dua bulan untuk membuat proposal tentang cara meningkatkan hubungan gender dalam organisasi), komisi evaluasi (yang bertemu setiap bulan untuk memantau suatu proses) atau badan jaminan (yang mengumpulkan insiden, pelanggaran atau proposal untuk memperbaiki prosedur pengambilan keputusan) adalah semua contoh majelis.</p>\n"
-          title: Apa itu majelis?
+          contextual: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          page: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          title: What are assemblies?
     log:
       value_types:
         assembly_presenter:
-          not_found: 'Perakitan tidak ditemukan di database (ID: %{id})'
+          not_found: 'The assembly was not found on the database (ID: %{id})'
     menu:
       assemblies: Assemblies
     metrics:
       assemblies:
-        description: Jumlah rakitan dibuat
-        object: majelis
+        description: Number of assemblies created
+        object: assemblies
         title: Assemblies
   errors:
     messages:
-      cannot_be_blank: tidak bisa kosong
+      cannot_be_blank: can not be blank
   layouts:
     decidim:
       assemblies:
         assembly:
-          take_part: Ambil bagian
+          take_part: Take part
         index:
-          organizational_chart: Struktur organisasi
-          promoted_assemblies: Majelis yang disorot
-          reset_chart: Setel ulang
+          organizational_chart: Organizational chart
+          promoted_assemblies: Highlighted assemblies
+          reset_chart: Reset
         order_by_assemblies:
           assemblies:
-            other: "%{count} rakitan"
+            one: "%{count} assemblies"
+            other: "%{count} assemblies"
         promoted_assembly:
-          more_info: Info lebih lanjut
-          take_part: Ambil bagian
+          more_info: More info
+          take_part: Take part
       assembly_navigation:
-        assembly_member_menu_item: Anggota
-        assembly_menu_item: Perakitan
+        assembly_member_menu_item: Members
+        assembly_menu_item: The assembly
       assembly_widgets:
         show:
-          take_part: Ambil bagian
+          take_part: Take part

--- a/decidim-assemblies/config/locales/it.yml
+++ b/decidim-assemblies/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/nl.yml
+++ b/decidim-assemblies/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/pl.yml
+++ b/decidim-assemblies/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -66,19 +67,19 @@ pl:
   activerecord:
     models:
       decidim/assembly:
-        one: montaż
         few: Złożenia
         many: Złożenia
+        one: montaż
         other: Złożenia
       decidim/assembly_member:
-        one: Członek zespołu
         few: Członkowie zgromadzenia
         many: Członkowie zgromadzenia
+        one: Członek zespołu
         other: Członkowie zgromadzenia
       decidim/assembly_user_role:
-        one: Zbierz rolę użytkownika
         few: Zbierz role użytkowników
         many: Zbierz role użytkowników
+        one: Zbierz rolę użytkownika
         other: Zbierz role użytkowników
   decidim:
     admin:
@@ -366,9 +367,9 @@ pl:
           reset_chart: Nastawić
         order_by_assemblies:
           assemblies:
-            one: "%{count} montaż"
             few: "%{count} złożeń"
             many: "%{count} złożeń"
+            one: "%{count} montaż"
             other: "%{count} złożeń"
         promoted_assembly:
           more_info: Więcej informacji

--- a/decidim-assemblies/config/locales/pt-BR.yml
+++ b/decidim-assemblies/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -360,8 +361,8 @@ pt-BR:
           reset_chart: Restabelecer
         order_by_assemblies:
           assemblies:
-            one: "Assembly %{count}"
-            other: "Conjuntos %{count}"
+            one: Assembly %{count}
+            other: Conjuntos %{count}
         promoted_assembly:
           more_info: Mais informações
           take_part: Participar

--- a/decidim-assemblies/config/locales/pt.yml
+++ b/decidim-assemblies/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -360,8 +361,8 @@ pt:
           reset_chart: Restabelecer
         order_by_assemblies:
           assemblies:
-            one: "Assembly %{count}"
-            other: "Conjuntos %{count}"
+            one: Assembly %{count}
+            other: Conjuntos %{count}
         promoted_assembly:
           more_info: Mais informações
           take_part: Participar

--- a/decidim-assemblies/config/locales/ru.yml
+++ b/decidim-assemblies/config/locales/ru.yml
@@ -1,3 +1,4 @@
+---
 ru:
   activemodel:
     attributes:
@@ -31,6 +32,7 @@ ru:
         is_transparent: Прозрачное
         local_area: Участок организации
         meta_scope: Метаданные охвата
+        parent_id: Parent assembly
         participatory_processes_ids: Сопутствующие движения соучастия
         participatory_scope: Что решается
         participatory_structure: Как это решается
@@ -65,19 +67,19 @@ ru:
   activerecord:
     models:
       decidim/assembly:
-        one: Собрание
         few: Собрания
         many: Собраний
+        one: Собрание
         other: Собраний
       decidim/assembly_member:
-        one: Член президиума собрания
         few: Члена президиума собрания
         many: Членов президиума собрания
+        one: Член президиума собрания
         other: Членов президиума собрания
       decidim/assembly_user_role:
-        one: Роль участника собрания
         few: Роли участников собрания
         many: Ролей участников собрания
+        one: Роль участника собрания
         other: Ролей участников собрания
   decidim:
     admin:
@@ -221,6 +223,7 @@ ru:
             select_a_created_by: Укажите, кем создано
             select_an_area: Выберите участок
             select_an_assembly_type: Выберите вид собрания
+            select_parent_assembly: Select parent assembly
             slug_help: 'Сокращенные веб-адреса используются для создания ссылок на это собрание. В них допустимы только буквы, цифры и тире, и они должны начинаться с буквы. Пример: %{url}'
             social_handlers: Социальные сети
         assembly_copies:
@@ -240,6 +243,9 @@ ru:
               not_ceased: Срок полномочий не истек
             filter_by: 'Отобрать по признаку:'
             search: Поиск
+        content_blocks:
+          highlighted_assemblies:
+            max_results: Maximum amount of elements to show
       assembly_members:
         index:
           members: Члены президиума
@@ -260,8 +266,20 @@ ru:
         public: Граждане
       filter:
         all: Все
+        commission: Commission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        help: 'Show:'
+        label: 'Show:'
+        others: Others
+        participatory: Participatory
+        placeholder: Filter by type
+        working_group: Working group
       index:
         title: Собрания
+      last_activity:
+        new_assembly: New assembly
       pages:
         home:
           highlighted_assemblies:
@@ -318,12 +336,23 @@ ru:
         designated_on: 'Полномочия предоставлены:'
       index:
         title: Члены президиума
+    help:
+      participatory_spaces:
+        assemblies:
+          contextual: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          page: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          title: What are assemblies?
     log:
       value_types:
         assembly_presenter:
           not_found: 'Собрание не найдено в базе данных (ID: %{id})'
     menu:
       assemblies: Собрания
+    metrics:
+      assemblies:
+        description: Number of assemblies created
+        object: assemblies
+        title: Assemblies
   errors:
     messages:
       cannot_be_blank: не может быть пустым
@@ -333,17 +362,20 @@ ru:
         assembly:
           take_part: Принять участие
         index:
+          organizational_chart: Organizational chart
           promoted_assemblies: Рекомендуемые собрания
+          reset_chart: Reset
         order_by_assemblies:
           assemblies:
-            one: "%{count} собрание"
             few: "%{count} собрания"
             many: "%{count} собраний"
+            one: "%{count} собрание"
             other: "%{count} собраний"
         promoted_assembly:
           more_info: Дополнительные сведения
           take_part: Принять участие
       assembly_navigation:
+        assembly_member_menu_item: Members
         assembly_menu_item: Собрание
       assembly_widgets:
         show:

--- a/decidim-assemblies/config/locales/sv.yml
+++ b/decidim-assemblies/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:

--- a/decidim-assemblies/config/locales/tr-TR.yml
+++ b/decidim-assemblies/config/locales/tr-TR.yml
@@ -1,373 +1,374 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       assembly:
-        area_id: alan
-        assembly_type: Montaj tipi
-        assembly_type_other: Diğer montaj türü
-        banner_image: Banner resmi
-        closing_date: Kapanış tarihi
-        closing_date_reason: Kapanış tarihi nedeni
-        composition: bileştirme, kompozisyon
-        copy_categories: Kategorileri kopyala
-        copy_components: Bileşenleri kopyala
-        copy_features: Özellikleri kopyala
-        created_by: Tarafından yaratıldı
-        created_by_other: Diğer tarafından oluşturuldu
-        creation_date: Tarih oluşturuldu
-        decidim_area_id: alan
-        decidim_scope_id: kapsam
-        description: Açıklama
-        developer_group: Tanıtım grubu
-        domain: domain
-        duration: süre
+        area_id: Area
+        assembly_type: Assembly type
+        assembly_type_other: Assembly type other
+        banner_image: Banner image
+        closing_date: Closing date
+        closing_date_reason: Closing date reason
+        composition: Composition
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_features: Copy features
+        created_by: Created by
+        created_by_other: Created by other
+        creation_date: Date created
+        decidim_area_id: Area
+        decidim_scope_id: Scope
+        description: Description
+        developer_group: Promoter group
+        domain: Domain
+        duration: Duration
         facebook: Facebook
         github: GitHub
-        hashtag: Başlık etiketi
-        hero_image: Ana resim
-        included_at: Dahil
+        hashtag: Hashtag
+        hero_image: Home image
+        included_at: Included at
         instagram: Instagram
-        internal_organisation: İç organizasyon
-        is_transparent: Şeffaf mı
-        local_area: Organizasyon alanı
-        meta_scope: Kapsam meta verileri
-        parent_id: Ana montaj
-        participatory_processes_ids: İlgili Katılımcı süreçler
-        participatory_scope: Karar nedir
-        participatory_structure: Nasıl karar verilir
-        private_space: Özel alan
-        promoted: Tanıtılan
-        published_at: Yayınlandı
-        purpose_of_action: Eylem amacı
-        scope_id: kapsam
-        scopes_enabled: Kapsamlar etkin
-        short_description: Kısa Açıklama
-        show_statistics: İstatistikleri göster
-        slug: URL sümüklü böcek
-        special_features: Özel özellikler
-        subtitle: Alt yazı
-        target: Kimler katılır
-        title: Başlık
-        twitter: heyecan
-        youtube: Youtube
+        internal_organisation: Internal organisation
+        is_transparent: Is transparent
+        local_area: Organization area
+        meta_scope: Scope metadata
+        parent_id: Parent assembly
+        participatory_processes_ids: Related Participatory processes
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: Private space
+        promoted: Promoted
+        published_at: Published at
+        purpose_of_action: Purpose of action
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
+        slug: URL slug
+        special_features: Special features
+        subtitle: Subtitle
+        target: Who participates
+        title: Title
+        twitter: Twitter
+        youtube: YouTube
       assembly_member:
-        birthday: Doğum günü
-        birthplace: doğum yeri
-        ceased_date: Bitiş tarihi
-        designation_date: Atama tarihi
-        designation_mode: Tanımlama modu
-        full_name: Ad Soyad
-        gender: Cinsiyet
-        position: pozisyon
+        birthday: Birthday
+        birthplace: Birthplace
+        ceased_date: Ceased date
+        designation_date: Designation date
+        designation_mode: Designation mode
+        full_name: Full name
+        gender: Gender
+        position: Position
       assembly_user_role:
-        email: E-posta
-        name: isim
-        role: rol
+        email: Email
+        name: Name
+        role: Role
   activerecord:
     models:
       decidim/assembly:
-        one: montaj
-        other: meclisleri
+        one: Assembly
+        other: Assemblies
       decidim/assembly_member:
-        one: Montaj üyesi
-        other: Meclis üyeleri
+        one: Assembly member
+        other: Assembly members
       decidim/assembly_user_role:
-        one: Montaj kullanıcısı rolü
-        other: Montaj kullanıcı rolleri
+        one: Assembly user role
+        other: Assembly user roles
   decidim:
     admin:
       actions:
-        new_assembly: Yeni montaj
+        new_assembly: New assembly
       assemblies:
         create:
-          error: Yeni bir derleme oluştururken bir hata oluştu.
-          success: Montaj başarıyla oluşturuldu.
+          error: There was an error creating a new assembly.
+          success: Assembly created successfully.
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          title: Genel bilgi
+          title: General Information
         index:
-          not_published: Yayınlanmadı
-          private: Özel
-          public: halka açık
-          published: Yayınlanan
+          not_published: Not published
+          private: Private
+          public: Public
+          published: Published
         new:
-          create: yaratmak
-          title: Yeni montaj
+          create: Create
+          title: New assembly
         update:
-          error: Bu derleme güncellenirken bir hata oluştu.
-          success: Montaj başarıyla güncellendi.
+          error: There was an error when updating this assembly.
+          success: Assembly updated successfully.
       assemblies_copies:
         create:
-          error: Bu derlemeyi çoğaltırken bir hata oluştu.
-          success: Montaj başarıyla kopyalandı.
+          error: There was an error when duplicating this assembly.
+          success: Assembly duplicated successfully.
       assembly_copies:
         new:
-          copy: kopya
-          select: Çoğaltmak istediğiniz verileri seçin
+          copy: Copy
+          select: Select which data you would like to duplicate
           title: Duplicate assembly
       assembly_members:
         create:
-          error: Bu derleme için üye eklenirken bir hata oluştu.
-          success: Üye bu derleme için başarıyla oluşturuldu.
+          error: There was an error adding a member for this assembly.
+          success: Member created successfully for this assembly.
         destroy:
-          success: Üye bu derlemede başarıyla silindi.
+          success: Member deleted successfully for this assembly.
         edit:
-          title: Montaj üyesini güncelle.
-          update: Güncelleştirme
+          title: Update assembly member.
+          update: Update
         index:
-          assembly_members_title: Meclis üyeleri
+          assembly_members_title: Assembly members
         new:
-          create: yaratmak
-          title: Yeni montaj üyesi.
+          create: Create
+          title: New assembly member.
         update:
-          error: Bu derleme için üye güncellenirken bir hata oluştu.
-          success: Üye bu derleme için başarıyla güncellendi.
+          error: There was an error updating the member for this assembly.
+          success: Member updated successfully for this assembly.
       assembly_publications:
         create:
-          error: Bu derleme yayınlanırken bir hata oluştu.
-          success: Montaj başarıyla yayınlandı.
+          error: There was an error publishing this assembly.
+          success: Assembly published successfully.
         destroy:
-          error: Bu derlemenin yayından kaldırılmasıyla ilgili bir hata oluştu.
-          success: Montaj başarıyla yayından kaldırıldı.
+          error: There was an error unpublishing this assembly.
+          success: Assembly unpublished successfully.
       assembly_user_roles:
         create:
-          error: Bu derleme için bir kullanıcı eklenirken bir hata oluştu.
-          success: Kullanıcı bu meclise başarıyla eklendi.
+          error: There was an error adding a user for this assembly.
+          success: User added successfully to this assembly.
         destroy:
-          success: Kullanıcı bu derlemeden başarıyla kaldırıldı.
+          success: User removed successfully from this assembly.
         edit:
-          title: Montaj kullanıcısını güncelle.
-          update: Güncelleştirme
+          title: Update assembly user.
+          update: Update
         index:
-          assembly_admins_title: Montaj kullanıcıları
+          assembly_admins_title: Assembly users
         new:
-          create: yaratmak
-          title: Yeni montaj kullanıcısı.
+          create: Create
+          title: New assembly user.
         update:
-          error: Bu derleme için bir kullanıcı güncellendi bir hata oluştu.
-          success: Kullanıcı bu derleme için başarıyla güncellendi.
+          error: There was an error updated a user for this assembly.
+          success: User updated successfully for this assembly.
       menu:
-        assemblies: meclisleri
+        assemblies: Assemblies
         assemblies_submenu:
-          assembly_admins: Montaj kullanıcıları
-          assembly_members: Üyeler
-          attachment_collections: Klasörler
-          attachment_files: Dosyalar
-          attachments: Ekler
-          categories: Kategoriler
-          components: Bileşenler
-          info: Bilgi
-          moderations: Denetimler
-          private_users: Özel kullanıcılar
+          assembly_admins: Assembly users
+          assembly_members: Members
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
+          info: Info
+          moderations: Moderations
+          private_users: Private users
       models:
         assembly:
           fields:
-            created_at: Düzenlendi
-            private: Özel
-            promoted: Vurgulanan
-            published: Yayınlanan
-            title: Başlık
-          name: montaj
+            created_at: Created at
+            private: Private
+            promoted: Highlighted
+            published: Published
+            title: Title
+          name: Assembly
         assembly_member:
           fields:
-            ceased_date: Bitiş tarihi
-            designation_date: Atama tarihi
-            full_name: isim
-            position: pozisyon
-          name: üye
+            ceased_date: Ceased date
+            designation_date: Designation date
+            full_name: Name
+            position: Position
+          name: Member
           positions:
-            other: Diğer
-            president: Devlet Başkanı
-            secretary: Sekreter
-            vice_president: Başkan Vekili
+            other: Other
+            president: President
+            secretary: Secretary
+            vice_president: Vice president
         assembly_user_role:
           fields:
-            email: E-posta
-            name: isim
-            role: rol
-          name: Montaj Kullanıcı
+            email: Email
+            name: Name
+            role: Role
+          name: Assembly User
           roles:
-            admin: yönetici
-            collaborator: işbirlikçi
-            moderator: arabulucu
+            admin: Administrator
+            collaborator: Collaborator
+            moderator: Moderator
       titles:
-        assemblies: meclisleri
+        assemblies: Assemblies
     admin_log:
       assembly:
-        create: "%{user_name} %{resource_name} meclisi oluşturdu"
-        publish: "%{user_name} %{resource_name} meclisi yayınladı"
-        unpublish: "%{user_name} %{resource_name} montajı yayından kaldırıldı"
-        update: "%{user_name} güncellenmiş %{resource_name} meclis"
+        create: "%{user_name} created the %{resource_name} assembly"
+        publish: "%{user_name} published the %{resource_name} assembly"
+        unpublish: "%{user_name} unpublished the %{resource_name} assembly"
+        update: "%{user_name} updated the %{resource_name} assembly"
       assembly_member:
-        create: "%{user_name} , %{space_name} mecliste %{resource_name} üye yarattı"
-        delete: "%{user_name} uzaklaştırıldı %{resource_name} den elemanı %{space_name} montaj"
-        update: "%{user_name} , %{space_name} mecliste %{resource_name} üye güncellendi"
+        create: "%{user_name} created the %{resource_name} member in the %{space_name} assembly"
+        delete: "%{user_name} removed the %{resource_name} member from the %{space_name} assembly"
+        update: "%{user_name} updated the %{resource_name} member in the %{space_name} assembly"
       assembly_user_role:
-        create: "%{user_name} %{space_name} mecraya %{resource_name} davet edildi"
-        delete: "%{user_name} kullanıcı %{resource_name} %{space_name} aksamından çıkardı"
-        update: "%{user_name} , %{space_name} mecliste %{resource_name} rolünü değiştirdi"
+        create: "%{user_name} invited %{resource_name} to the %{space_name} assembly"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} assembly"
+        update: "%{user_name} changed the role of %{resource_name} in the %{space_name} assembly"
     assemblies:
       admin:
         assemblies:
           form:
-            duration_help: Bu meclisin süresi sınırlı ise, bitiş tarihini seçin. Aksi halde, belirsiz olarak görünecektir.
-            included_at_help: Bu montajın Decidim'e eklendiği tarihi seçin. Yaratılış tarihi ile aynı olmak zorunda değildir.
-            select_a_created_by: Tarafından oluşturulmuş bir seç
-            select_an_area: Bir alan seçin
-            select_an_assembly_type: Bir montaj tipi seçin
-            select_parent_assembly: Ebeveyn grubunu seç
-            slug_help: 'URL sümükleri, bu derleme işaret eden URL''leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
-            social_handlers: Sosyal
+            duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
+            included_at_help: Select the date when this assembly was added to Decidim. It does not necessarily have to be the same as the creation date.
+            select_a_created_by: Select a created by
+            select_an_area: Select an Area
+            select_an_assembly_type: Select an assembly type
+            select_parent_assembly: Select parent assembly
+            slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+            social_handlers: Social
         assembly_copies:
           form:
-            slug_help: 'URL sümükleri, bu derleme işaret eden URL''leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         assembly_members:
           form:
-            existing_user: Mevcut kullanıcı
-            non_user: Kullanıcı yok
-            select_a_position: Bir pozisyon seç
-            select_user: Bir kullanıcı seç
-            user_type: Kullanıcı tipi
+            existing_user: Existing user
+            non_user: Non user
+            select_a_position: Select a position
+            select_user: Select an user
+            user_type: User type
           index:
             filter:
-              all: Herşey
-              ceased: durdurdu
-              not_ceased: Durdurulmadı
-            filter_by: Tarafından filtre
-            search: Arama
+              all: All
+              ceased: Ceased
+              not_ceased: Not ceased
+            filter_by: Filter by
+            search: Search
         content_blocks:
           highlighted_assemblies:
-            max_results: Gösterilecek maksimum öğe miktarı
+            max_results: Maximum amount of elements to show
       assembly_members:
         index:
-          members: Üyeler
+          members: Members
       assembly_types:
-        commission: Komisyonu
-        consultative_advisory: Danışma / Danışma
-        executive: yönetici
-        government: hükümet
-        others: Diğerleri
-        participatory: katılımcı
-        working_group: Çalışma Grubu
+        commission: Comission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        others: Others
+        participatory: Participatory
+        working_group: Working group
       content_blocks:
         highlighted_assemblies:
-          name: Vurgulanan derlemeler
+          name: Highlighted assemblies
       created_by:
-        city_council: Belediye Meclisi
-        others: Diğerleri
-        public: halka açık
+        city_council: City Council
+        others: Others
+        public: Public
       filter:
-        all: Herşey
-        commission: komisyon
-        consultative_advisory: Danışma / Danışma
-        executive: yönetici
-        government: hükümet
-        help: 'Göstermek:'
-        label: 'Göstermek:'
-        others: Diğerleri
-        participatory: katılımcı
-        placeholder: Türüne göre filtrele
-        working_group: Çalışma Grubu
+        all: All
+        commission: Commission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        help: 'Show:'
+        label: 'Show:'
+        others: Others
+        participatory: Participatory
+        placeholder: Filter by type
+        working_group: Working group
       index:
-        title: meclisleri
+        title: Assemblies
       last_activity:
-        new_assembly: Yeni montaj
+        new_assembly: New assembly
       pages:
         home:
           highlighted_assemblies:
-            active_assemblies: Aktif meclisler
-            see_all_assemblies: Tüm montajları gör
+            active_assemblies: Active assemblies
+            see_all_assemblies: See all assemblies
         user_profile:
           member_of:
-            member_of: Üyesi
+            member_of: Member of
       show:
-        area: alan
-        assembly_type: Montaj tipi
-        children: meclisleri
-        closing_date: Kapanış tarihi
-        composition: bileştirme, kompozisyon
-        created_by: Tarafından yaratıldı
-        creation_date: Tarih oluşturuldu
-        developer_group: Tanıtım grubu
-        duration: süre
-        included_at: Dahil
-        indefinite_duration: Belirsiz
-        internal_organisation: İç organizasyon
+        area: Area
+        assembly_type: Assembly type
+        children: Assemblies
+        closing_date: Closing date
+        composition: Composition
+        created_by: Created by
+        creation_date: Date created
+        developer_group: Promoter group
+        duration: Duration
+        included_at: Included at
+        indefinite_duration: Indefinite
+        internal_organisation: Internal organisation
         is_transparent:
-          'false': opak
-          'true': şeffaf
-        local_area: Organizasyon alanı
-        participatory_scope: Karar nedir
-        participatory_structure: Nasıl karar verilir
-        private_space: Bu özel bir meclis
-        purpose_of_action: Eylem amacı
-        read_less: Az oku
-        read_more: Daha fazla oku
-        related_participatory_processes: İlgili katılımcı süreçler
-        scope: kapsam
-        social_networks: Sosyal ağlar
-        target: Kimler katılır
+          'false': opaque
+          'true': transparent
+        local_area: Organization area
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: This is a private assembly
+        purpose_of_action: Purpose of action
+        read_less: Read less
+        read_more: Read more
+        related_participatory_processes: Related participatory processes
+        scope: Scope
+        social_networks: Social Networks
+        target: Who participates
       statistics:
-        answers_count: Cevaplar
-        assemblies_count: meclisleri
-        comments_count: Yorumlar
-        debates_count: Tartışmalar
-        endorsements_count: Cirolar
-        headline: Aktivite
-        meetings_count: Toplantılar
-        orders_count: oy
-        pages_count: Sayfalar
-        projects_count: Projeler
-        proposals_count: Teklif
-        results_count: Sonuçlar
-        surveys_count: Anketler
-        users_count: Katılımcılar
-        votes_count: oy
+        answers_count: Answers
+        assemblies_count: Assemblies
+        comments_count: Comments
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
     assembly_members:
       assembly_member:
-        designated_on: Üzerinde belirlenen
+        designated_on: Designated on
       index:
-        title: Üyeler
+        title: Members
     help:
       participatory_spaces:
         assemblies:
-          contextual: "<p>bir düzenek organizasyonun belirli bir alan veya kapsamı hakkında kararlar almak için periyodik olarak bir araya bir örgütün üyelerinin bir gruptur.</p> <p>Toplantılar toplantı yapar, bazıları özeldir ve bazıları açıktır. Açık olmaları halinde, onlara katılmak mümkündür (örneğin: kapasitenin buna izin verip vermediğine katılmak, gündeme puan eklemek veya bu organ tarafından alınan teklif ve kararlara yorum yapmak).</p> <p>Örnekler: Genel bir kurul (kuruluşun ana faaliyet alanlarını ve yürütme organlarını oy kullanarak tanımlamak için yılda bir kez toplanır), bir eşitlik danışma konseyi (her iki ayda bir, toplumsal cinsiyet ilişkilerinin nasıl geliştirileceğine dair önerilerde bulunur) kuruluşta) bir değerlendirme komisyonu (bir süreci izlemek için her ay toplanır) veya bir garanti organı (karar alma prosedürlerini iyileştirmek için olayları, kötüye kullanımları veya teklifleri toplar) meclislere örnektir.</p>\n"
-          page: "<p>bir düzenek organizasyonun belirli bir alan veya kapsamı hakkında kararlar almak için periyodik olarak bir araya bir örgütün üyelerinin bir gruptur.</p> <p>Toplantılar toplantı yapar, bazıları özeldir ve bazıları açıktır. Açık olmaları halinde, onlara katılmak mümkündür (örneğin: kapasitenin buna izin verip vermediğine katılmak, gündeme puan eklemek veya bu organ tarafından alınan teklif ve kararlara yorum yapmak).</p> <p>Örnekler: Genel bir kurul (kuruluşun ana faaliyet alanlarını ve yürütme organlarını oy kullanarak tanımlamak için yılda bir kez toplanır), bir eşitlik danışma konseyi (her iki ayda bir, toplumsal cinsiyet ilişkilerinin nasıl geliştirileceğine dair önerilerde bulunur) kuruluşta) bir değerlendirme komisyonu (bir süreci izlemek için her ay toplanır) veya bir garanti organı (karar alma prosedürlerini iyileştirmek için olayları, kötüye kullanımları veya teklifleri toplar) meclislere örnektir.</p>\n"
-          title: Meclis nedir?
+          contextual: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          page: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          title: What are assemblies?
     log:
       value_types:
         assembly_presenter:
-          not_found: 'Derleme veritabanında bulunamadı (ID: %{id})'
+          not_found: 'The assembly was not found on the database (ID: %{id})'
     menu:
-      assemblies: meclisleri
+      assemblies: Assemblies
     metrics:
       assemblies:
-        description: Oluşturulan derleme sayısı
-        object: düzenekleri
-        title: meclisleri
+        description: Number of assemblies created
+        object: assemblies
+        title: Assemblies
   errors:
     messages:
-      cannot_be_blank: boş bırakılamaz
+      cannot_be_blank: can not be blank
   layouts:
     decidim:
       assemblies:
         assembly:
-          take_part: Yer almak
+          take_part: Take part
         index:
-          organizational_chart: Organizasyon şeması
-          promoted_assemblies: Vurgulanan derlemeler
+          organizational_chart: Organizational chart
+          promoted_assemblies: Highlighted assemblies
           reset_chart: Reset
         order_by_assemblies:
           assemblies:
-            one: "%{count} derleme"
-            other: "%{count} derleme"
+            one: "%{count} assemblies"
+            other: "%{count} assemblies"
         promoted_assembly:
-          more_info: Daha fazla bilgi
-          take_part: Yer almak
+          more_info: More info
+          take_part: Take part
       assembly_navigation:
-        assembly_member_menu_item: Üyeler
-        assembly_menu_item: Meclis
+        assembly_member_menu_item: Members
+        assembly_menu_item: The assembly
       assembly_widgets:
         show:
-          take_part: Yer almak
+          take_part: Take part

--- a/decidim-assemblies/config/locales/uk.yml
+++ b/decidim-assemblies/config/locales/uk.yml
@@ -1,3 +1,4 @@
+---
 uk:
   activemodel:
     attributes:
@@ -31,6 +32,7 @@ uk:
         is_transparent: Є прозорими
         local_area: Дільниця організації
         meta_scope: Метавідомості обсягу
+        parent_id: Parent assembly
         participatory_processes_ids: Пов'язані рухи співучасті
         participatory_scope: Що вирішується
         participatory_structure: Як це вирішується
@@ -65,19 +67,19 @@ uk:
   activerecord:
     models:
       decidim/assembly:
-        one: Збори
         few: Зібрань
         many: Зібрань
+        one: Збори
         other: Зібрань
       decidim/assembly_member:
-        one: Член президії зборів
         few: Члени президії зборів
         many: Членів президії зборів
+        one: Член президії зборів
         other: Членів президії зборів
       decidim/assembly_user_role:
-        one: Роль учасника зборів
         few: Ролей учасників зборів
         many: Ролей учасників зборів
+        one: Роль учасника зборів
         other: Ролей учасників зборів
   decidim:
     admin:
@@ -221,6 +223,7 @@ uk:
             select_a_created_by: Вкажіть, ким створені
             select_an_area: Оберіть дільницю
             select_an_assembly_type: Оберіть різновид зборів
+            select_parent_assembly: Select parent assembly
             slug_help: 'Cкорочені веб-адреси використовуються для створення посилань на ці збори. В них припустимі лише букви, цифри та тире, і вони мають починатися з букви. Приклад: %{url}'
             social_handlers: Соціальні мережі
         assembly_copies:
@@ -240,6 +243,9 @@ uk:
               not_ceased: Повноваження не припинені
             filter_by: 'Відібрати за ознакою:'
             search: Шукати
+        content_blocks:
+          highlighted_assemblies:
+            max_results: Maximum amount of elements to show
       assembly_members:
         index:
           members: Члени президії
@@ -260,8 +266,20 @@ uk:
         public: Громадяни
       filter:
         all: Усі
+        commission: Commission
+        consultative_advisory: Consultative/Advisory
+        executive: Executive
+        government: Government
+        help: 'Show:'
+        label: 'Show:'
+        others: Others
+        participatory: Participatory
+        placeholder: Filter by type
+        working_group: Working group
       index:
         title: Збори
+      last_activity:
+        new_assembly: New assembly
       pages:
         home:
           highlighted_assemblies:
@@ -318,12 +336,23 @@ uk:
         designated_on: 'Надано повноваження:'
       index:
         title: Члени президії
+    help:
+      participatory_spaces:
+        assemblies:
+          contextual: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          page: "<p>An assembly is a group of members of an organization who meet periodically to make decisions about a specific area or scope of the organization.</p> <p>Assemblies hold meetings, some are private and some are open. If they are open, it is possible to participate in them (for example: attending if the capacity allows it, adding points to the agenda, or commenting on the proposals and decisions taken by this organ).</p> <p>Examples: A general assembly (which meets once a year to define the organisation's main lines of action as well as its executive bodies by vote), an equality advisory council (which meets every two months to make proposals on how to improve gender relations in the organisation), an evaluation commission (which meets every month to monitor a process) or a guarantee body (which collects incidents, abuses or proposals to improve decision-making procedures) are all examples of assemblies.</p>\n"
+          title: What are assemblies?
     log:
       value_types:
         assembly_presenter:
           not_found: 'Ці збори не знайдено в базі даних (ID: %{id})'
     menu:
       assemblies: Збори
+    metrics:
+      assemblies:
+        description: Number of assemblies created
+        object: assemblies
+        title: Assemblies
   errors:
     messages:
       cannot_be_blank: не може бути порожнім
@@ -333,17 +362,20 @@ uk:
         assembly:
           take_part: Взяти участь
         index:
+          organizational_chart: Organizational chart
           promoted_assemblies: Висвітлені збори
+          reset_chart: Reset
         order_by_assemblies:
           assemblies:
-            one: "%{count} (одні) збори"
             few: "%{count} зборів"
             many: "%{count} зборів"
+            one: "%{count} (одні) збори"
             other: "%{count} зборів"
         promoted_assembly:
           more_info: Додаткові відомості
           take_part: Взяти участь
       assembly_navigation:
+        assembly_member_menu_item: Members
         assembly_menu_item: Збори
       assembly_widgets:
         show:

--- a/decidim-blogs/config/locales/fi-pl.yml
+++ b/decidim-blogs/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     models:

--- a/decidim-blogs/config/locales/id-ID.yml
+++ b/decidim-blogs/config/locales/id-ID.yml
@@ -1,74 +1,80 @@
-id:
+---
+id-ID:
   activemodel:
     models:
-      decidim/blogs/create_post_event: Posting blog baru
+      decidim/blogs/create_post_event: New blog post
   activerecord:
     models:
       decidim/blogs/post:
-        other: Posting
+        one: Post
+        other: Posts
   decidim:
     blogs:
       actions:
-        confirm_destroy: Anda yakin ingin menghapus posting ini?
-        destroy: Menghapus
+        confirm_destroy: Are you sure you want to delete this post?
+        destroy: Delete
         edit: Edit
-        new: Berita Baru
-        title: Tindakan
+        new: New post
+        title: Actions
       admin:
         models:
           components:
-            body: Tubuh
+            body: Body
           post:
-            name: Pos
+            name: Post
         posts:
           create:
-            success: Pos berhasil dibuat
+            invalid: There's been a problem creating this post
+            success: Post successfully created
           destroy:
-            success: Posting berhasil dihapus
+            success: Post successfully deleted
           edit:
-            save: Memperbarui
+            save: Update
           index:
-            title: Posting
+            title: Posts
           new:
-            create: Membuat
-            title: Buat posting
+            create: Create
+            title: Create post
+          update:
+            invalid: There's been errors when saving the post.
+            success: Post saved successfully
       last_activity:
-        new_post_at_html: "<span>Posting baru di %{link}</span>"
+        new_post_at_html: "<span>New post at %{link}</span>"
       models:
         post:
           fields:
-            author: Penulis
-            body: Tubuh
-            created_at: Dibuat di
-            title: judul
+            author: Author
+            body: Body
+            created_at: Created at
+            title: title
       posts:
         show:
-          view: Melihat
+          view: View
         sidebar_blog:
-          comments: komentar
-          most_commented_posts: Posting yang paling banyak dikomentari
-      read_more: Baca lebih lajut
+          comments: comments
+          most_commented_posts: Most commented posts
+      read_more: Read more
     components:
       blogs:
         name: Blog
         settings:
           global:
-            announcement: Pengumuman
-            comments_enabled: Komentar diaktifkan
+            announcement: Announcement
+            comments_enabled: Comments enabled
           step:
-            announcement: Pengumuman
-            comments_blocked: Komentar diblokir
+            announcement: Announcement
+            comments_blocked: Comments blocked
     events:
       blogs:
         post_created:
-          email_intro: Posting "%{resource_title}" telah dipublikasikan di "%{participatory_space_title}" yang Anda ikuti.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{participatory_space_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Posting baru diterbitkan pada %{participatory_space_title}
-          notification_title: Posting <a href="%{resource_path}">%{resource_title}</a> telah diterbitkan dalam %{participatory_space_title}
+          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New post published in %{participatory_space_title}
+          notification_title: The post <a href="%{resource_path}">%{resource_title}</a> has been published in %{participatory_space_title}
     pages:
       home:
         statistics:
-          posts_count: Posting
+          posts_count: Posts
     participatory_processes:
       statistics:
-        posts_count: Posting
+        posts_count: Posts

--- a/decidim-blogs/config/locales/tr-TR.yml
+++ b/decidim-blogs/config/locales/tr-TR.yml
@@ -1,79 +1,80 @@
-tr:
+---
+tr-TR:
   activemodel:
     models:
-      decidim/blogs/create_post_event: Yeni blog yazısı
+      decidim/blogs/create_post_event: New blog post
   activerecord:
     models:
       decidim/blogs/post:
-        one: posta
-        other: Mesajlar
+        one: Post
+        other: Posts
   decidim:
     blogs:
       actions:
-        confirm_destroy: Bu yayını silmek istediğinize emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        new: Yeni posta
-        title: Eylemler
+        confirm_destroy: Are you sure you want to delete this post?
+        destroy: Delete
+        edit: Edit
+        new: New post
+        title: Actions
       admin:
         models:
           components:
-            body: Vücut
+            body: Body
           post:
-            name: posta
+            name: Post
         posts:
           create:
-            invalid: "Bu yayın oluştururken bir sorun oluştu\n \n"
-            success: Yayın başarıyla oluşturuldu
+            invalid: There's been a problem creating this post
+            success: Post successfully created
           destroy:
-            success: Yayın başarıyla silindi
+            success: Post successfully deleted
           edit:
-            save: Güncelleştirme
+            save: Update
           index:
-            title: Mesajlar
+            title: Posts
           new:
-            create: yaratmak
-            title: Gönderi oluştur
+            create: Create
+            title: Create post
           update:
-            invalid: Gönderi kaydedilirken hatalar oluştu.
-            success: Gönderi başarıyla kaydedildi
+            invalid: There's been errors when saving the post.
+            success: Post saved successfully
       last_activity:
-        new_post_at_html: "<span> %{link}</span>yeni gönderi"
+        new_post_at_html: "<span>New post at %{link}</span>"
       models:
         post:
           fields:
-            author: Yazar
-            body: Vücut
-            created_at: Adresinde düzenlendi
-            title: Başlık
+            author: Author
+            body: Body
+            created_at: Created at
+            title: title
       posts:
         show:
-          view: Görünüm
+          view: View
         sidebar_blog:
-          comments: yorumlar
-          most_commented_posts: En çok yorum yapılan yazılar
-      read_more: Daha fazla oku
+          comments: comments
+          most_commented_posts: Most commented posts
+      read_more: Read more
     components:
       blogs:
         name: Blog
         settings:
           global:
-            announcement: duyuru
-            comments_enabled: Yorumlar etkin
+            announcement: Announcement
+            comments_enabled: Comments enabled
           step:
-            announcement: duyuru
-            comments_blocked: Yorumlar engellendi
+            announcement: Announcement
+            comments_blocked: Comments blocked
     events:
       blogs:
         post_created:
-          email_intro: '"%{resource_title}" yazısı, takip ettiğiniz "%{participatory_space_title}" harfinde yayınlandı.'
-          email_outro: Bu bildirimi aldınız çünkü "%{participatory_space_title}" u takip ediyorsun. Bunu önceki linkten takip edebilirsiniz.
-          email_subject: '%{participatory_space_title}yayınlanan yeni gönderi'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> sonrası %{participatory_space_title}olarak yayınlandı.
+          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New post published in %{participatory_space_title}
+          notification_title: The post <a href="%{resource_path}">%{resource_title}</a> has been published in %{participatory_space_title}
     pages:
       home:
         statistics:
-          posts_count: Mesajlar
+          posts_count: Posts
     participatory_processes:
       statistics:
-        posts_count: Mesajlar
+        posts_count: Posts

--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -61,16 +61,13 @@ ca:
             success: S'ha importat amb èxit %{number} propostes en projectes
           new:
             create: Importa propostes a projectes
-            no_components: No hi ha cap component de propostes en aquest espai participatiu
-              per importar les propostes a projectes.
+            no_components: No hi ha cap component de propostes en aquest espai participatiu per importar les propostes a projectes.
             select_component: Selecciona un component
       admin_log:
         project:
           create: "%{user_name} ha creat el projecte %{resource_name} a l'espai %{space_name}"
-          delete: "%{user_name} ha eliminat el projecte %{resource_name} de l'espai
-            %{space_name}"
-          update: "%{user_name} ha actualitzat el projecte %{resource_name} de l'espai
-            %{space_name}"
+          delete: "%{user_name} ha eliminat el projecte %{resource_name} de l'espai %{space_name}"
+          update: "%{user_name} ha actualitzat el projecte %{resource_name} de l'espai %{space_name}"
       models:
         project:
           fields:
@@ -78,18 +75,14 @@ ca:
             title: Títol
       projects:
         budget_confirm:
-          are_you_sure: Hi estàs d'acord? Un cop hagis confirmat el teu vot, no podràs
-            canviar-lo.
+          are_you_sure: Hi estàs d'acord? Un cop hagis confirmat el teu vot, no podràs canviar-lo.
           cancel: Cancel·lar
           confirm: Confirmar
-          description: Aquests són els projectes que has seleccionat per formar part
-            del pressupost.
+          description: Aquests són els projectes que has seleccionat per formar part del pressupost.
           title: Confirmar vot
         budget_excess:
           close: Tancar
-          description: Aquest projecte sobrepassa el pressupost màxim i no es pot
-            afegir. Si ho desitges, pots eliminar un projecte ja seleccionat per afegir
-            aquest o donar suport amb les seves preferències.
+          description: Aquest projecte sobrepassa el pressupost màxim i no es pot afegir. Si ho desitges, pots eliminar un projecte ja seleccionat per afegir aquest o donar suport amb les seves preferències.
           ok: D'acord
           title: Pressupost superat
         budget_summary:
@@ -97,15 +90,11 @@ ca:
           assigned: 'Assignat:'
           cancel_order: eliminar el teu vot i començar de nou
           checked_out:
-            description: Ja has votat pel pressupost. Si has canviat d'idea, pots
-              %{cancel_link}.
+            description: Ja has votat pel pressupost. Si has canviat d'idea, pots %{cancel_link}.
             title: Vot pels pressupostos completat
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Tu decideixes el pressupost
         count:
           projects_count:
@@ -124,12 +113,8 @@ ca:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -176,8 +161,7 @@ ca:
             comments_enabled: Comentaris habilitats
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projectes per pàgina
-            resources_permissions_enabled: Es poden establir permisos d'accions per
-              a cada trobada
+            resources_permissions_enabled: Es poden establir permisos d'accions per a cada trobada
             total_budget: Pressupost total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -191,8 +175,7 @@ ca:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/de.yml
+++ b/decidim-budgets/config/locales/de.yml
@@ -61,17 +61,13 @@ de:
             success: "%{number} Vorschläge wurden erfolgreich in Projekte importiert"
           new:
             create: Importieren Sie Vorschläge in Projekte
-            no_components: Es gibt keine weiteren Vorschlagskomponenten in diesem
-              partizipativen Raum, um die Vorschläge in Projekte zu importieren.
+            no_components: Es gibt keine weiteren Vorschlagskomponenten in diesem partizipativen Raum, um die Vorschläge in Projekte zu importieren.
             select_component: Bitte wählen Sie eine Komponente aus
       admin_log:
         project:
-          create: "%{user_name} erstellt das %{resource_name} Projekt in dem %{space_name}
-            Raum"
-          delete: "%{user_name} löschte das %{resource_name} Projekt in den %{space_name}
-            Leerzeichen"
-          update: "%{user_name} aktualisiert das %{resource_name} Projekt in den %{space_name}
-            Räumen"
+          create: "%{user_name} erstellt das %{resource_name} Projekt in dem %{space_name} Raum"
+          delete: "%{user_name} löschte das %{resource_name} Projekt in den %{space_name} Leerzeichen"
+          update: "%{user_name} aktualisiert das %{resource_name} Projekt in den %{space_name} Räumen"
       models:
         project:
           fields:
@@ -79,18 +75,14 @@ de:
             title: Titel
       projects:
         budget_confirm:
-          are_you_sure: Sind Sie einverstanden? Sobald Sie Ihre Stimme bestätigt haben,
-            können Sie sie nicht ändern.
+          are_you_sure: Sind Sie einverstanden? Sobald Sie Ihre Stimme bestätigt haben, können Sie sie nicht ändern.
           cancel: Stornieren
           confirm: Bestätigen
-          description: Dies sind die Projekte, die Sie ausgewählt haben, um Teil des
-            Budgets zu sein.
+          description: Dies sind die Projekte, die Sie ausgewählt haben, um Teil des Budgets zu sein.
           title: Bestätigung der Abstimmung
         budget_excess:
           close: Schließen
-          description: Dieses Projekt überschreitet das maximale Budget und kann nicht
-            hinzugefügt werden. Wenn Sie möchten, können Sie ein Projekt löschen,
-            das Sie bereits ausgewählt haben, oder Sie wählen mit Ihren Einstellungen.
+          description: Dieses Projekt überschreitet das maximale Budget und kann nicht hinzugefügt werden. Wenn Sie möchten, können Sie ein Projekt löschen, das Sie bereits ausgewählt haben, oder Sie wählen mit Ihren Einstellungen.
           ok: OK
           title: Maximales Budget überschritten
         budget_summary:
@@ -98,15 +90,11 @@ de:
           assigned: 'Zugewiesen:'
           cancel_order: Löschen Sie Ihre Stimme und beginnen Sie von vorne
           checked_out:
-            description: Sie haben bereits für das Budget gestimmt. Wenn Sie Ihre
-              Meinung geändert haben, können Sie %{cancel_link}.
+            description: Sie haben bereits für das Budget gestimmt. Wenn Sie Ihre Meinung geändert haben, können Sie %{cancel_link}.
             title: Haushaltsabstimmung abgeschlossen
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Sie entscheiden über das Budget
         count:
           projects_count:
@@ -125,12 +113,8 @@ de:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -177,8 +161,7 @@ de:
             comments_enabled: Kommentare aktiviert
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projekte pro Seite
-            resources_permissions_enabled: Aktionsberechtigungen können für jedes
-              Meeting festgelegt werden
+            resources_permissions_enabled: Aktionsberechtigungen können für jedes Meeting festgelegt werden
             total_budget: Gesamtbudget; Gesamtetat
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -192,8 +175,7 @@ de:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -64,17 +64,13 @@ en:
             success: "%{number} proposals successfully imported into projects"
           new:
             create: Import proposals to projects
-            no_components: There are no other proposal components in this participatory
-              space to import the proposals into projects.
+            no_components: There are no other proposal components in this participatory space to import the proposals into projects.
             select_component: Please select a component
       admin_log:
         project:
-          create: "%{user_name} created the %{resource_name} project in the %{space_name}
-            space"
-          delete: "%{user_name} deleted the %{resource_name} project in the %{space_name}
-            space"
-          update: "%{user_name} updated the %{resource_name} project in the %{space_name}
-            space"
+          create: "%{user_name} created the %{resource_name} project in the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} project in the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} project in the %{space_name} space"
       models:
         project:
           fields:
@@ -82,18 +78,14 @@ en:
             title: Title
       projects:
         budget_confirm:
-          are_you_sure: Do you agree? Once you have confirmed your vote, you can not
-            change it.
+          are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.
           cancel: Cancel
           confirm: Confirm
           description: These are the projects you have chosen to be part of the budget.
           title: Confirm vote
         budget_excess:
           close: Закрити
-          description: Додавання цього проекту перевищить максимальний бюджет, і тому
-            його не можна зараз додати. За бажанням ви можете видалити якийсь з тих
-            проектів, що ви раніше вибрали для додавання, або проголосувати згідно
-            ваших уподобань.
+          description: Додавання цього проекту перевищить максимальний бюджет, і тому його не можна зараз додати. За бажанням ви можете видалити якийсь з тих проектів, що ви раніше вибрали для додавання, або проголосувати згідно ваших уподобань.
           ok: Гаразд
           title: Перевищено граничний бюджет
         budget_summary:
@@ -101,15 +93,11 @@ en:
           assigned: 'Assigned:'
           cancel_order: delete your vote and start over
           checked_out:
-            description: You've already voted for the budget. If you've changed your
-              mind, you can %{cancel_link}.
+            description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
             title: Budget vote completed
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: You decide the budget
         count:
           projects_count:
@@ -128,12 +116,8 @@ en:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -180,8 +164,7 @@ en:
             comments_enabled: Comments enabled
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projects per page
-            resources_permissions_enabled: Actions permissions can be set for each
-              meeting
+            resources_permissions_enabled: Actions permissions can be set for each meeting
             total_budget: Total budget
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -195,11 +178,10 @@ en:
     events:
       budgets:
         order_checkout:
-          email_intro: "Your vote has been validated. You can always edit it if you
-            like by clicking here: <a href='%{resource_url}'>%{participatory_space_title}"
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here: <a href=''%{resource_url}''>%{participatory_space_title}'
           email_outro: Thank you for your participation
-          email_subject: "Your vote has been validated on %{participatory_space_title}"
-          notification_title: "Your vote has been validated on <a href='%{resource_url}'>%{participatory_space_title}</a> You can always edit it if you like."
+          email_subject: Your vote has been validated on %{participatory_space_title}
+          notification_title: Your vote has been validated on <a href='%{resource_url}'>%{participatory_space_title}</a> You can always edit it if you like.
     orders:
       checkout:
         error: An error ocurred while processing your vote

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -95,7 +95,6 @@ en:
           checked_out:
             description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
             title: Budget vote completed
-          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
           description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
           description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: You decide the budget

--- a/decidim-budgets/config/locales/es-PY.yml
+++ b/decidim-budgets/config/locales/es-PY.yml
@@ -61,15 +61,13 @@ es-PY:
             success: "%{number} propuestas importadas con éxito en proyectos"
           new:
             create: Importar propuestas a proyectos
-            no_components: No hay otros componentes de la propuesta en este espacio
-              participativo para importar las propuestas en los proyectos.
+            no_components: No hay otros componentes de la propuesta en este espacio participativo para importar las propuestas en los proyectos.
             select_component: Por favor seleccione un componente
       admin_log:
         project:
           create: "%{user_name} creó el proyecto %{resource_name} en el espacio %{space_name}"
           delete: "%{user_name} borró el proyecto %{resource_name} en el espacio %{space_name}"
-          update: "%{user_name} actualizó el proyecto %{resource_name} en el espacio
-            %{space_name}"
+          update: "%{user_name} actualizó el proyecto %{resource_name} en el espacio %{space_name}"
       models:
         project:
           fields:
@@ -77,18 +75,14 @@ es-PY:
             title: Título
       projects:
         budget_confirm:
-          are_you_sure: "¿Estás de acuerdo? Una vez que hayas confirmado tu voto,
-            no puedes cambiarlo."
+          are_you_sure: "¿Estás de acuerdo? Una vez que hayas confirmado tu voto, no puedes cambiarlo."
           cancel: Cancelar
           confirm: Confirmar
-          description: Estos son los proyectos que has elegido para formar parte del
-            presupuesto.
+          description: Estos son los proyectos que has elegido para formar parte del presupuesto.
           title: Confirmar voto
         budget_excess:
           close: Cerrar
-          description: Este proyecto sobrepasa el presupuesto máximo y no se puede
-            añadir. Si lo deseas, puede eliminar un proyecto que ya hayas seleccionado
-            o dar apoyo con tus preferencias.
+          description: Este proyecto sobrepasa el presupuesto máximo y no se puede añadir. Si lo deseas, puede eliminar un proyecto que ya hayas seleccionado o dar apoyo con tus preferencias.
           ok: De acuerdo
           title: Presupuesto excedido
         budget_summary:
@@ -96,15 +90,11 @@ es-PY:
           assigned: 'Asignado:'
           cancel_order: eliminar tu voto y empezar de nuevo
           checked_out:
-            description: Ya has votado para el presupuesto. Si has cambiado de idea,
-              puedes %{cancel_link}.
+            description: Ya has votado para el presupuesto. Si has cambiado de idea, puedes %{cancel_link}.
             title: Voto enviado correctamente
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Tú decides el presupuesto
         count:
           projects_count:
@@ -123,12 +113,8 @@ es-PY:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -175,8 +161,7 @@ es-PY:
             comments_enabled: Comentarios habilitados
             geocoding_enabled: Geocoding enabled
             projects_per_page: Proyectos por página
-            resources_permissions_enabled: Los permisos sobre acciones pueden establecerse
-              para cada reunión
+            resources_permissions_enabled: Los permisos sobre acciones pueden establecerse para cada reunión
             total_budget: Presupuesto total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -190,8 +175,7 @@ es-PY:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -61,15 +61,13 @@ es:
             success: "%{number} propuestas importadas con éxito en proyectos"
           new:
             create: Importar propuestas a proyectos
-            no_components: No hay otros componentes de la propuesta en este espacio
-              participativo para importar las propuestas en los proyectos.
+            no_components: No hay otros componentes de la propuesta en este espacio participativo para importar las propuestas en los proyectos.
             select_component: Por favor seleccione un componente
       admin_log:
         project:
           create: "%{user_name} creó el proyecto %{resource_name} en el espacio %{space_name}"
           delete: "%{user_name} borró el proyecto %{resource_name} en el espacio %{space_name}"
-          update: "%{user_name} actualizó el proyecto %{resource_name} en el espacio
-            %{space_name}"
+          update: "%{user_name} actualizó el proyecto %{resource_name} en el espacio %{space_name}"
       models:
         project:
           fields:
@@ -77,18 +75,14 @@ es:
             title: Título
       projects:
         budget_confirm:
-          are_you_sure: "¿Estás de acuerdo? Una vez que hayas confirmado tu voto,
-            no puedes cambiarlo."
+          are_you_sure: "¿Estás de acuerdo? Una vez que hayas confirmado tu voto, no puedes cambiarlo."
           cancel: Cancelar
           confirm: Confirmar
-          description: Estos son los proyectos que has elegido para formar parte del
-            presupuesto.
+          description: Estos son los proyectos que has elegido para formar parte del presupuesto.
           title: Confirmar voto
         budget_excess:
           close: Cerrar
-          description: Este proyecto sobrepasa el presupuesto máximo y no se puede
-            añadir. Si lo deseas, puede eliminar un proyecto que ya hayas seleccionado
-            o dar apoyo con tus preferencias.
+          description: Este proyecto sobrepasa el presupuesto máximo y no se puede añadir. Si lo deseas, puede eliminar un proyecto que ya hayas seleccionado o dar apoyo con tus preferencias.
           ok: De acuerdo
           title: Presupuesto excedido
         budget_summary:
@@ -96,15 +90,11 @@ es:
           assigned: 'Asignado:'
           cancel_order: eliminar tu voto y empezar de nuevo
           checked_out:
-            description: Ya has votado para el presupuesto. Si has cambiado de idea,
-              puedes %{cancel_link}.
+            description: Ya has votado para el presupuesto. Si has cambiado de idea, puedes %{cancel_link}.
             title: Voto enviado correctamente
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Tú decides el presupuesto
         count:
           projects_count:
@@ -123,12 +113,8 @@ es:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -175,8 +161,7 @@ es:
             comments_enabled: Comentarios habilitados
             geocoding_enabled: Geocoding enabled
             projects_per_page: Proyectos por página
-            resources_permissions_enabled: Se pueden establecer permisos de acciones
-              para cada encuentro
+            resources_permissions_enabled: Se pueden establecer permisos de acciones para cada encuentro
             total_budget: Presupuesto total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -190,8 +175,7 @@ es:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/eu.yml
+++ b/decidim-budgets/config/locales/eu.yml
@@ -61,17 +61,13 @@ eu:
             success: "%{number} proposamen arrakastaz proiektuak inportatu"
           new:
             create: Inportatu proposamenak proiektuetarako
-            no_components: Proposamenak proiektuetan inportatzeko espazio parte hartzaile
-              honetan ez dago proposamenrik.
+            no_components: Proposamenak proiektuetan inportatzeko espazio parte hartzaile honetan ez dago proposamenrik.
             select_component: Hautatu osagaia
       admin_log:
         project:
-          create: "%{user_name} %{resource_name} proiektua %{space_name} espazioan
-            sortu zen"
-          delete: "%{user_name} %{resource_name} proiektua %{space_name} espazioan
-            ezabatu da"
-          update: "%{user_name} %{resource_name} proiektuaren %{space_name} espazio
-            eguneratu du"
+          create: "%{user_name} %{resource_name} proiektua %{space_name} espazioan sortu zen"
+          delete: "%{user_name} %{resource_name} proiektua %{space_name} espazioan ezabatu da"
+          update: "%{user_name} %{resource_name} proiektuaren %{space_name} espazio eguneratu du"
       models:
         project:
           fields:
@@ -79,17 +75,14 @@ eu:
             title: Titulua
       projects:
         budget_confirm:
-          are_you_sure: Ados zaude? Behin zure botoa baieztatuta, ezin izanen duzu
-            aldatu.
+          are_you_sure: Ados zaude? Behin zure botoa baieztatuta, ezin izanen duzu aldatu.
           cancel: Utzi
           confirm: Baieztatu
           description: Proiektu hauek hautatu dituzu aurrekontuan sartzeko.
           title: Baieztatu botoa
         budget_excess:
           close: Itxi
-          description: Proiektu honek gehieneko aurrekontua gainditzen du, eta ezin
-            da gehitu. Nahi baduzu, jada hautatua duzun proiektu bat ezaba dezakezu
-            edo botoa eman zure lehenespenekin bat.
+          description: Proiektu honek gehieneko aurrekontua gainditzen du, eta ezin da gehitu. Nahi baduzu, jada hautatua duzun proiektu bat ezaba dezakezu edo botoa eman zure lehenespenekin bat.
           ok: Ados
           title: Aurrekontua gainditu da
         budget_summary:
@@ -97,15 +90,11 @@ eu:
           assigned: 'Esleituta:'
           cancel_order: ezabatu ezazu botoa eta hasi berriro
           checked_out:
-            description: 'Jada bozkatu duzu aurrekonturako. Iritziz aldatu baduzu,
-              ezeztatu hemen: %{cancel_link}.'
+            description: 'Jada bozkatu duzu aurrekonturako. Iritziz aldatu baduzu, ezeztatu hemen: %{cancel_link}.'
             title: Botoa zuzen bidali da
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Zure esku dago aurrekontua erabakitzea
         count:
           projects_count:
@@ -124,12 +113,8 @@ eu:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -176,8 +161,7 @@ eu:
             comments_enabled: Iruzkinak gaituta
             geocoding_enabled: Geocoding enabled
             projects_per_page: Orrialde bakoitzeko proiektuak
-            resources_permissions_enabled: Akzioen baimenak bilera bakoitzerako ezarri
-              daitezke
+            resources_permissions_enabled: Akzioen baimenak bilera bakoitzerako ezarri daitezke
             total_budget: Aurrekontu osoa
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -191,8 +175,7 @@ eu:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/fi-pl.yml
+++ b/decidim-budgets/config/locales/fi-pl.yml
@@ -10,6 +10,9 @@ fi-pl:
         proposal_ids: Liittyvät ehdotukset
         title: Otsikko
   activerecord:
+    errors:
+      messages:
+        equal_to: must be equal to %{count}
     models:
       decidim/budgets/project:
         one: Suunnitelma
@@ -39,6 +42,9 @@ fi-pl:
           edit:
             title: Muokkaa suunnitelmaa
             update: Päivitä
+          form:
+            fields:
+              address: Address
           index:
             finished_orders: Valmiit äänet
             pending_orders: Odottavat äänet
@@ -55,33 +61,28 @@ fi-pl:
             success: "%{number} ehdotusta tuotu onnistuneesti suunnitelmiin"
           new:
             create: Tuo ehdotuksia suunnitelmiin
-            no_components: Tässä osallisuustilassa ei ole ole muita ehdotuskomponentteja,
-              joista voitaisiin tuoda ehdotuksia suunnitelmiin.
+            no_components: Tässä osallisuustilassa ei ole ole muita ehdotuskomponentteja, joista voitaisiin tuoda ehdotuksia suunnitelmiin.
             select_component: Valitse komponentti
       admin_log:
         project:
           create: "%{user_name} loi %{resource_name} -suunnitelman %{space_name} -tilassa"
-          delete: "%{user_name} poisti %{resource_name} -suunnitelman %{space_name}
-            -tilassa"
-          update: "%{user_name} päivitti %{resource_name} -suunnitelman %{space_name}
-            -tilassa"
+          delete: "%{user_name} poisti %{resource_name} -suunnitelman %{space_name} -tilassa"
+          update: "%{user_name} päivitti %{resource_name} -suunnitelman %{space_name} -tilassa"
       models:
         project:
           fields:
+            map: Map
             title: Otsikko
       projects:
         budget_confirm:
-          are_you_sure: Oletko samaa mieltä? Kun olet vahvistanut äänesi, et voi enää
-            muuttaa sitä.
+          are_you_sure: Oletko samaa mieltä? Kun olet vahvistanut äänesi, et voi enää muuttaa sitä.
           cancel: Peruuta
           confirm: Vahvista
           description: Olet valinnut nämä suunnitelmat osaksi budjettia.
           title: Vahvista ääni
         budget_excess:
           close: Sulje
-          description: Tämä suunnitelma ylittää maksimibudjetin, minkä takia sitä
-            ei voida lisätä. Jos haluat, voit tehdä "tilaa" budjettiin poistamalla
-            suunnitelman, jonka olet jo valinnut lisättäväksi.
+          description: Tämä suunnitelma ylittää maksimibudjetin, minkä takia sitä ei voida lisätä. Jos haluat, voit tehdä "tilaa" budjettiin poistamalla suunnitelman, jonka olet jo valinnut lisättäväksi.
           ok: OK
           title: Maksimibudjetti ylitetty
         budget_summary:
@@ -89,12 +90,11 @@ fi-pl:
           assigned: 'Varattu:'
           cancel_order: poista äänesi ja aloitta alusta
           checked_out:
-            description: Olet jo äänestänyt tätä budjettia. Jos muutit mieltäsi, voit
-              %{cancel_link}.
+            description: Olet jo äänestänyt tätä budjettia. Jos muutit mieltäsi, voit %{cancel_link}.
             title: Budjetin äänestys suoritettu
-          description: Mitä suunnitelmia varten sinun mielestäsi budjettia tulisi
-            varata? Varaa vähintään %{minimum_budget} suunnitelmille, jotka haluat
-            toteutettavan ja äänestä mieltymystesi mukaisesti määrittääksesi budjetin.
+          description: Mitä suunnitelmia varten sinun mielestäsi budjettia tulisi varata? Varaa vähintään %{minimum_budget} suunnitelmille, jotka haluat toteutettavan ja äänestä mieltymystesi mukaisesti määrittääksesi budjetin.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Voit päättää budjetin
         count:
           projects_count:
@@ -109,14 +109,34 @@ fi-pl:
           filter: Suodata
           filter_by: Suodata
           unfold: Avaa
+        index:
+          view_project: View project
+        limit_excess:
+          close: Close
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
+          ok: OK
+          title_per_budget: Maximum budget exceeded
+          title_per_project: Maximum number of projects reached
         order_progress:
           vote: Äänestä
         order_selected_projects:
+          choose: Choisissez encore
+          per_project:
+            one: project selected out of a total of
+            other: projects selected out of a total of
+          remaining_projects:
+            one: 1 project to validate your vote.
+            other: "%{count} projects to validate your vote."
           remove: Poista
           selected_projects:
             one: suunnitelma valittu
             other: projektia valittu
+          total_projects:
+            one: projet
+            other: projets
           view: Näytä
+          vote: Voter
         project:
           add: Lisää
           count:
@@ -139,10 +159,13 @@ fi-pl:
           global:
             announcement: Ilmoitus
             comments_enabled: Kommentit ovat käytössä
+            geocoding_enabled: Geocoding enabled
             projects_per_page: Suunnitelmat sivua kohden
-            resources_permissions_enabled: Toiminnallisuutta koskevat oikeudet voidaan
-              asettaa jokaiselle suunnitelmalle
+            resources_permissions_enabled: Toiminnallisuutta koskevat oikeudet voidaan asettaa jokaiselle suunnitelmalle
             total_budget: Kokonaisbudjetti
+            total_projects: Total projects
+            vote_per_budget: budget sum enabled (default)
+            vote_per_project: project number enabled
             vote_threshold_percent: Äänestyksen kynnysprosentti
           step:
             announcement: Ilmoitus
@@ -152,8 +175,7 @@ fi-pl:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/fi.yml
+++ b/decidim-budgets/config/locales/fi.yml
@@ -92,6 +92,7 @@ fi:
           checked_out:
             description: Olet jo äänestänyt tätä budjettia. Jos muutit mieltäsi, voit %{cancel_link}.
             title: Budjetin äänestys suoritettu
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
           description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
           description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Voit päättää budjetin
@@ -174,8 +175,7 @@ fi:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/fr.yml
+++ b/decidim-budgets/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -91,6 +92,7 @@ fr:
           checked_out:
             description: Vous avez déjà voté. Si vous avez changé d'avis, vous pouvez %{cancel_link}.
             title: Vote du budget terminé
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
           description_per_budget: Sélectionnez les projets que vous souhaitez voir être réalisés puis confirmez votre choix. Les projets choisis doivent atteindre le montant minimum cumulé de %{minimum_budget}.
           description_per_project: Sélectionnez les projets que vous souhaitez voir être réalisés puis confirmez votre choix. Vous devez choisir %{minimum_project} minimum.
           title: Vous décidez du budget
@@ -173,10 +175,10 @@ fr:
     events:
       budgets:
         order_checkout:
-          email_intro: "Votre vote a été validé. Vous pouvez toujours l'éditer si vous voulez en cliquant ici : <a href='%{resource_url}'>%{participatory_space_title}"
+          email_intro: 'Votre vote a été validé. Vous pouvez toujours l''éditer si vous voulez en cliquant ici : <a href=''%{resource_url}''>%{participatory_space_title}'
           email_outro: Merci de votre participation
-          email_subject: "Une enquête est terminée à %{participatory_space_title}"
-          notification_title: "Votre vote a été validé le <a href='%{resource_url}'>%{participatory_space_title}</a> Vous pouvez toujours l'éditer si vous le souhaitez."
+          email_subject: Une enquête est terminée à %{participatory_space_title}
+          notification_title: Votre vote a été validé le <a href='%{resource_url}'>%{participatory_space_title}</a> Vous pouvez toujours l'éditer si vous le souhaitez.
     orders:
       checkout:
         error: Une erreur s'est produite lors du traitement de votre vote

--- a/decidim-budgets/config/locales/gl.yml
+++ b/decidim-budgets/config/locales/gl.yml
@@ -61,8 +61,7 @@ gl:
             success: "%{number} propostas importadas con éxito en proxectos"
           new:
             create: Importa propostas a proxectos
-            no_components: Non existen outros compoñentes de proposta neste espazo
-              participativo para importar as propostas en proxectos.
+            no_components: Non existen outros compoñentes de proposta neste espazo participativo para importar as propostas en proxectos.
             select_component: Selecciona un compoñente
       admin_log:
         project:
@@ -76,17 +75,14 @@ gl:
             title: Título
       projects:
         budget_confirm:
-          are_you_sure: Estás de acordo? Unha vez confirmado o teu voto non podes
-            cambialo.
+          are_you_sure: Estás de acordo? Unha vez confirmado o teu voto non podes cambialo.
           cancel: Cancelar
           confirm: Confirmar
           description: Estes son os proxectos que escolleu para formar parte do orzamento.
           title: Confirmar voto
         budget_excess:
           close: Pechar
-          description: Este proxecto supera o orzamento máximo e non se pode engadir.
-            Se o desexa, pode eliminar un proxecto que xa seleccionou para engadir
-            ou facer o seu voto coas súas preferencias.
+          description: Este proxecto supera o orzamento máximo e non se pode engadir. Se o desexa, pode eliminar un proxecto que xa seleccionou para engadir ou facer o seu voto coas súas preferencias.
           ok: Ok
           title: O orzamento máximo excedeu
         budget_summary:
@@ -96,12 +92,9 @@ gl:
           checked_out:
             description: Xa votou polo orzamento. Se mudou de idea, pode %{cancel_link}.
             title: A votación do orzamento completada
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Vostede decide o orzamento
         count:
           projects_count:
@@ -120,12 +113,8 @@ gl:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -172,8 +161,7 @@ gl:
             comments_enabled: Comentarios habilitados
             geocoding_enabled: Geocoding enabled
             projects_per_page: Proxectos por páxina
-            resources_permissions_enabled: Os permisos de acción pódense establecer
-              para cada reunión
+            resources_permissions_enabled: Os permisos de acción pódense establecer para cada reunión
             total_budget: Orzamento total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -187,8 +175,7 @@ gl:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/hu.yml
+++ b/decidim-budgets/config/locales/hu.yml
@@ -61,17 +61,13 @@ hu:
             success: "%{number} javaslat sikeresen importálva a projektekbe"
           new:
             create: Javaslatok importálása projektekbe
-            no_components: Ebben a részvételi térben nincs más javaslat-összetevő
-              a javaslatok projektekbe való importálásához.
+            no_components: Ebben a részvételi térben nincs más javaslat-összetevő a javaslatok projektekbe való importálásához.
             select_component: Válassz ki egy elemet
       admin_log:
         project:
-          create: "%{user_name} létrehozta a(z) %{resource_name} nevű projektet itt:
-            %{space_name}"
-          delete: "%{user_name} eltávolította a(z) %{resource_name} nevű projektet
-            itt: %{space_name}"
-          update: "%{user_name} frissítette a(z) %{resource_name} nevű projektet itt:
-            %{space_name}"
+          create: "%{user_name} létrehozta a(z) %{resource_name} nevű projektet itt: %{space_name}"
+          delete: "%{user_name} eltávolította a(z) %{resource_name} nevű projektet itt: %{space_name}"
+          update: "%{user_name} frissítette a(z) %{resource_name} nevű projektet itt: %{space_name}"
       models:
         project:
           fields:
@@ -79,17 +75,14 @@ hu:
             title: Cím
       projects:
         budget_confirm:
-          are_you_sure: Egyetértesz? Ha megerősítetted a szavazatod, már nem változtathatod
-            meg.
+          are_you_sure: Egyetértesz? Ha megerősítetted a szavazatod, már nem változtathatod meg.
           cancel: Mégse
           confirm: Megerősítés
           description: Ezek azok a projektek, amelyek a költségvetés részét képezik.
           title: Szavazás megerősítése
         budget_excess:
           close: Bezárás
-          description: Ez a projekt meghaladja a költségvetés maximumát és nem adható
-            hozzá. Ha szeretnéd, törölheted az egyszer már kiválasztott projektet,
-            vagy kedved szerint szavazhatsz róluk.
+          description: Ez a projekt meghaladja a költségvetés maximumát és nem adható hozzá. Ha szeretnéd, törölheted az egyszer már kiválasztott projektet, vagy kedved szerint szavazhatsz róluk.
           ok: OK
           title: Maximális költségkeret túllépve
         budget_summary:
@@ -97,15 +90,11 @@ hu:
           assigned: 'Hozzárendelve:'
           cancel_order: töröld a szavazatod és kezdd újra
           checked_out:
-            description: 'Már szavaztál a költségvetésre. Ha meggondoltad magad, kattints
-              ide: %{cancel_link}.'
+            description: 'Már szavaztál a költségvetésre. Ha meggondoltad magad, kattints ide: %{cancel_link}.'
             title: Költségvetési szavazás befejeződött
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Dönts a költségvetéstről
         count:
           projects_count:
@@ -124,12 +113,8 @@ hu:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -190,8 +175,7 @@ hu:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/id-ID.yml
+++ b/decidim-budgets/config/locales/id-ID.yml
@@ -1,139 +1,197 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       project:
-        budget: Anggaran
-        decidim_category_id: Kategori
-        decidim_scope_id: Cakupan
-        description: Deskripsi
-        proposal_ids: Proposal terkait
-        title: Judul
+        budget: Budget
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        proposal_ids: Related proposals
+        title: Title
   activerecord:
+    errors:
+      messages:
+        equal_to: must be equal to %{count}
     models:
       decidim/budgets/project:
-        other: Proyek
+        few: Project
+        many: Projects
+        one: Project
+        other: Projects
+        zero: Project
   decidim:
     budgets:
       actions:
-        attachment_collections: Folder
-        attachments: Lampiran
-        confirm_destroy: Anda yakin ingin menghapus proyek ini?
-        destroy: Menghapus
+        attachment_collections: Folders
+        attachments: Attachments
+        confirm_destroy: Are you sure you want to delete this project?
+        destroy: Delete
         edit: Edit
-        import: Impor proposal ke proyek
-        new: Proyek baru
-        preview: Pratinjau
-        title: Tindakan
+        import: Import proposals to projects
+        new: New project
+        preview: Preview
+        title: Actions
       admin:
         models:
           project:
-            name: Proyek
+            name: Project
         projects:
           create:
-            success: Proyek berhasil dibuat
+            invalid: There's been a problem creating this project
+            success: Project successfully created
           destroy:
-            success: Proyek berhasil dihapus
+            success: Project successfully deleted
           edit:
-            title: Edit proyek
-            update: Memperbarui
+            title: Edit project
+            update: Update
+          form:
+            fields:
+              address: Address
           index:
-            finished_orders: Suara jadi
-            pending_orders: Suara yang tertunda
-            title: Proyek
+            finished_orders: Finished votes
+            pending_orders: Pending votes
+            title: Projects
           new:
-            create: Membuat
-            title: Proyek baru
+            create: Create
+            title: New project
           update:
-            success: Proyek berhasil diperbarui
+            invalid: There's been a problem updating this project
+            success: Project successfully updated
         proposals_imports:
           create:
-            success: "%{number} proposal berhasil diimpor ke proyek"
+            invalid: There's been a problem importing the proposals into projects
+            success: "%{number} proposals successfully imported into projects"
           new:
-            create: Impor proposal ke proyek
-            no_components: Tidak ada komponen proposal lain dalam ruang partisipatif ini untuk mengimpor proposal ke proyek.
-            select_component: Silakan pilih satu komponen
+            create: Import proposals to projects
+            no_components: There are no other proposal components in this participatory space to import the proposals into projects.
+            select_component: Please select a component
       admin_log:
         project:
-          create: "%{user_name} menciptakan proyek %{resource_name} dalam %{space_name} ruang"
-          delete: "%{user_name} menghapus %{resource_name} proyek di %{space_name} ruang"
-          update: "%{user_name} memperbarui proyek %{resource_name} di ruang %{space_name}"
+          create: "%{user_name} created the %{resource_name} project in the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} project in the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} project in the %{space_name} space"
       models:
         project:
           fields:
-            title: Judul
+            map: Map
+            title: Title
       projects:
         budget_confirm:
-          are_you_sure: Apa kamu setuju? Setelah Anda mengkonfirmasi suara Anda, Anda tidak dapat mengubahnya.
-          cancel: Membatalkan
-          confirm: Memastikan
-          description: Ini adalah proyek yang Anda pilih untuk menjadi bagian dari anggaran.
-          title: Konfirmasikan suara
+          are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.
+          cancel: Cancel
+          confirm: Confirm
+          description: These are the projects you have chosen to be part of the budget.
+          title: Confirm vote
         budget_excess:
-          close: Dekat
-          description: Proyek ini melebihi anggaran maksimum dan tidak dapat ditambahkan. Jika mau, Anda dapat menghapus proyek yang sudah Anda pilih untuk ditambahkan, atau pilih dengan preferensi Anda.
-          ok: baik
-          title: Anggaran maksimum terlampaui
+          close: Закрити
+          description: Додавання цього проекту перевищить максимальний бюджет, і тому його не можна зараз додати. За бажанням ви можете видалити якийсь з тих проектів, що ви раніше вибрали для додавання, або проголосувати згідно ваших уподобань.
+          ok: Гаразд
+          title: Перевищено граничний бюджет
         budget_summary:
-          are_you_sure: Anda yakin ingin membatalkan suara?
-          assigned: 'Ditugaskan:'
-          cancel_order: hapus suara Anda dan mulai lagi dari awal
+          are_you_sure: Are you sure you want to cancel your vote?
+          assigned: 'Assigned:'
+          cancel_order: delete your vote and start over
           checked_out:
-            description: Anda telah memberikan suara untuk anggaran. Jika Anda berubah pikiran, Anda dapat %{cancel_link}.
-            title: Suara anggaran selesai
-          description: Menurut Anda proyek apa yang harus kita alokasikan anggarannya? Tetapkan setidaknya %{minimum_budget} untuk proyek yang Anda inginkan dan pilih dengan preferensi Anda untuk menentukan anggaran.
-          title: Anda yang memutuskan anggaran
+            description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
+            title: Budget vote completed
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
+          title: You decide the budget
         count:
           projects_count:
-            other: "%{count} proyek"
+            one: 1 project
+            other: "%{count} projects"
         filters:
-          category: Kategori
-          category_prompt: Pilih Kategori
-          search: Pencarian
+          category: Category
+          category_prompt: Select a category
+          search: Search
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Saring menurut
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
+        index:
+          view_project: View project
+        limit_excess:
+          close: Close
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
+          ok: OK
+          title_per_budget: Maximum budget exceeded
+          title_per_project: Maximum number of projects reached
         order_progress:
-          vote: Memilih
+          vote: Vote
         order_selected_projects:
-          remove: Menghapus
+          choose: Choisissez encore
+          per_project:
+            one: project selected out of a total of
+            other: projects selected out of a total of
+          remaining_projects:
+            one: 1 project to validate your vote.
+            other: "%{count} projects to validate your vote."
+          remove: Remove
           selected_projects:
-            other: proyek yang dipilih
-          view: Melihat
+            one: project selected
+            other: projects selected
+          total_projects:
+            one: projet
+            other: projets
+          view: View
+          vote: Voter
         project:
-          add: Menambahkan
+          add: Add
           count:
-            other: "%{count} mendukung"
-          remove: Menghapus
-          view: Melihat
+            one: 1 support
+            other: "%{count} supports"
+          remove: Remove
+          view: View
         project_budget_button:
-          add: Menambahkan
-          added: Ditambahkan
+          add: Add
+          added: Added
         show:
-          budget: Anggaran
-          view_all_projects: Lihat semua proyek
+          budget: Budget
+          view_all_projects: Back to projects list
     components:
       budgets:
         actions:
-          vote: Memilih
-        name: Anggaran
+          vote: Vote
+        name: Budgets
         settings:
           global:
-            announcement: Pengumuman
-            comments_enabled: Komentar diaktifkan
-            projects_per_page: Proyek per halaman
-            resources_permissions_enabled: Izin tindakan dapat ditetapkan untuk setiap pertemuan
-            total_budget: Total anggaran
-            vote_threshold_percent: Batas ambang persentase suara
+            announcement: Announcement
+            comments_enabled: Comments enabled
+            geocoding_enabled: Geocoding enabled
+            projects_per_page: Projects per page
+            resources_permissions_enabled: Actions permissions can be set for each meeting
+            total_budget: Total budget
+            total_projects: Total projects
+            vote_per_budget: budget sum enabled (default)
+            vote_per_project: project number enabled
+            vote_threshold_percent: Vote threshold percent
           step:
-            announcement: Pengumuman
-            comments_blocked: Komentar diblokir
-            show_votes: Tampilkan suara
-            votes_enabled: Voting diaktifkan
+            announcement: Announcement
+            comments_blocked: Comments blocked
+            show_votes: Show votes
+            votes_enabled: Voting enabled
+    events:
+      budgets:
+        order_checkout:
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here: <a href=''%{resource_url}''>%{participatory_space_title}'
+          email_outro: Thank you for your participation
+          email_subject: Your vote has been validated on %{participatory_space_title}
+          notification_title: Your vote has been validated on <a href='%{resource_url}'>%{participatory_space_title}</a> You can always edit it if you like.
+    orders:
+      checkout:
+        error: An error ocurred while processing your vote
+        success: Your vote has been accepted successfully
+      destroy:
+        error: An error ocurred while canceling your vote
+        success: Your vote has been canceled successfully
     resource_links:
       included_proposals:
-        project_proposal: 'Proposal yang termasuk dalam proyek ini:'
+        project_proposal: 'Proposals included in this project:'
   index:
-    confirmed_orders_count: Votes dihitung
-  total_budget: Total anggaran
+    confirmed_orders_count: Votes count
+  total_budget: Total budget

--- a/decidim-budgets/config/locales/it.yml
+++ b/decidim-budgets/config/locales/it.yml
@@ -61,17 +61,13 @@ it:
             success: "%{number} proposte importate con successo nei progetti"
           new:
             create: Importa proposte per progetti
-            no_components: Non ci sono altri componenti della proposta in questo spazio
-              partecipativo per importare le proposte in progetti.
+            no_components: Non ci sono altri componenti della proposta in questo spazio partecipativo per importare le proposte in progetti.
             select_component: Si prega di selezionare un componente
       admin_log:
         project:
-          create: "%{user_name} ha creato il progetto %{resource_name} nello spazio
-            %{space_name}"
-          delete: "%{user_name} eliminato il progetto %{resource_name} nello spazio
-            %{space_name}"
-          update: "%{user_name} ha aggiornato il progetto %{resource_name} nello spazio
-            %{space_name}"
+          create: "%{user_name} ha creato il progetto %{resource_name} nello spazio %{space_name}"
+          delete: "%{user_name} eliminato il progetto %{resource_name} nello spazio %{space_name}"
+          update: "%{user_name} ha aggiornato il progetto %{resource_name} nello spazio %{space_name}"
       models:
         project:
           fields:
@@ -79,18 +75,14 @@ it:
             title: Titolo
       projects:
         budget_confirm:
-          are_you_sure: Sei d'accordo? Dopo che avrai confermato il tuo voto non potrai
-            più modificarlo
+          are_you_sure: Sei d'accordo? Dopo che avrai confermato il tuo voto non potrai più modificarlo
           cancel: Annulla
           confirm: Conferma
-          description: Questi sono i progetti per i quali hai scelto di partecipare
-            al budget.
+          description: Questi sono i progetti per i quali hai scelto di partecipare al budget.
           title: Conferma il voto
         budget_excess:
           close: Chiudi
-          description: Questo progetto supera il budget e non può essere aggiunto.
-            Se vuoi puoi cancellare un progetto che hai già scelto di aggiungere,
-            oppure votare in base alle tue preferenze.
+          description: Questo progetto supera il budget e non può essere aggiunto. Se vuoi puoi cancellare un progetto che hai già scelto di aggiungere, oppure votare in base alle tue preferenze.
           ok: Ok
           title: Budget superato
         budget_summary:
@@ -100,12 +92,9 @@ it:
           checked_out:
             description: Hai già votato per il budget. Se hai cambiato idea puoi %{cancel_link}.
             title: Voto di budget completato.
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Tu decidi il budget
         count:
           projects_count:
@@ -124,12 +113,8 @@ it:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -176,8 +161,7 @@ it:
             comments_enabled: Commenti abilitati
             geocoding_enabled: Geocoding enabled
             projects_per_page: Progetti per pagina
-            resources_permissions_enabled: Le autorizzazioni delle azioni possono
-              essere impostate per ogni riunione
+            resources_permissions_enabled: Le autorizzazioni delle azioni possono essere impostate per ogni riunione
             total_budget: Budget totale
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -191,8 +175,7 @@ it:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/nl.yml
+++ b/decidim-budgets/config/locales/nl.yml
@@ -57,22 +57,17 @@ nl:
             success: Project succesvol bijgewerkt
         proposals_imports:
           create:
-            invalid: Er is een probleem opgetreden bij het importeren van de voorstellen
-              in projecten
+            invalid: Er is een probleem opgetreden bij het importeren van de voorstellen in projecten
             success: "%{number} voorstellen succesvol geïmporteerd in projecten"
           new:
             create: Voorstellen importeren in projecten
-            no_components: Er zijn geen andere voorstelcomponenten in deze participatieruimte
-              om de voorstellen in projecten te importeren.
+            no_components: Er zijn geen andere voorstelcomponenten in deze participatieruimte om de voorstellen in projecten te importeren.
             select_component: Selecteer een component
       admin_log:
         project:
-          create: "%{user_name} heeft het project %{resource_name} in de ruimte %{space_name}
-            gemaakt"
-          delete: "%{user_name} verwijderde het %{resource_name} project in de %{space_name}
-            ruimte"
-          update: "%{user_name} heeft het project %{resource_name} bijgewerkt in de
-            ruimte %{space_name}"
+          create: "%{user_name} heeft het project %{resource_name} in de ruimte %{space_name} gemaakt"
+          delete: "%{user_name} verwijderde het %{resource_name} project in de %{space_name} ruimte"
+          update: "%{user_name} heeft het project %{resource_name} bijgewerkt in de ruimte %{space_name}"
       models:
         project:
           fields:
@@ -80,18 +75,14 @@ nl:
             title: Titel
       projects:
         budget_confirm:
-          are_you_sure: Bent u het eens? Zodra u uw stem hebt bevestigd, kunt u deze
-            niet meer wijzigen.
+          are_you_sure: Bent u het eens? Zodra u uw stem hebt bevestigd, kunt u deze niet meer wijzigen.
           cancel: Annuleer
           confirm: Bevestigen
-          description: Dit zijn de projecten die u hebt gekozen om deel uit te maken
-            van de begroting.
+          description: Dit zijn de projecten die u hebt gekozen om deel uit te maken van de begroting.
           title: Bevestig de stem
         budget_excess:
           close: Sluit
-          description: Dit project overschrijdt het maximale budget en kan niet worden
-            toegevoegd. Als u wilt, kunt u een project verwijderen dat u al hebt geselecteerd
-            om toe te voegen of uw stem te maken met uw voorkeuren.
+          description: Dit project overschrijdt het maximale budget en kan niet worden toegevoegd. Als u wilt, kunt u een project verwijderen dat u al hebt geselecteerd om toe te voegen of uw stem te maken met uw voorkeuren.
           ok: OK
           title: Maximum budget overschreden
         budget_summary:
@@ -99,15 +90,11 @@ nl:
           assigned: 'Toegewezen:'
           cancel_order: Verwijder uw stem en begin opnieuw
           checked_out:
-            description: Je hebt al voor de begroting gestemd. Als u van mening bent,
-              kunt u %{cancel_link}.
+            description: Je hebt al voor de begroting gestemd. Als u van mening bent, kunt u %{cancel_link}.
             title: Begrotingsstemming voltooid
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: U bepaalt het budget
         count:
           projects_count:
@@ -126,12 +113,8 @@ nl:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -178,14 +161,12 @@ nl:
             comments_enabled: Reacties ingeschakeld
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projecten per pagina
-            resources_permissions_enabled: Actiemachtigingen kunnen voor elke vergadering
-              worden ingesteld
+            resources_permissions_enabled: Actiemachtigingen kunnen voor elke vergadering worden ingesteld
             total_budget: Totale budget
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
             vote_per_project: project number enabled
-            vote_threshold_percent: Percentage van het budget dat bereikt moet worden
-              om te kunnen stemmen
+            vote_threshold_percent: Percentage van het budget dat bereikt moet worden om te kunnen stemmen
           step:
             announcement: Aankondiging
             comments_blocked: Reacties geblokkeerd
@@ -194,8 +175,7 @@ nl:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/pl.yml
+++ b/decidim-budgets/config/locales/pl.yml
@@ -63,15 +63,13 @@ pl:
             success: "%{number} propozycji pomyślnie zaimportowanych do projektów"
           new:
             create: Importuj propozycje do projektów
-            no_components: W tej przestrzeni partycypacyjnej nie ma innych komponentów
-              propozycji do importowania propozycji do projektów.
+            no_components: W tej przestrzeni partycypacyjnej nie ma innych komponentów propozycji do importowania propozycji do projektów.
             select_component: Wybierz komponent
       admin_log:
         project:
           create: "%{user_name} utworzył projekt %{resource_name} w przestrzeni %{space_name}"
           delete: "%{user_name} usunął projekt %{resource_name} z przestrzeni %{space_name}"
-          update: "%{user_name} zaktualizował projekt %{resource_name} w przestrzeni
-            %{space_name}"
+          update: "%{user_name} zaktualizował projekt %{resource_name} w przestrzeni %{space_name}"
       models:
         project:
           fields:
@@ -79,17 +77,14 @@ pl:
             title: Tytuł
       projects:
         budget_confirm:
-          are_you_sure: Czy sie zgadzasz? Po zatwierdzeniu swojego głosu nie możesz
-            go zmienić.
+          are_you_sure: Czy sie zgadzasz? Po zatwierdzeniu swojego głosu nie możesz go zmienić.
           cancel: Anuluj
           confirm: Potwierdzać
           description: Są to projekty, które wybrałeś jako część budżetu.
           title: Potwierdź głosowanie
         budget_excess:
           close: Blisko
-          description: Ten projekt przekracza maksymalny budżet i nie można go dodać.
-            Jeśli chcesz, możesz usunąć projekt, który został już wybrany, aby dodać
-            lub sprawić, aby głosował z Twoimi preferencjami.
+          description: Ten projekt przekracza maksymalny budżet i nie można go dodać. Jeśli chcesz, możesz usunąć projekt, który został już wybrany, aby dodać lub sprawić, aby głosował z Twoimi preferencjami.
           ok: ok
           title: Przekroczono maksymalny budżet
         budget_summary:
@@ -97,15 +92,11 @@ pl:
           assigned: 'Przydzielony:'
           cancel_order: Usuń głos i zacznij od nowa
           checked_out:
-            description: Już głosowałeś na budżet. Jeśli zmieniłeś zdanie, możesz
-              %{cancel_link}.
+            description: Już głosowałeś na budżet. Jeśli zmieniłeś zdanie, możesz %{cancel_link}.
             title: Ukończono budżet budżetowy
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Ty decydujesz budżet
         count:
           projects_count:
@@ -126,12 +117,8 @@ pl:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -182,8 +169,7 @@ pl:
             comments_enabled: Komentarze włączone
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projekty na stronę
-            resources_permissions_enabled: Uprawnienia akcji można ustawić dla każdego
-              spotkania
+            resources_permissions_enabled: Uprawnienia akcji można ustawić dla każdego spotkania
             total_budget: Cały budżet
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -197,8 +183,7 @@ pl:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/pt-BR.yml
+++ b/decidim-budgets/config/locales/pt-BR.yml
@@ -61,8 +61,7 @@ pt-BR:
             success: "%{number} propostas importadas para projetos"
           new:
             create: Importar propostas para projetos
-            no_components: Não há outros componentes da proposta neste espaço participativo
-              para importar as propostas para projetos.
+            no_components: Não há outros componentes da proposta neste espaço participativo para importar as propostas para projetos.
             select_component: Selecione um componente
       admin_log:
         project:
@@ -79,14 +78,11 @@ pt-BR:
           are_you_sure: Você concorda? Depois de confirmar o seu voto, não pode alterá-lo.
           cancel: Cancelar
           confirm: confirme
-          description: Estes são os projetos que você escolheu para fazer parte do
-            orçamento.
+          description: Estes são os projetos que você escolheu para fazer parte do orçamento.
           title: Confirmar votação
         budget_excess:
           close: Fechar
-          description: Este projeto excede o orçamento máximo e não pode ser adicionado.
-            Se você quiser, você pode excluir um projeto que você já selecionou para
-            adicionar ou fazer seu voto com suas preferências.
+          description: Este projeto excede o orçamento máximo e não pode ser adicionado. Se você quiser, você pode excluir um projeto que você já selecionou para adicionar ou fazer seu voto com suas preferências.
           ok: OK
           title: O orçamento máximo excedeu
         budget_summary:
@@ -94,15 +90,11 @@ pt-BR:
           assigned: 'Atribuído:'
           cancel_order: exclua seu voto e comece de novo
           checked_out:
-            description: Você já votou no orçamento. Se você mudou de idéia, você
-              pode %{cancel_link}.
+            description: Você já votou no orçamento. Se você mudou de idéia, você pode %{cancel_link}.
             title: Votação do orçamento concluída
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Você decide o orçamento
         count:
           projects_count:
@@ -121,12 +113,8 @@ pt-BR:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -173,8 +161,7 @@ pt-BR:
             comments_enabled: Comentários ativados
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projetos por página
-            resources_permissions_enabled: Permissões de ações podem ser definidas
-              para cada reunião
+            resources_permissions_enabled: Permissões de ações podem ser definidas para cada reunião
             total_budget: Orçamento total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -188,8 +175,7 @@ pt-BR:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/pt.yml
+++ b/decidim-budgets/config/locales/pt.yml
@@ -61,8 +61,7 @@ pt:
             success: "%{number} propostas importadas com sucesso para projetos"
           new:
             create: Importar propostas para projetos
-            no_components: Não há outros componentes da proposta neste espaço participativo
-              para importar as propostas para projetos.
+            no_components: Não há outros componentes da proposta neste espaço participativo para importar as propostas para projetos.
             select_component: Por favor selecione um componente
       admin_log:
         project:
@@ -79,14 +78,11 @@ pt:
           are_you_sure: Você concorda? Depois de confirmar o seu voto, não pode alterá-lo.
           cancel: Cancelar
           confirm: confirme
-          description: Estes são os projetos que você escolheu para fazer parte do
-            orçamento.
+          description: Estes são os projetos que você escolheu para fazer parte do orçamento.
           title: Confirmar votação
         budget_excess:
           close: Fechar
-          description: Este projeto excede o orçamento máximo e não pode ser adicionado.
-            Se você quiser, você pode excluir um projeto que você já selecionou para
-            adicionar ou fazer seu voto com suas preferências.
+          description: Este projeto excede o orçamento máximo e não pode ser adicionado. Se você quiser, você pode excluir um projeto que você já selecionou para adicionar ou fazer seu voto com suas preferências.
           ok: Está bem
           title: O orçamento máximo excedeu
         budget_summary:
@@ -94,15 +90,11 @@ pt:
           assigned: 'Atribuído:'
           cancel_order: exclua seu voto e comece de novo
           checked_out:
-            description: Você já votou no orçamento. Se você mudou de idéia, você
-              pode %{cancel_link}.
+            description: Você já votou no orçamento. Se você mudou de idéia, você pode %{cancel_link}.
             title: Votação do orçamento concluída
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Você decide o orçamento
         count:
           projects_count:
@@ -121,12 +113,8 @@ pt:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -173,8 +161,7 @@ pt:
             comments_enabled: Comentários ativados
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projetos por página
-            resources_permissions_enabled: Permissões de ações podem ser definidas
-              para cada reunião
+            resources_permissions_enabled: Permissões de ações podem ser definidas para cada reunião
             total_budget: Orçamento total
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -188,8 +175,7 @@ pt:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/ru.yml
+++ b/decidim-budgets/config/locales/ru.yml
@@ -59,13 +59,11 @@ ru:
             success: Проект успешно обновлен
         proposals_imports:
           create:
-            invalid: При попытке позаимствовать эти предложения в проекты произошла
-              ошибка
+            invalid: При попытке позаимствовать эти предложения в проекты произошла ошибка
             success: "%{number} предложений успешно позаимствованы для проектов"
           new:
             create: Внести в проекты позаимствованные предложения
-            no_components: В этом пространстве соучастия нет других составляющих предложений,
-              куда можно было бы внести позаимствованные предложения.
+            no_components: В этом пространстве соучастия нет других составляющих предложений, куда можно было бы внести позаимствованные предложения.
             select_component: Пожалуйста, выберите составляющую
       admin_log:
         project:
@@ -79,18 +77,14 @@ ru:
             title: Название
       projects:
         budget_confirm:
-          are_you_sure: Вы согласны? Подтвердив свой голос, вы не сможете потом его
-            изменить.
+          are_you_sure: Вы согласны? Подтвердив свой голос, вы не сможете потом его изменить.
           cancel: Отменить
           confirm: Подтвердить
           description: Вот те проекты, которые вы выбрали для включения в бюджет.
           title: Подтвердить голос
         budget_excess:
           close: Закрыть
-          description: Добавление этого проекта превысит предельный бюджет, и поэтому
-            его сейчас нельзя добавить. Если хотите, вы можете удалить один из проектов,
-            который вы ранее выбрали для добавления, или проголосовать за то распределение
-            средств, которое вы уже сделали.
+          description: Добавление этого проекта превысит предельный бюджет, и поэтому его сейчас нельзя добавить. Если хотите, вы можете удалить один из проектов, который вы ранее выбрали для добавления, или проголосовать за то распределение средств, которое вы уже сделали.
           ok: Хорошо
           title: Превышен предельный бюджет
         budget_summary:
@@ -98,15 +92,11 @@ ru:
           assigned: 'Выделено:'
           cancel_order: удалить свой голос и начать все сначала
           checked_out:
-            description: Вы уже голосовали за бюджет. Если вы передумали, вы можете
-              %{cancel_link}.
+            description: Вы уже голосовали за бюджет. Если вы передумали, вы можете %{cancel_link}.
             title: Голосование по бюджету завершено
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Вы определяете бюджет
         count:
           projects_count:
@@ -127,12 +117,8 @@ ru:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -183,8 +169,7 @@ ru:
             comments_enabled: Комментарии включены
             geocoding_enabled: Geocoding enabled
             projects_per_page: Проектов на страницу
-            resources_permissions_enabled: Для каждой встречи можно задать те или
-              иные разрешения на действия
+            resources_permissions_enabled: Для каждой встречи можно задать те или иные разрешения на действия
             total_budget: Общий бюджет
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -198,8 +183,7 @@ ru:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/sv.yml
+++ b/decidim-budgets/config/locales/sv.yml
@@ -57,20 +57,17 @@ sv:
             success: Projektet har uppdaterats
         proposals_imports:
           create:
-            invalid: Det har uppstått ett problem med att importera förslagen till
-              projekt
+            invalid: Det har uppstått ett problem med att importera förslagen till projekt
             success: "%{number} förslag importerades till projekt"
           new:
             create: Importera förslag till projekt
-            no_components: Det finns inga andra förslagskomponenter i detta deltagandeutrymme
-              för att importera förslagen till projekt.
+            no_components: Det finns inga andra förslagskomponenter i detta deltagandeutrymme för att importera förslagen till projekt.
             select_component: Var god välj en komponent
       admin_log:
         project:
           create: "%{user_name} skapade projektet %{resource_name} i utrymmet %{space_name}"
           delete: "%{user_name} raderade projektet %{resource_name} i utrymmet %{space_name}"
-          update: "%{user_name} uppdaterade projektet %{resource_name} i utrymmet
-            %{space_name}"
+          update: "%{user_name} uppdaterade projektet %{resource_name} i utrymmet %{space_name}"
       models:
         project:
           fields:
@@ -78,17 +75,14 @@ sv:
             title: Titel
       projects:
         budget_confirm:
-          are_you_sure: Håller du med? När du har bekräftat din röst kan du inte ändra
-            den.
+          are_you_sure: Håller du med? När du har bekräftat din röst kan du inte ändra den.
           cancel: Avbryt
           confirm: Bekräfta
           description: Det här är de projekt du har valt att vara del av budgeten.
           title: Bekräfta röst
         budget_excess:
           close: Stäng
-          description: Detta projekt överstiger den maximala budgeten och kan inte
-            läggas till. Om du vill kan du ta bort ett projekt som du redan har valt
-            för att lägga till eller göra din röst med dina önskemål.
+          description: Detta projekt överstiger den maximala budgeten och kan inte läggas till. Om du vill kan du ta bort ett projekt som du redan har valt för att lägga till eller göra din röst med dina önskemål.
           ok: OK
           title: Maximal budget överskreds
         budget_summary:
@@ -96,15 +90,11 @@ sv:
           assigned: 'Tilldelad:'
           cancel_order: ta bort din röst och börja om
           checked_out:
-            description: Du har redan röstat för budgeten. Om du har ändrat dig kan
-              du %{cancel_link}.
+            description: Du har redan röstat för budgeten. Om du har ändrat dig kan du %{cancel_link}.
             title: Budgetomröstning slutförd
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Du bestämmer budgeten
         count:
           projects_count:
@@ -123,12 +113,8 @@ sv:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -175,8 +161,7 @@ sv:
             comments_enabled: Kommentarer aktiverade
             geocoding_enabled: Geocoding enabled
             projects_per_page: Projekt per sida
-            resources_permissions_enabled: Åtgärdsbehörigheter kan ställas in för
-              varje möte
+            resources_permissions_enabled: Åtgärdsbehörigheter kan ställas in för varje möte
             total_budget: Total budget
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -190,8 +175,7 @@ sv:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-budgets/config/locales/tr-TR.yml
+++ b/decidim-budgets/config/locales/tr-TR.yml
@@ -1,153 +1,197 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       project:
-        budget: Bütçe
-        decidim_category_id: Kategori
-        decidim_scope_id: kapsam
-        description: Açıklama
-        proposal_ids: İlgili teklifler
-        title: Başlık
+        budget: Budget
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        proposal_ids: Related proposals
+        title: Title
   activerecord:
+    errors:
+      messages:
+        equal_to: must be equal to %{count}
     models:
       decidim/budgets/project:
-        one: proje
-        other: Projeler
+        few: Project
+        many: Projects
+        one: Project
+        other: Projects
+        zero: Project
   decidim:
     budgets:
       actions:
-        attachment_collections: Klasörler
-        attachments: Ekler
-        confirm_destroy: Bu projeyi silmek istediğinize emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        import: Projelere teklif alma
-        new: Yeni proje
-        preview: Ön izleme
-        title: Eylemler
+        attachment_collections: Folders
+        attachments: Attachments
+        confirm_destroy: Are you sure you want to delete this project?
+        destroy: Delete
+        edit: Edit
+        import: Import proposals to projects
+        new: New project
+        preview: Preview
+        title: Actions
       admin:
         models:
           project:
-            name: proje
+            name: Project
         projects:
           create:
-            invalid: "Bu yayın oluştururken bir sorun oluştu\n \n"
-            success: Proje başarıyla oluşturuldu
+            invalid: There's been a problem creating this project
+            success: Project successfully created
           destroy:
-            success: Proje başarıyla silindi
+            success: Project successfully deleted
           edit:
-            title: Projeyi düzenle
-            update: Güncelleştirme
+            title: Edit project
+            update: Update
+          form:
+            fields:
+              address: Address
           index:
-            finished_orders: Tamamlanan oylar
-            pending_orders: Bekleyen oylar
-            title: Projeler
+            finished_orders: Finished votes
+            pending_orders: Pending votes
+            title: Projects
           new:
-            create: yaratmak
-            title: Yeni proje
+            create: Create
+            title: New project
           update:
-            invalid: "Bu yayın oluştururken bir sorun oluştu\n \n"
-            success: Proje başarıyla güncellendi
+            invalid: There's been a problem updating this project
+            success: Project successfully updated
         proposals_imports:
           create:
-            invalid: Teklifleri projelere aktarırken bir sorun oluştu
-            success: "%{number} teklif başarıyla projelere aktarıldı"
+            invalid: There's been a problem importing the proposals into projects
+            success: "%{number} proposals successfully imported into projects"
           new:
-            create: Projelere teklif alma
-            no_components: Bu katılımcı alanda teklifleri projelere aktarmak için başka bir teklif bileşeni yoktur.
-            select_component: Lütfen bir bileşen seçin
+            create: Import proposals to projects
+            no_components: There are no other proposal components in this participatory space to import the proposals into projects.
+            select_component: Please select a component
       admin_log:
         project:
-          create: "%{user_name} , %{space_name} alanda %{resource_name} proje yarattı"
-          delete: "%{user_name} , %{space_name} uzayda %{resource_name} projeyi sildi"
-          update: "%{user_name} , %{space_name} uzayda %{resource_name} proje güncellendi"
+          create: "%{user_name} created the %{resource_name} project in the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} project in the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} project in the %{space_name} space"
       models:
         project:
           fields:
-            title: Başlık
+            map: Map
+            title: Title
       projects:
         budget_confirm:
-          are_you_sure: Katılıyor musun? Oyunuzu onayladıktan sonra, değiştiremezsiniz.
-          cancel: İptal etmek
-          confirm: Onaylamak
-          description: Bunlar bütçenin bir parçası olmak için seçtiğiniz projeler.
-          title: Oylamayı onayla
+          are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.
+          cancel: Cancel
+          confirm: Confirm
+          description: These are the projects you have chosen to be part of the budget.
+          title: Confirm vote
         budget_excess:
-          close: Kapat
-          description: Bu proje azami bütçeyi aşıyor ve eklenemiyor. İsterseniz, eklemek için önceden seçtiğiniz bir projeyi silebilir veya tercihlerinize oy verebilirsiniz.
-          ok: tamam
-          title: Maksimum bütçe aşıldı
+          close: Закрити
+          description: Додавання цього проекту перевищить максимальний бюджет, і тому його не можна зараз додати. За бажанням ви можете видалити якийсь з тих проектів, що ви раніше вибрали для додавання, або проголосувати згідно ваших уподобань.
+          ok: Гаразд
+          title: Перевищено граничний бюджет
         budget_summary:
-          are_you_sure: Oyunuzu iptal etmek istediğinizden emin misiniz?
-          assigned: 'atanan:'
-          cancel_order: oyunuzu silin ve baştan başlayın
+          are_you_sure: Are you sure you want to cancel your vote?
+          assigned: 'Assigned:'
+          cancel_order: delete your vote and start over
           checked_out:
-            description: Bütçeye zaten oy verdiniz. Fikrinizi değiştirdiyseniz, %{cancel_link}yapabilirsiniz.
-            title: Bütçe oyu tamamlandı
+            description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
+            title: Budget vote completed
           description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
-          title: Bütçeye siz karar verin
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
+          title: You decide the budget
         count:
           projects_count:
-            one: 1 proje
-            other: "%{count} proje"
+            one: 1 project
+            other: "%{count} projects"
         filters:
-          category: Kategori
-          category_prompt: bir kategori seç
-          search: Arama
+          category: Category
+          category_prompt: Select a category
+          search: Search
         filters_small_view:
-          close_modal: Kalıcı modal
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
+        index:
+          view_project: View project
+        limit_excess:
+          close: Close
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
+          ok: OK
+          title_per_budget: Maximum budget exceeded
+          title_per_project: Maximum number of projects reached
         order_progress:
-          vote: Oy
+          vote: Vote
         order_selected_projects:
-          remove: Kaldır
+          choose: Choisissez encore
+          per_project:
+            one: project selected out of a total of
+            other: projects selected out of a total of
+          remaining_projects:
+            one: 1 project to validate your vote.
+            other: "%{count} projects to validate your vote."
+          remove: Remove
           selected_projects:
-            one: proje seçildi
-            other: seçilen projeler
-          view: Görünüm
+            one: project selected
+            other: projects selected
+          total_projects:
+            one: projet
+            other: projets
+          view: View
+          vote: Voter
         project:
-          add: Eklemek
+          add: Add
           count:
-            one: 1 destek
-            other: "%{count} destek"
-          remove: Kaldır
-          view: Görünüm
+            one: 1 support
+            other: "%{count} supports"
+          remove: Remove
+          view: View
         project_budget_button:
-          add: Eklemek
-          added: Katma
+          add: Add
+          added: Added
         show:
-          budget: Bütçe
-          view_all_projects: Tüm projeleri görüntüle
+          budget: Budget
+          view_all_projects: Back to projects list
     components:
       budgets:
         actions:
-          vote: Oy
-        name: Bütçeler
+          vote: Vote
+        name: Budgets
         settings:
           global:
-            announcement: duyuru
-            comments_enabled: Yorumlar etkin
-            projects_per_page: Sayfa başına projeler
-            resources_permissions_enabled: Her toplantı için eylem izinleri ayarlanabilir
-            total_budget: Toplam bütçe
-            vote_threshold_percent: Oy eşiği yüzde
+            announcement: Announcement
+            comments_enabled: Comments enabled
+            geocoding_enabled: Geocoding enabled
+            projects_per_page: Projects per page
+            resources_permissions_enabled: Actions permissions can be set for each meeting
+            total_budget: Total budget
+            total_projects: Total projects
+            vote_per_budget: budget sum enabled (default)
+            vote_per_project: project number enabled
+            vote_threshold_percent: Vote threshold percent
           step:
-            announcement: duyuru
-            comments_blocked: Yorumlar engellendi
-            show_votes: Oyları göster
-            votes_enabled: Oylama etkin
+            announcement: Announcement
+            comments_blocked: Comments blocked
+            show_votes: Show votes
+            votes_enabled: Voting enabled
+    events:
+      budgets:
+        order_checkout:
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here: <a href=''%{resource_url}''>%{participatory_space_title}'
+          email_outro: Thank you for your participation
+          email_subject: Your vote has been validated on %{participatory_space_title}
+          notification_title: Your vote has been validated on <a href='%{resource_url}'>%{participatory_space_title}</a> You can always edit it if you like.
     orders:
       checkout:
-        error: Oyunuz işlenirken bir hata oluştu
-        success: Oyunuz başarıyla kabul edildi
+        error: An error ocurred while processing your vote
+        success: Your vote has been accepted successfully
       destroy:
-        error: Oyunuz iptal edilirken bir hata oluştu
-        success: Oyunuz başarıyla iptal edildi
+        error: An error ocurred while canceling your vote
+        success: Your vote has been canceled successfully
     resource_links:
       included_proposals:
-        project_proposal: 'Bu projede yer alan teklifler:'
+        project_proposal: 'Proposals included in this project:'
   index:
-    confirmed_orders_count: Oy sayısı
-  total_budget: Toplam bütçe
+    confirmed_orders_count: Votes count
+  total_budget: Total budget

--- a/decidim-budgets/config/locales/uk.yml
+++ b/decidim-budgets/config/locales/uk.yml
@@ -63,8 +63,7 @@ uk:
             success: "%{number} пропозицій успішно запозичено до проектів"
           new:
             create: Внести до проектів запозичені пропозиції
-            no_components: У цьому просторі співучасті немає інших складових пропозицій,
-              куди можна було б внести запозичені пропозиції.
+            no_components: У цьому просторі співучасті немає інших складових пропозицій, куди можна було б внести запозичені пропозиції.
             select_component: Будь ласка, оберіть складову
       admin_log:
         project:
@@ -78,18 +77,14 @@ uk:
             title: Назва
       projects:
         budget_confirm:
-          are_you_sure: Чи ви згодні? Підтвердивши свій голос, ви не зможете його
-            потім змінити.
+          are_you_sure: Чи ви згодні? Підтвердивши свій голос, ви не зможете його потім змінити.
           cancel: Скасувати
           confirm: Підтвердити
           description: Ось проекти, які ви обрали складовими бюджету.
           title: Підтвердьте голос
         budget_excess:
           close: Закрити
-          description: Додавання цього проекту перевищить максимальний бюджет, і тому
-            його не можна зараз додати. За бажанням ви можете видалити якийсь з тих
-            проектів, що ви раніше вибрали для додавання, або проголосувати згідно
-            ваших уподобань.
+          description: Додавання цього проекту перевищить максимальний бюджет, і тому його не можна зараз додати. За бажанням ви можете видалити якийсь з тих проектів, що ви раніше вибрали для додавання, або проголосувати згідно ваших уподобань.
           ok: Гаразд
           title: Перевищено граничний бюджет
         budget_summary:
@@ -97,15 +92,11 @@ uk:
           assigned: 'Надано:'
           cancel_order: видалити ваш голос і почати все спочатку
           checked_out:
-            description: Ви вже проголосували за бюджет. Якщо ви змінили свою думку,
-              ви можете %{cancel_link}.
+            description: Ви вже проголосували за бюджет. Якщо ви змінили свою думку, ви можете %{cancel_link}.
             title: Голосування щодо бюджету завершено
-          description_per_budget: What projects do you think we should allocate budget
-            for? Assign at least %{minimum_budget} to the projects you want and vote
-            with your preferences to define the budget.
-          description_per_project: To which projects do you think we should allocate
-            a budget? Choose %{minimum_project} projects and validate your vote. Attention,
-            all votes are irrevocable.
+          description: Hangi projeler için bütçe ayırmamız gerektiğini düşünüyorsunuz? İstediğiniz projelere en az %{minimum_budget} atayın ve bütçeyi belirlemek için tercihleriniz doğrultusunda oy kullanın.
+          description_per_budget: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description_per_project: To which projects do you think we should allocate a budget? Choose %{minimum_project} projects and validate your vote. Attention, all votes are irrevocable.
           title: Ви визначаєте бюджет
         count:
           projects_count:
@@ -126,12 +117,8 @@ uk:
           view_project: View project
         limit_excess:
           close: Close
-          description_per_budget: This project exceeds the maximum budget and can
-            not be added. If you want, you can delete a project you have already selected
-            to add, or make your vote with your preferences.
-          description_per_project: You have reached the maximum number of projects
-            allowed for this budget. If you wish, you can delete a project that you
-            have already selected.
+          description_per_budget: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description_per_project: You have reached the maximum number of projects allowed for this budget. If you wish, you can delete a project that you have already selected.
           ok: OK
           title_per_budget: Maximum budget exceeded
           title_per_project: Maximum number of projects reached
@@ -182,8 +169,7 @@ uk:
             comments_enabled: Коментарі увімкнено
             geocoding_enabled: Geocoding enabled
             projects_per_page: Проектів на сторінку
-            resources_permissions_enabled: Для кожної зустрічі можна встановити ті
-              чи інші дозволи на дії
+            resources_permissions_enabled: Для кожної зустрічі можна встановити ті чи інші дозволи на дії
             total_budget: Загальний бюджет
             total_projects: Total projects
             vote_per_budget: budget sum enabled (default)
@@ -197,8 +183,7 @@ uk:
     events:
       budgets:
         order_checkout:
-          email_intro: 'Your vote has been validated. You can always edit it if you
-            like by clicking here:'
+          email_intro: 'Your vote has been validated. You can always edit it if you like by clicking here:'
           email_outro: Thank you for your participation
           email_subject: Your vote has been validated
           notification_title: Your vote has been validated

--- a/decidim-comments/config/locales/fi-pl.yml
+++ b/decidim-comments/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     models:
@@ -67,17 +68,19 @@ fi-pl:
         blocked_comments_warning: Kommentit on poistettu käytöstä tällä hetkellä, mutta voit lukea aikaisempia kommentteja.
         loading: Ladataan kommentteja ...
         title: "%{count} kommenttia"
+        title_0: There are no comments yet
+        title_1: "%{count} comment"
     events:
       comments:
         comment_by_followed_user:
           email_intro: "%{author_name} on jättänyt kommentin %{resource_title}. Voit lukea sen tällä sivulla:"
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat %{author_name}. Voit perua seuraamisen kyseisen käyttäjän profiilisivulta.
-          email_subject: '%{author_name} on jättänyt uuden kommentin kohtaan %{resource_title}'
+          email_subject: "%{author_name} on jättänyt uuden kommentin kohtaan %{resource_title}"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> on jättänyt uuden kommentin kohtaan <a href="%{resource_path}">%{resource_title}</a>.
         comment_created:
           email_intro: "%{resource_title} on kommentoitu. Voit lukea kommentin tällä sivulla:"
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}" tai sen kirjoittajaa. Voit lopettaa seuraamisen edellä esitetyn linkin kautta.
-          email_subject: '%{author_name} on jättänyt uuden kommentin kohtaan %{resource_title}'
+          email_subject: "%{author_name} on jättänyt uuden kommentin kohtaan %{resource_title}"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>on jättänyt uuden kommentin kohtaan <a href="%{resource_path}">%{resource_title}</a>
         reply_created:
           email_intro: "%{author_name} on vastannut kommentiisi kohdassa %{resource_title}. Voit lukea sen tällä sivulla:"

--- a/decidim-comments/config/locales/id-ID.yml
+++ b/decidim-comments/config/locales/id-ID.yml
@@ -1,92 +1,102 @@
-id:
+---
+id-ID:
   activemodel:
     models:
-      decidim/comments/comment_by_followed_user_event: Komentar
-      decidim/comments/comment_created_event: Komentar
-      decidim/comments/reply_created_event: Balasan komentar
-      decidim/comments/user_mentioned_event: Menyebut
+      decidim/comments/comment_by_followed_user_event: Comment
+      decidim/comments/comment_created_event: Comment
+      decidim/comments/reply_created_event: Comment reply
+      decidim/comments/user_mentioned_event: Mention
   activerecord:
     models:
       decidim/comments/comment:
-        other: Komentar
+        one: Comment
+        other: Comments
       decidim/comments/comment_vote:
-        other: Voting
+        one: Vote
+        other: Votes
   decidim:
     comments:
-      comments: Komentar
+      comments: Comments
       last_activity:
-        new_comment_at_html: "<span>Komentar baru di %{link}</span>"
+        new_comment_at_html: "<span>New comment at %{link}</span>"
+      votes:
+        create:
+          error: There's been errors when voting the comment.
     components:
       add_comment_form:
-        account_message: <a href="%{sign_in_url}">Masuk dengan akun Anda</a> atau <a href="%{sign_up_url}">mendaftar</a> untuk menambahkan komentar Anda.
+        account_message: <a href="%{sign_in_url}">Sign in with your account</a> or <a href="%{sign_up_url}">sign up</a> to add your comment.
         form:
           body:
-            label: Komentar
-            placeholder: Apa yang Anda pikirkan tentang ini?
-          form_error: Teks diperlukan dan tidak boleh lebih dari %{length} karakter.
-          submit: Kirim
+            label: Comment
+            placeholder: What do you think about this?
+          form_error: The text is required and it can't be longer than %{length} characters.
+          submit: Send
           user_group_id:
-            label: Beri komentar sebagai
+            label: Comment as
         opinion:
-          neutral: Netral
-        remaining_characters: "%{count} karakter tersisa"
-        remaining_characters_1: "%{count} karakter tersisa"
-        title: Tambahkan komentar Anda
+          neutral: Neutral
+        remaining_characters: "%{count} characters left"
+        remaining_characters_1: "%{count} character left"
+        title: Add your comment
       comment:
         alignment:
-          against: Melawan
-          in_favor: Mendukung
-        reply: Balasan
+          against: Against
+          in_favor: In favor
+        deleted_user: Deleted user
+        reply: Reply
         report:
-          action: Melaporkan
-          already_reported: Konten ini sudah dilaporkan dan akan ditinjau oleh admin.
-          close: Dekat
-          description: Apakah konten ini tidak pantas?
-          details: Komentar tambahan
+          action: Report
+          already_reported: This content is already reported and it will be reviewed by an admin.
+          close: Close
+          description: Is this content inappropriate?
+          details: Additional comments
           reasons:
-            does_not_belong: Berisi aktivitas ilegal, ancaman bunuh diri, informasi pribadi, atau sesuatu yang menurut Anda bukan milik %{organization_name}
-            offensive: Berisi rasisme, seksisme, penghinaan, serangan pribadi, ancaman kematian, permintaan bunuh diri atau segala bentuk pidato kebencian.
-            spam: Berisi clickbait, iklan, penipuan atau bot skrip.
-          title: Laporkan masalah
+            does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+            offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+            spam: Contains clickbait, advertising, scams or script bots.
+          title: Report a problem
       comment_order_selector:
         order:
-          best_rated: Nilai terbaik
-          most_discussed: Paling banyak dibicarakan
-          older: Lebih tua
-          recent: Baru
-        title: 'Dipesan oleh:'
+          best_rated: Best rated
+          most_discussed: Most discussed
+          older: Older
+          recent: Recent
+        title: 'Order by:'
       comment_thread:
-        title: Percakapan dengan %{authorName}
+        title: Conversation with %{authorName}
       comments:
-        blocked_comments_warning: Komentar dinonaktifkan saat ini, tetapi Anda dapat membaca yang sebelumnya.
-        loading: Memuat komentar ...
-        title: "%{count} komentar"
+        blocked_comments_warning: Comments are disabled at this time, but you can read the previous ones.
+        loading: Loading comments ...
+        title: "%{count} comments"
+        title_0: There are no comments yet
+        title_1: "%{count} comment"
     events:
       comments:
         comment_by_followed_user:
-          email_intro: "%{author_name} telah menulis komentar dalam %{resource_title}. Anda dapat membacanya di halaman ini:"
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{author_name}. Anda dapat berhenti mengikuti pengguna ini dari halaman profil mereka.
-          email_subject: Ada komentar baru dengan %{author_name} in %{resource_title}
-          notification_title: Ada komentar baru oleh <a href="%{author_path}">%{author_name} %{author_nickname}</a> di <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: "%{author_name} has left a comment in %{resource_title}. You can read it in this page:"
+          email_outro: You have received this notification because you are following %{author_name}. You can unfollow this user from their profile page.
+          email_subject: There is a new comment by %{author_name} in %{resource_title}
+          notification_title: There is a new comment by <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>.
         comment_created:
-          email_intro: "%{resource_title} telah dikomentari. Anda dapat membaca komentar di halaman ini:"
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{resource_title}" atau penulisnya. Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Ada komentar baru dari %{author_name} in %{resource_title}
-          notification_title: Ada komentar baru dari <a href="%{author_path}">%{author_name} %{author_nickname}</a> di <a href="%{resource_path}">%{resource_title}</a>
+          email_intro: "%{resource_title} has been commented. You can read the comment in this page:"
+          email_outro: You have received this notification because you are following "%{resource_title}" or its author. You can unfollow it from the previous link.
+          email_subject: There is a new comment from %{author_name} in %{resource_title}
+          notification_title: There is a new comment from <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>
         reply_created:
-          email_intro: "%{author_name} telah membalas komentar Anda dalam %{resource_title}. Anda dapat membacanya di halaman ini:"
-          email_outro: Anda telah menerima pemberitahuan ini karena komentar Anda dijawab.
-          email_subject: "%{author_name} telah membalas komentar Anda dalam %{resource_title}"
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> telah menjawab komentar Anda di <a href="%{resource_path}">%{resource_title}</a>
+          email_intro: "%{author_name} has replied your comment in %{resource_title}. You can read it in this page:"
+          email_outro: You have received this notification because your comment was replied.
+          email_subject: "%{author_name} has replied your comment in %{resource_title}"
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> has replied your comment in <a href="%{resource_path}">%{resource_title}</a>
         user_mentioned:
-          email_intro: Anda telah disebutkan
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda telah disebutkan dalam %{resource_title}.
-          email_subject: Anda telah disebutkan dalam %{resource_title}
-          notification_title: Anda telah disebutkan dalam <a href="%{resource_path}">%{resource_title}</a> oleh <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+          email_intro: You have been mentioned
+          email_outro: You have received this notification because you have been mentioned in %{resource_title}.
+          email_subject: You have been mentioned in %{resource_title}
+          notification_title: You have been mentioned in <a href="%{resource_path}">%{resource_title}</a> by <a href="%{author_path}">%{author_name} %{author_nickname}</a>
     metrics:
       comments:
-        object: komentar
-        title: Komentar
+        description: Number of Comments generated by users
+        object: comments
+        title: Comments
   errors:
     messages:
-      cannot_have_comments: tidak dapat memiliki komentar
+      cannot_have_comments: can't have comments

--- a/decidim-comments/config/locales/tr-TR.yml
+++ b/decidim-comments/config/locales/tr-TR.yml
@@ -1,99 +1,102 @@
-tr:
+---
+tr-TR:
   activemodel:
     models:
-      decidim/comments/comment_by_followed_user_event: Yorum Yap
-      decidim/comments/comment_created_event: Yorum Yap
-      decidim/comments/reply_created_event: Yorum cevabı
-      decidim/comments/user_mentioned_event: Anma
+      decidim/comments/comment_by_followed_user_event: Comment
+      decidim/comments/comment_created_event: Comment
+      decidim/comments/reply_created_event: Comment reply
+      decidim/comments/user_mentioned_event: Mention
   activerecord:
     models:
       decidim/comments/comment:
-        one: Yorum Yap
-        other: Yorumlar
+        one: Comment
+        other: Comments
       decidim/comments/comment_vote:
-        one: Oy
-        other: oy
+        one: Vote
+        other: Votes
   decidim:
     comments:
-      comments: Yorumlar
+      comments: Comments
       last_activity:
-        new_comment_at_html: "<span> %{link}</span>yeni yorum"
+        new_comment_at_html: "<span>New comment at %{link}</span>"
       votes:
         create:
-          error: Gönderi kaydedilirken hatalar oluştu.
+          error: There's been errors when voting the comment.
     components:
       add_comment_form:
-        account_message: <a href="%{sign_in_url}">Yorumunuzu eklemek için</a> veya <a href="%{sign_up_url}">hesabınızla giriş yapın</a>.
+        account_message: <a href="%{sign_in_url}">Sign in with your account</a> or <a href="%{sign_up_url}">sign up</a> to add your comment.
         form:
           body:
-            label: Yorum Yap
-            placeholder: Bunun hakkında ne düşünüyorsun?
-          form_error: Metin gereklidir ve %{length} karakterden uzun olamaz.
-          submit: göndermek
+            label: Comment
+            placeholder: What do you think about this?
+          form_error: The text is required and it can't be longer than %{length} characters.
+          submit: Send
           user_group_id:
-            label: Olarak yorum yap
+            label: Comment as
         opinion:
-          neutral: nötr
-        remaining_characters: "%{count} karakter kaldı"
-        remaining_characters_1: "%{count} karakter kaldı"
-        title: yorumunu ekle
+          neutral: Neutral
+        remaining_characters: "%{count} characters left"
+        remaining_characters_1: "%{count} character left"
+        title: Add your comment
       comment:
         alignment:
-          against: Karşısında
-          in_favor: Lehine
-        deleted_user: Silinmiş kullanıcı
-        reply: cevap
+          against: Against
+          in_favor: In favor
+        deleted_user: Deleted user
+        reply: Reply
         report:
-          action: Rapor
-          already_reported: Bu içerik zaten bildirildi ve bir yönetici tarafından incelenecek.
-          close: Kapat
-          description: Bu içerik uygunsuz mu?
-          details: Ek Yorumlar
+          action: Report
+          already_reported: This content is already reported and it will be reviewed by an admin.
+          close: Close
+          description: Is this content inappropriate?
+          details: Additional comments
           reasons:
-            does_not_belong: Yasadışı faaliyet, intihar tehditleri, kişisel bilgiler veya %{organization_name}ait olmadığını düşündüğünüz başka bir şey içerir.
-            offensive: Irkçılık, cinsiyetçilik, hakaretler, kişisel saldırılar, ölüm tehditleri, intihar talepleri veya herhangi bir nefret söylemi içerir.
-            spam: Clickbait, reklam, dolandırıcılık veya script botları içerir.
-          title: Sorun bildir
+            does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+            offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+            spam: Contains clickbait, advertising, scams or script bots.
+          title: Report a problem
       comment_order_selector:
         order:
-          best_rated: En çok oy alan
-          most_discussed: En çok tartışılan
-          older: Daha eski
-          recent: Son
-        title: 'Tarafından sipariş:'
+          best_rated: Best rated
+          most_discussed: Most discussed
+          older: Older
+          recent: Recent
+        title: 'Order by:'
       comment_thread:
-        title: '%{authorName}ile sohbet'
+        title: Conversation with %{authorName}
       comments:
-        blocked_comments_warning: Yorumlar şu anda devre dışı, ancak öncekileri okuyabilirsiniz.
-        loading: Yorumlar yükleniyor ...
-        title: "%{count} yorum"
+        blocked_comments_warning: Comments are disabled at this time, but you can read the previous ones.
+        loading: Loading comments ...
+        title: "%{count} comments"
+        title_0: There are no comments yet
+        title_1: "%{count} comment"
     events:
       comments:
         comment_by_followed_user:
-          email_intro: "%{author_name} , %{resource_title}yorum yaptı. Bu sayfada okuyabilirsiniz:"
-          email_outro: '%{author_name}takip ettiğiniz için bu bildirimi aldınız. Bu kullanıcıyı profil sayfasından takip edebilirsiniz.'
-          email_subject: '%{author_name} %{resource_title}tarafından yeni bir yorum var'
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> tarafından <a href="%{resource_path}">%{resource_title}</a>yeni bir yorum var.
+          email_intro: "%{author_name} has left a comment in %{resource_title}. You can read it in this page:"
+          email_outro: You have received this notification because you are following %{author_name}. You can unfollow this user from their profile page.
+          email_subject: There is a new comment by %{author_name} in %{resource_title}
+          notification_title: There is a new comment by <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>.
         comment_created:
-          email_intro: "%{resource_title} yorum yapıldı. Bu sayfadaki yorumu okuyabilirsiniz:"
-          email_outro: '"%{resource_title}" veya yazarı takip ettiğiniz için bu bildirimi aldınız. Bunu önceki linkten takip edebilirsiniz.'
-          email_subject: '%{author_name} %{resource_title}yeni bir yorum var'
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <a href="%{resource_path}">%{resource_title}</a>yeni bir yorum var
+          email_intro: "%{resource_title} has been commented. You can read the comment in this page:"
+          email_outro: You have received this notification because you are following "%{resource_title}" or its author. You can unfollow it from the previous link.
+          email_subject: There is a new comment from %{author_name} in %{resource_title}
+          notification_title: There is a new comment from <a href="%{author_path}">%{author_name} %{author_nickname}</a> in <a href="%{resource_path}">%{resource_title}</a>
         reply_created:
-          email_intro: "%{author_name} , yorumunuzu %{resource_title}yanıtladı. Bu sayfada okuyabilirsiniz:"
-          email_outro: Yorumunuz yanıtlandığı için bu bildirimi aldınız.
-          email_subject: "%{author_name} Yorumunuzu %{resource_title}yanıtladı."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <a href="%{resource_path}">%{resource_title}</a>yorumunuzu yanıtladı.
+          email_intro: "%{author_name} has replied your comment in %{resource_title}. You can read it in this page:"
+          email_outro: You have received this notification because your comment was replied.
+          email_subject: "%{author_name} has replied your comment in %{resource_title}"
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> has replied your comment in <a href="%{resource_path}">%{resource_title}</a>
         user_mentioned:
-          email_intro: Sen bahsettin
-          email_outro: Bu bildirimi, %{resource_title}belirtildiğiniz için aldınız.
-          email_subject: '%{resource_title}bahsettiniz'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> tarafından <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+          email_intro: You have been mentioned
+          email_outro: You have received this notification because you have been mentioned in %{resource_title}.
+          email_subject: You have been mentioned in %{resource_title}
+          notification_title: You have been mentioned in <a href="%{resource_path}">%{resource_title}</a> by <a href="%{author_path}">%{author_name} %{author_nickname}</a>
     metrics:
       comments:
-        description: Kullanıcılar tarafından oluşturulan Yorum Sayısı
-        object: yorumlar
-        title: Yorumlar
+        description: Number of Comments generated by users
+        object: comments
+        title: Comments
   errors:
     messages:
-      cannot_have_comments: yorum yapamam
+      cannot_have_comments: can't have comments

--- a/decidim-conferences/config/locales/ca.yml
+++ b/decidim-conferences/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ ca:
         votes_count: Vots
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: El registre de la conferència <a href="%{resource_url}">%{resource_title}</a> està pendent de confirmació.
         conference_registration_confirmed:
           notification_title: S'ha confirmat el teu registre a la conferència <a href="%{resource_url}">%{resource_title}</a>.
+        conference_registration_validation_pending:
+          notification_title: El registre de la conferència <a href="%{resource_url}">%{resource_title}</a> està pendent de confirmació.
         conference_registrations_over_percentage:
           email_intro: Les places ocupades per a la conferència "%{resource_title}" ocupen més del %{percentage}%.
           email_outro: Has rebut aquesta notificació perquè ets administrador de la conferència.

--- a/decidim-conferences/config/locales/de.yml
+++ b/decidim-conferences/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ de:
         votes_count: Stimmen
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Ihre Anmeldung für die Konferenz <a href="%{resource_url}">%{resource_title}</a> steht noch aus.
         conference_registration_confirmed:
           notification_title: Ihre Anmeldung für die Konferenz <a href="%{resource_url}">%{resource_title}</a> wurde bestätigt.
+        conference_registration_validation_pending:
+          notification_title: Ihre Anmeldung für die Konferenz <a href="%{resource_url}">%{resource_title}</a> steht noch aus.
         conference_registrations_over_percentage:
           email_intro: Die "%{resource_title}" Konferenz belegt Slots sind über %{percentage}%.
           email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Administrator des Teilnahmebereichs der Konferenz sind.

--- a/decidim-conferences/config/locales/es-PY.yml
+++ b/decidim-conferences/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -475,8 +476,8 @@ es-PY:
           title: Tipos de inscripción
       shared:
         conference_user_login:
-          already_account: '¿Ya tienes una cuenta en decidim?'
-          new_user: '¿Nuevo usuario?'
+          already_account: "¿Ya tienes una cuenta en decidim?"
+          new_user: "¿Nuevo usuario?"
           sign_in: Inicie sesión para registrarse para la conferencia
           sign_up: Crear una cuenta en decidim para registrarse para la conferencia
       show:
@@ -505,10 +506,10 @@ es-PY:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Su inscripción para la conferencia <a href="%{resource_url}">%{resource_title}</a> está pendiente de confirmación.
         conference_registration_confirmed:
           notification_title: Su registro para la conferencia <a href="%{resource_url}">%{resource_title}</a> ha sido confirmado.
+        conference_registration_validation_pending:
+          notification_title: Su inscripción para la conferencia <a href="%{resource_url}">%{resource_title}</a> está pendiente de confirmación.
         conference_registrations_over_percentage:
           email_intro: Las ranuras ocupadas por la conferencia "%{resource_title}" superan el %{percentage}%.
           email_outro: Recibió esta notificación porque usted es administrador del espacio participativo de la conferencia.
@@ -527,7 +528,7 @@ es-PY:
         upcoming_conference:
           email_intro: 'La conferencia "%{resource_title}" se lleva a cabo en 2 días. Puedes leer la descripción de su página:'
           email_outro: Ha recibido esta notificación porque está siguiendo la conferencia "%{resource_title}". Puedes dejar de seguirlo desde el enlace anterior.
-          email_subject: '¡Se acerca la conferencia "%{resource_title}"!'
+          email_subject: ¡Se acerca la conferencia "%{resource_title}"!
           notification_title: La conferencia <a href="%{resource_path}">%{resource_title}</a> llegará en 2 días.
     log:
       value_types:

--- a/decidim-conferences/config/locales/es.yml
+++ b/decidim-conferences/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -475,8 +476,8 @@ es:
           title: Tipos de inscripción
       shared:
         conference_user_login:
-          already_account: '¿Ya tienes una cuenta en decidim?'
-          new_user: '¿Eres nuevo?'
+          already_account: "¿Ya tienes una cuenta en decidim?"
+          new_user: "¿Eres nuevo?"
           sign_in: Inicia sesión para inscribirte en la conferencia
           sign_up: Crea una cuenta de usuario para inscribirte en la conferencia
       show:
@@ -505,10 +506,10 @@ es:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Tu inscripción en la jornada <a href="%{resource_url}">%{resource_title}</a> está pendiente de confirmación.
         conference_registration_confirmed:
           notification_title: Se ha confirmado tu inscripción en la jornada <a href="%{resource_url}">%{resource_title}</a>.
+        conference_registration_validation_pending:
+          notification_title: Tu inscripción en la jornada <a href="%{resource_url}">%{resource_title}</a> está pendiente de confirmación.
         conference_registrations_over_percentage:
           email_intro: Las plazas ocupadas para la conferencia "%{resource_title}" superan el %{percentage}%.
           email_outro: Recibes esta notificación porque eres administrador del espacio participativo de la conferencia.
@@ -527,7 +528,7 @@ es:
         upcoming_conference:
           email_intro: 'La jornada "%{resource_title}" tendrá lugar dentro de 2 días. Puedes leer la descripción desde su página:'
           email_outro: Has recibido esta notificación porque estás siguiendo la jornada "%{resource_title}". Puedes dejar de seguirla desde el enlace anterior.
-          email_subject: '¡Se acerca la jornada "%{resource_title}"!'
+          email_subject: ¡Se acerca la jornada "%{resource_title}"!
           notification_title: La jornada <a href="%{resource_path}">%{resource_title}</a> se realizará dentro de 2 días.
     log:
       value_types:

--- a/decidim-conferences/config/locales/eu.yml
+++ b/decidim-conferences/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -339,7 +340,7 @@ eu:
           invite:
             decline: Baztertu gonbidapena '%{conference_title}'
             invited_you_to_join_a_conference: "%{invited_by} gonbidatu zaitu hitzaldi batean %{application}. Beheko esteken bidez baztertu edo onartu dezakezu."
-            registration: '''%{conference_title}'' izen-ematea'
+            registration: "'%{conference_title}' izen-ematea"
         partners:
           index:
             title: Bazkideak
@@ -379,7 +380,7 @@ eu:
       conference_registration_mailer:
         confirmation:
           confirmed_html: Zure hitzaldirako izena emateko <a href="%{url}">%{title}</a> baieztatu da.
-          details_1: '%{registration_type} motako hitzaldian erregistratuta zaude. %{price} kostua dauka eta ondorengo ekitaldietara jo dezakezu:'
+          details_1: "%{registration_type} motako hitzaldian erregistratuta zaude. %{price} kostua dauka eta ondorengo ekitaldietara jo dezakezu:"
           details_2: Biltzarraren xehetasunak eranskinean aurkituko dituzu.
         pending_validation:
           confirmation_pending: Berrespena jasoko duzu laster
@@ -414,7 +415,7 @@ eu:
           collaborators: Bazkideak
           main_promotors: Antolatzaileak
         show:
-          login_as: '%{name} <%{email}> gisa erregistratuta zaude'
+          login_as: "%{name} <%{email}> gisa erregistratuta zaude"
           make_conference_registration: 'Egin zure izen ematea hitzaldian:'
           register: Eman izena
       content_blocks:
@@ -470,7 +471,7 @@ eu:
       registration_types:
         index:
           choose_an_option: 'Aukeratu zure erregistro-aukera:'
-          login_as: '%{name} <%{email}> gisa erregistratuta zaude'
+          login_as: "%{name} <%{email}> gisa erregistratuta zaude"
           register: Eman izena
           title: Izen-emate motak
       shared:
@@ -505,10 +506,10 @@ eu:
         votes_count: Botoak
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Zure hitzaldirako izena emateko <a href="%{resource_url}">%{resource_title}</a> zain dago berresteko.
         conference_registration_confirmed:
           notification_title: Zure hitzaldirako izena emateko <a href="%{resource_url}">%{resource_title}</a> baieztatu da.
+        conference_registration_validation_pending:
+          notification_title: Zure hitzaldirako izena emateko <a href="%{resource_url}">%{resource_title}</a> zain dago berresteko.
         conference_registrations_over_percentage:
           email_intro: Biltzarra "%{resource_title}" okupatutako slotak% %{percentage}baino gehiago dira.
           email_outro: Jakinarazpen hau jaso duzu, hitzaldiko parte hartzaileen gunea delako.

--- a/decidim-conferences/config/locales/fi-pl.yml
+++ b/decidim-conferences/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ fi-pl:
         votes_count: Ääniä
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> odottaa vahvistusta.
         conference_registration_confirmed:
           notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> on vahvistettu.
+        conference_registration_validation_pending:
+          notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> odottaa vahvistusta.
         conference_registrations_over_percentage:
           email_intro: '"%{resource_title}" -konferenssista on varattu yli %{percentage}% vapaista paikoista.'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet konferenssin osallisuustilan hallinnoija.

--- a/decidim-conferences/config/locales/fi.yml
+++ b/decidim-conferences/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ fi:
         votes_count: Ääntä
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> odottaa vahvistusta.
         conference_registration_confirmed:
           notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> on vahvistettu.
+        conference_registration_validation_pending:
+          notification_title: Ilmoittautumisesi konferenssiin <a href="%{resource_url}">%{resource_title}</a> odottaa vahvistusta.
         conference_registrations_over_percentage:
           email_intro: '"%{resource_title}" -konferenssista on varattu yli %{percentage}% vapaista paikoista.'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet konferenssin osallisuustilan hallinnoija.

--- a/decidim-conferences/config/locales/fr.yml
+++ b/decidim-conferences/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:

--- a/decidim-conferences/config/locales/gl.yml
+++ b/decidim-conferences/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ gl:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: O teu rexistro para a conferencia <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registration_confirmed:
           notification_title: Inscríbase o rexistro da conferencia <a href="%{resource_url}">%{resource_title}</a>.
+        conference_registration_validation_pending:
+          notification_title: O teu rexistro para a conferencia <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registrations_over_percentage:
           email_intro: Os slots ocupados por "%{resource_title}" ocupan máis do %{percentage}%.
           email_outro: Recibiches esta notificación porque es administrador do espazo participativo da conferencia.

--- a/decidim-conferences/config/locales/hu.yml
+++ b/decidim-conferences/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -329,7 +330,7 @@ hu:
             available_slots_help: Hagyja 0-ra, ha van korlátlan slot.
             registrations_count:
               one: 1 regisztráció volt.
-              other: '%{count} regisztráció volt.'
+              other: "%{count} regisztráció volt."
             slug_help: 'Az URL-csigákat használják az e konferenciára utaló URL-ek előállításához. Csak leveleket, számokat és kötőjeleket fogad el, és betűvel kell kezdenie. Példa: %{url}'
         diplomas:
           edit:
@@ -414,7 +415,7 @@ hu:
           collaborators: Partnerek
           main_promotors: Szervezők
         show:
-          login_as: '%{name} <%{email}> -ként jelentkeztél be'
+          login_as: "%{name} <%{email}> -ként jelentkeztél be"
           make_conference_registration: 'Regisztráljon a konferencián:'
           register: Regisztráció
       content_blocks:
@@ -470,7 +471,7 @@ hu:
       registration_types:
         index:
           choose_an_option: 'Válassza ki a regisztrációs lehetőséget:'
-          login_as: '%{name} <%{email}> -ként jelentkezett be'
+          login_as: "%{name} <%{email}> -ként jelentkezett be"
           register: Regisztráció
           title: Regisztrációs típusok
       shared:
@@ -505,10 +506,10 @@ hu:
         votes_count: szavazatok
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: A <a href="%{resource_url}">%{resource_title}</a> konferencijára történt regisztrációd függőben van.
         conference_registration_confirmed:
           notification_title: A <a href="%{resource_url}">%{resource_title}</a> konferencia regisztrációd megerősítést nyert.
+        conference_registration_validation_pending:
+          notification_title: A <a href="%{resource_url}">%{resource_title}</a> konferencijára történt regisztrációd függőben van.
         conference_registrations_over_percentage:
           email_intro: A "%{resource_title}" konferencia foglalt rések több mint %{percentage}%.
           email_outro: Ezt az értesítést megkaptuk, mert Ön a konferencia részvételi helyének adminisztrátora.

--- a/decidim-conferences/config/locales/id-ID.yml
+++ b/decidim-conferences/config/locales/id-ID.yml
@@ -1,565 +1,571 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       conference:
-        assemblies_ids: Rakitan Terkait
-        banner_image: Gambar spanduk
-        consultations_ids: Konsultasi Terkait
-        copy_categories: Salin kategori
-        copy_components: Salin komponen
-        copy_features: Salin fitur
-        decidim_scope_id: Cakupan
-        description: Deskripsi
-        hashtag: Tanda pagar
-        hero_image: Gambar rumah
-        participatory_processes_ids: Proses Partisipatif Terkait
-        promoted: Dipromosikan
-        published_at: Diterbitkan di
-        scope_id: Cakupan
-        scopes_enabled: Lingkup diaktifkan
-        short_description: Deskripsi Singkat
-        show_statistics: Tampilkan statistik
+        assemblies_ids: Related Assemblies
+        banner_image: Banner image
+        consultations_ids: Related Consultations
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_features: Copy features
+        decidim_scope_id: Scope
+        description: Description
+        hashtag: Hashtag
+        hero_image: Home image
+        participatory_processes_ids: Related Participatory processes
+        promoted: Promoted
+        published_at: Published at
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
         slogan: Slogan
-        slug: Siput URL
-        title: Judul
+        slug: URL slug
+        title: Title
       conference_speaker:
-        full_name: Nama lengkap
+        full_name: Full name
       conference_user_role:
-        email: E-mail
-        name: Nama
-        role: Peran
+        email: Email
+        name: Name
+        role: Role
     errors:
       models:
         conference_registration_invite:
           attributes:
             email:
-              already_invited: Email ini sudah diundang
+              already_invited: This email has already been invited
   activerecord:
     models:
       decidim/conference:
-        other: Konferensi
+        one: Conference
+        other: Conferences
       decidim/conference_speaker:
-        other: Pembicara konferensi
+        one: Conference speaker
+        other: Conference speakers
       decidim/conference_user_role:
-        other: Peran pengguna konferensi
+        one: Conference user role
+        other: Conference user roles
   decidim:
     admin:
       actions:
-        confirm: Memastikan
-        new_conference: Konferensi Baru
-        send_diplomas: Kirim sertifikat kehadiran
+        confirm: Confirm
+        new_conference: New Conference
+        send_diplomas: Send certificates of attendance
       conference_copies:
         new:
-          copy: Salinan
-          select: Pilih data mana yang ingin Anda gandakan
-          title: Konferensi duplikat
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate conference
       conference_publications:
         create:
-          error: Terjadi kesalahan saat mempublikasikan konferensi ini.
-          success: Konferensi berhasil diterbitkan.
+          error: There was an error publishing this conference.
+          success: Conference published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi konferensi ini.
-          success: Konferensi tidak berhasil diterbitkan.
+          error: There was an error unpublishing this conference.
+          success: Conference unpublished successfully.
       conference_registration:
         confirm:
-          error: Ada kesalahan saat mengonfirmasi pendaftaran konferensi ini.
-          success: Pendaftaran konferensi dikonfirmasi berhasil.
+          error: There was an error when confirm this conference registration.
+          success: Conference registration confirmed successfully.
       conference_speakers:
         create:
-          error: Terjadi kesalahan saat menambahkan pembicara untuk konferensi ini.
-          success: Pembicara berhasil dibuat untuk konferensi ini.
+          error: There was an error adding a speaker for this conference.
+          success: Speaker created successfully for this conference.
         destroy:
-          success: Pembicara berhasil dihapus untuk konferensi ini.
+          success: Speaker deleted successfully for this conference.
         edit:
-          title: Perbarui pembicara konferensi.
-          update: Memperbarui
+          title: Update conference speaker.
+          update: Update
         index:
-          conference_speakers_title: Pembicara konferensi
+          conference_speakers_title: Conference speakers
         new:
-          create: Membuat
-          title: Pembicara konferensi baru.
+          create: Create
+          title: New conference speaker.
         update:
-          error: Terjadi kesalahan saat memperbarui pembicara untuk konferensi ini.
-          success: Pembicara berhasil diperbarui untuk konferensi ini.
+          error: There was an error updating the speaker for this conference.
+          success: Speaker updated successfully for this conference.
       conference_user_roles:
         create:
-          error: Terjadi kesalahan saat menambahkan pengguna untuk konferensi ini.
-          success: Pengguna berhasil ditambahkan ke konferensi ini.
+          error: There was an error adding a user for this conference.
+          success: User added successfully to this conference.
         destroy:
-          success: Pengguna berhasil dihapus dari konferensi ini.
+          success: User removed successfully from this conference.
         edit:
-          title: Perbarui pengguna konferensi.
-          update: Memperbarui
+          title: Update conference user.
+          update: Update
         index:
-          conference_admins_title: pengguna konferensi
+          conference_admins_title: conference users
         new:
-          create: Membuat
-          title: Pengguna konferensi baru.
+          create: Create
+          title: New conference user.
         update:
-          error: Terjadi kesalahan saat memperbarui pengguna untuk konferensi ini.
-          success: Pengguna berhasil diperbarui untuk konferensi ini.
+          error: There was an error updated a user for this conference.
+          success: User updated successfully for this conference.
       conferences:
         create:
-          error: Terjadi kesalahan saat membuat konferensi baru.
-          success: Konferensi berhasil dibuat.
+          error: There was an error creating a new conference.
+          success: Conference created successfully.
         edit:
-          update: Memperbarui
+          update: Update
         exports:
-          registrations: Pendaftaran
+          registrations: Registrations
         form:
-          title: Informasi Umum
+          title: General Information
         index:
-          not_published: Tidak diterbitkan
-          published: Diterbitkan
+          not_published: Not published
+          published: Published
         new:
-          create: Membuat
-          title: Konferensi
+          create: Create
+          title: Conference
         update:
-          error: Ada kesalahan saat memperbarui konferensi ini.
-          success: Konferensi berhasil diperbarui.
+          error: There was an error when updating this conference.
+          success: Conference updated successfully.
       conferences_copies:
         create:
-          error: Ada kesalahan saat menduplikasi konferensi ini.
-          success: Konferensi berhasil digandakan.
+          error: There was an error when duplicating this conference.
+          success: Conference duplicated successfully.
       media_links:
         create:
-          error: Terjadi kesalahan saat membuat tautan media baru.
-          success: Media Link berhasil dibuat.
+          error: There was an error creating a new media link.
+          success: Media Link created successfully.
         destroy:
-          success: Tautan Media berhasil dihapus.
+          success: Media Link deleted successfully.
         edit:
-          title: Perbarui tautan media.
-          update: Memperbarui
+          title: Update media link.
+          update: Update
         index:
-          media_links_title: Tautan Media
+          media_links_title: Media Links
         new:
-          create: Membuat
-          title: Tautan Media
+          create: Create
+          title: Media Link
         update:
-          error: Terjadi kesalahan saat memperbarui tautan media ini.
-          success: Media Link berhasil diperbarui.
+          error: There was an error when updating this media link.
+          success: Media Link updated successfully.
       menu:
-        conferences: Konferensi
+        conferences: Conferences
         conferences_submenu:
-          attachment_collections: Folder
-          attachment_files: File
-          attachments: Lampiran
-          categories: Kategori
-          components: Komponen
-          conference_admins: Pengguna konferensi
-          conference_invites: Undangan
-          conference_speakers: Pembicara
-          diploma: Sertifikat kehadiran
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
+          conference_admins: Conference users
+          conference_invites: Invites
+          conference_speakers: Speakers
+          diploma: Certificate of Attendance
           info: Info
-          media_links: Tautan Media
-          moderations: Moderasi
-          partners: Mitra
-          registration_types: Jenis Pendaftaran
-          registrations: Pendaftaran
-          user_registrations: Registrasi Pengguna
+          media_links: Media Links
+          moderations: Moderations
+          partners: Partners
+          registration_types: Registration Types
+          registrations: Registrations
+          user_registrations: User Registrations
       models:
         conference:
           fields:
-            created_at: Dibuat di
-            promoted: Dipromosikan
-            published: Diterbitkan
-            title: Judul
+            created_at: Created at
+            promoted: Promoted
+            published: Published
+            title: Title
         conference_speaker:
           fields:
-            affiliation: Afiliasi
-            full_name: Nama lengkap
-            position: Posisi
-          name: Pembicara Konferensi
+            affiliation: Affiliation
+            full_name: Full name
+            position: Position
+          name: Conference Speaker
         conference_user_role:
           fields:
-            email: E-mail
-            name: Nama
-            role: Peran
-          name: Pengguna Konferensi
+            email: Email
+            name: Name
+            role: Role
+          name: Conference User
           roles:
             admin: Administrator
-            collaborator: Kolaborator
+            collaborator: Collaborator
             moderator: Moderator
         media_link:
           fields:
-            date: Tanggal
+            date: Date
             link: Link
-            title: Judul
-          name: Tautan Media
+            title: Title
+          name: Media Link
         partner:
           fields:
             link: Link
             logo: Logo
-            name: Nama
-            partner_type: Mengetik
-          name: Pasangan
+            name: Name
+            partner_type: Type
+          name: Partner
           types:
-            collaborator: Kolaborator
-            main_promotor: Promotor utama
+            collaborator: Collaborator
+            main_promotor: Main promotor
         registration_type:
           fields:
-            conference_meetings: Pertemuan konferensi
-            price: Harga
-            registrations_count: Jumlah registrasi
-            title: Judul
-            weight: Berat
-          name: Jenis pendaftaran
+            conference_meetings: Conference meetings
+            price: Price
+            registrations_count: Registrations count
+            title: Title
+            weight: Weight
+          name: Registration type
       partners:
         create:
-          error: Terjadi kesalahan saat menambahkan mitra untuk konferensi ini.
-          success: Mitra berhasil ditambahkan ke konferensi ini.
+          error: There was an error adding a partner for this conference.
+          success: Partner added successfully to this conference.
         destroy:
-          success: Mitra berhasil dihapus dari konferensi ini.
+          success: Partner removed successfully from this conference.
         edit:
-          title: Perbarui mitra.
-          update: Memperbarui
+          title: Update partner.
+          update: Update
         new:
-          create: Membuat
-          title: Mitra baru
+          create: Create
+          title: New partner
         update:
-          error: Terjadi kesalahan saat memperbarui mitra untuk konferensi ini.
-          success: Mitra berhasil diperbarui untuk konferensi ini.
+          error: There was an error updated a partner for this conference.
+          success: Partner updated successfully for this conference.
       registration_type_publications:
         create:
-          error: Terjadi kesalahan saat memublikasikan jenis pendaftaran ini.
-          success: Jenis pendaftaran berhasil diterbitkan.
+          error: There was an error publishing this registration type.
+          success: Registration type published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi jenis pendaftaran ini.
-          success: Jenis pendaftaran tidak berhasil diterbitkan.
+          error: There was an error unpublishing this registration type.
+          success: Registration type unpublished successfully.
       registration_types:
         create:
-          error: Terjadi kesalahan saat menambahkan jenis pendaftaran untuk konferensi ini.
-          success: Jenis pendaftaran berhasil ditambahkan ke konferensi ini.
+          error: There was an error adding a registration type for this conference.
+          success: Registration type added successfully to this conference.
         destroy:
-          success: Jenis pendaftaran berhasil dihapus dari konferensi ini.
+          success: Registration type removed successfully from this conference.
         edit:
-          title: Perbarui jenis pendaftaran.
-          update: Memperbarui
+          title: Update registration type.
+          update: Update
         new:
-          create: Membuat
-          title: Jenis pendaftaran baru
+          create: Create
+          title: New registration type
         update:
-          error: Terjadi kesalahan saat memperbarui jenis pendaftaran untuk konferensi ini.
-          success: Jenis pendaftaran berhasil diperbarui untuk konferensi ini.
+          error: There was an error updated a registration type for this conference.
+          success: Registration type updated successfully for this conference.
       titles:
-        conferences: Konferensi
+        conferences: Conferences
     admin_log:
       conference:
-        create: "%{user_name} menciptakan konferensi %{resource_name}"
-        publish: "%{user_name} mempublikasikan %{resource_name} konferensi"
-        send_conference_diplomas: "%{user_name} mengirimkan sertifikat kehadiran ke %{resource_name} peserta konferensi"
-        unpublish: "%{user_name} tidak menerbitkan %{resource_name} konferensi"
-        update: "%{user_name} memperbarui %{resource_name} konferensi"
-        update_diploma: "%{user_name} memperbarui sertifikat konfigurasi kehadiran untuk %{resource_name} konferensi"
+        create: "%{user_name} created the %{resource_name} conference"
+        publish: "%{user_name} published the %{resource_name} conference"
+        send_conference_diplomas: "%{user_name} sent certificates of attendance to the %{resource_name} conference atendees"
+        unpublish: "%{user_name} unpublished the %{resource_name} conference"
+        update: "%{user_name} updated the %{resource_name} conference"
+        update_diploma: "%{user_name} updated the certificates of attendance configuration for %{resource_name} conference"
       conference_speaker:
-        create: "%{user_name} menciptakan %{resource_name} pembicara dalam %{space_name} konferensi"
-        delete: "%{user_name} menghapus %{resource_name} pembicara dari %{space_name} konferensi"
-        update: "%{user_name} memperbarui %{resource_name} pembicara di konferensi %{space_name}"
+        create: "%{user_name} created the %{resource_name} speaker in the %{space_name} conference"
+        delete: "%{user_name} removed the %{resource_name} speaker from the %{space_name} conference"
+        update: "%{user_name} updated the %{resource_name} speaker in the %{space_name} conference"
       conference_user_role:
-        create: "%{user_name} diundang %{resource_name} ke %{space_name} konferensi"
-        delete: "%{user_name} menghapus pengguna %{resource_name} dari %{space_name} konferensi"
-        update: "%{user_name} mengubah peran %{resource_name} dalam %{space_name} konferensi"
+        create: "%{user_name} invited %{resource_name} to the %{space_name} conference"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} conference"
+        update: "%{user_name} changed the role of %{resource_name} in the %{space_name} conference"
       conferences:
         conference_registration:
-          confirm: "%{user_name} mengkonfirmasi pendaftaran konferensi dalam %{resource_name} konferensi"
+          confirm: "%{user_name} confirmed a conference registration in %{resource_name} conference"
         partner:
-          create: "%{user_name} dibuat %{resource_name} ke %{space_name} konferensi"
-          delete: "%{user_name} menghapus pengguna %{resource_name} dari %{space_name} konferensi"
-          update: "%{user_name} diperbarui %{resource_name} di %{space_name} konferensi"
+          create: "%{user_name} created %{resource_name} to the %{space_name} conference"
+          delete: "%{user_name} removed the user %{resource_name} from the %{space_name} conference"
+          update: "%{user_name} updated %{resource_name} in the %{space_name} conference"
         registration_type:
-          create: "%{user_name} menciptakan tipe %{resource_name} pendaftaran dalam %{space_name} konferensi"
-          publish: "%{user_name} menerbitkan %{resource_name} tipe pendaftaran dalam %{space_name} konferensi"
-          unpublish: "%{user_name} tidak menerbitkan %{resource_name} jenis pendaftaran dalam %{space_name} konferensi"
-          update: "%{user_name} memperbarui %{resource_name} tipe registrasi di %{space_name} konferensi"
+          create: "%{user_name} created the %{resource_name} registration type in the %{space_name} conference"
+          publish: "%{user_name} published the %{resource_name} registration type in the %{space_name} conference"
+          unpublish: "%{user_name} unpublished the %{resource_name} registration type in the %{space_name} conference"
+          update: "%{user_name} updated the %{resource_name} registration type in the %{space_name} conference"
       media_link:
-        create: "%{user_name} membuat tautan %{resource_name} media di %{space_name} konferensi"
-        delete: "%{user_name} menghapus %{resource_name} tautan media dari %{space_name} konferensi"
-        update: "%{user_name} memperbarui %{resource_name} tautan media dalam %{space_name} konferensi"
+        create: "%{user_name} created the %{resource_name} media link in the %{space_name} conference"
+        delete: "%{user_name} removed the %{resource_name} media link from the %{space_name} conference"
+        update: "%{user_name} updated the %{resource_name} media link in the %{space_name} conference"
     conference_program:
       index:
         title: Program
     conference_speakers:
       index:
-        title: Pembicara
+        title: Speakers
     conferences:
       admin:
         conference_copies:
           form:
-            slug_help: 'Siput URL digunakan untuk menghasilkan URL yang mengarah ke konferensi ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         conference_invites:
           create:
-            error: Ada masalah saat mengundang pengguna untuk bergabung dengan konferensi.
-            success: Pengguna berhasil diundang untuk bergabung dengan konferensi.
+            error: There's been a problem while inviting the user to join the conference.
+            success: User successfully invited to join the conference.
           form:
-            attendee_type: Tipe penerima tamu
-            existing_user: Pengguna yang sudah ada
-            invite_explanation: Pengguna akan diundang untuk bergabung dengan konferensi dan ke organisasi juga.
-            non_user: Pengguna tidak ada
-            select_user: Pilih pengguna
+            attendee_type: Attendee type
+            existing_user: Existing user
+            invite_explanation: The user will be invited to join the conference and to the organization as well.
+            non_user: Non existing user
+            select_user: Select user
           index:
             filter:
-              accepted: Diterima
-              all: Semua
-              rejected: Ditolak
-              sent: Terkirim
-            filter_by: Filter berdasarkan
-            invite_attendee: Undang Peserta
-            invites: Undangan
-            search: Pencarian
+              accepted: Accepted
+              all: All
+              rejected: Rejected
+              sent: Sent
+            filter_by: Filter by
+            invite_attendee: Invite Attendee
+            invites: Invites
+            search: Search
           new:
-            explanation: Pengguna akan diundang untuk bergabung dengan konferensi. Jika email tidak terdaftar mereka akan diundang ke organisasi juga.
-            invite: Undang
-            new_invite: Undang pengguna
+            explanation: The user will be invited to join a conference. If the email is not registered they will be invited to the organization as well.
+            invite: Invite
+            new_invite: Invite user
         conference_registrations:
           index:
-            registrations: Pendaftaran
+            registrations: Registrations
         conference_speakers:
           form:
-            existing_user: Pengguna yang sudah ada
-            non_user: Non-pengguna
-            select_user: Pilih pengguna
-            user_type: Tipe Pengguna
+            existing_user: Existing user
+            non_user: Non user
+            select_user: Select user
+            user_type: User type
           index:
-            search: Pencarian
+            search: Search
         conferences:
           form:
-            available_slots_help: Biarkan hingga 0 jika Anda memiliki slot tidak terbatas.
+            available_slots_help: Leave it to 0 if you have unlimited slots available.
             registrations_count:
-              other: Ada %{count} pendaftaran.
-            slug_help: 'Siput URL digunakan untuk menghasilkan URL yang mengarah ke konferensi ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
+              one: There has been 1 registration.
+              other: There has been %{count} registrations.
+            slug_help: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         diplomas:
           edit:
-            save: Menyimpan
-            title: Sertifikat kehadiran
+            save: Save
+            title: Certificate of Attendance
         invite_join_conference_mailer:
           invite:
-            decline: Tolak undangan '%{conference_title}'
-            invited_you_to_join_a_conference: "%{invited_by} telah mengundang Anda untuk bergabung dalam konferensi di %{application}. Anda dapat menolak atau menerimanya melalui tautan di bawah ini."
-            registration: Registrasi untuk '%{conference_title}'
+            decline: Decline invitation '%{conference_title}'
+            invited_you_to_join_a_conference: "%{invited_by} has invited you to join a conference at %{application}. You can decline or accept it through the links below."
+            registration: Registration for '%{conference_title}'
         partners:
           index:
-            title: Mitra
+            title: Partners
         registration_types:
           form:
-            select_conference_meetings: Pilih pertemuan konferensi
+            select_conference_meetings: Select conference meetings
           index:
-            title: Jenis pendaftaran
+            title: Registration types
         send_conference_diploma_mailer:
           diploma:
-            diploma_html: Anda akan menemukan sertifikat kehadiran untuk konferensi <a href="%{url}">%{title}</a> di lampiran.
+            diploma_html: You will be find the certificate of attendance for the conference <a href="%{url}">%{title}</a> in the attachments.
           diploma_user:
-            attendance_verified_by: Kehadiran diverifikasi oleh
-            certificate_of_attendance: Sertifikat kehadiran
-            certificate_of_attendance_description: Ini untuk menyatakan bahwa <strong>%{user}</strong> telah hadir dan mengambil bagian dalam <strong>%{title}</strong> diadakan pada <strong>%{location}</strong> pada <strong>%{start} - %{end}</strong>
+            attendance_verified_by: Attendance verified by
+            certificate_of_attendance: Certificate of Attendance
+            certificate_of_attendance_description: This is to certify that <strong>%{user}</strong> has attended and taken part in the <strong>%{title}</strong> held at the <strong>%{location}</strong> on <strong>%{start} - %{end}</strong>
         send_diploma:
-          error: Ada masalah saat mengirim diploma konferensi.
-          success: Konferensi Diploma dikirim dengan benar
+          error: There's been a problem while sending the conference certificates of attendance.
+          success: Conference certificates of attendance sent correctly
       conference:
         registration_confirm:
-          cancel: Membatalkan
-          confirm: Memastikan
+          cancel: Cancel
+          confirm: Confirm
         show:
-          free: Bebas
-          going: Pergi
-          no_slots_available: Tidak ada slot yang tersedia
-          registration: Pendaftaran
+          free: Free
+          going: Going
+          no_slots_available: No slots available
+          registration: Registration
       conference_program:
         program_meeting:
-          content: Konten
-          location: Lokasi
-          speakers: Pembicara
+          content: Content
+          location: Location
+          speakers: Speakers
           streaming: Streaming
         show:
-          day: Hari
+          day: Day
           program: Program
       conference_registration_mailer:
         confirmation:
-          confirmed_html: Pendaftaran Anda untuk konferensi <a href="%{url}">%{title}</a> telah dikonfirmasi.
-          details_1: 'Anda terdaftar di konferensi dengan %{registration_type} jenis. Ini memiliki biaya %{price} dan Anda dapat menghadiri acara-acara berikut:'
-          details_2: Anda akan menemukan rincian konferensi dalam lampiran.
+          confirmed_html: Your registration for the conference <a href="%{url}">%{title}</a> has been confirmed.
+          details_1: 'You are registered to the conference with %{registration_type} type. It has a cost of %{price} and you can attend to the following events:'
+          details_2: You will find the conference's details in the attachment.
         pending_validation:
-          confirmation_pending: Anda akan menerima konfirmasi segera
-          details: 'Anda telah mendaftar ke %{registration_type} jenis dengan biaya %{price} dan Anda dapat menghadiri acara-acara berikut:'
-          pending_html: Pendaftaran Anda untuk konferensi <a href="%{url}">%{title}</a> masih menunggu untuk dikonfirmasi.
+          confirmation_pending: You will receive the confirmation shortly
+          details: 'You have registered to %{registration_type} type with a cost of %{price} and you can attend to the following events:'
+          pending_html: Your registration for the conference <a href="%{url}">%{title}</a> is pending to be confirmed.
       conference_registrations:
         create:
-          invalid: Ada masalah saat bergabung dengan konferensi ini.
-          success: Anda telah berhasil mengikuti konferensi.
+          invalid: There's been a problem joining this conference.
+          success: You have joined the conference successfully.
         decline_invitation:
-          invalid: Terjadi masalah saat menolak undangan.
-          success: Anda berhasil menolak undangan.
+          invalid: There's been a problem declining the invitation.
+          success: You have declined the invitation successfully.
         destroy:
-          invalid: Ada masalah saat meninggalkan konferensi ini.
-          success: Anda telah meninggalkan konferensi dengan sukses.
+          invalid: There's been a problem leaving this conference.
+          success: You have left the conference successfully.
       conference_speaker:
-        go_to_twitter: Pergi ke Twitter
-        more_info: Info lebih lanjut
-        personal_website: Situs web pribadi
+        go_to_twitter: Go to Twitter
+        more_info: more info
+        personal_website: Personal website
         show:
-          more_info: Info lebih lanjut
+          more_info: more info
       conference_speaker_cell:
         personal_url:
-          personal_website: Situs web pribadi
+          personal_website: Personal website
         twitter_handle:
-          go_to_twitter: Pergi ke Twitter
+          go_to_twitter: Go to Twitter
       conference_speakers:
         index:
-          speakers: Pembicara
+          speakers: Speakers
       conferences:
         partners:
-          collaborators: Mitra
-          main_promotors: Penyelenggara
+          collaborators: Partners
+          main_promotors: Organizers
         show:
-          login_as: Anda masuk sebagai %{name} <%{email}>
-          make_conference_registration: 'Buat pendaftaran Anda di konferensi:'
-          register: Daftar
+          login_as: You are logged in as %{name} <%{email}>
+          make_conference_registration: 'Make your registration in the conference:'
+          register: Register
       content_blocks:
         highlighted_conferences:
-          name: Konferensi yang disorot
+          name: Highlighted conferences
       index:
-        title: Konferensi
+        title: Conferences
       mailer:
         conference_registration_mailer:
           confirmation:
-            subject: Pendaftaran konferensi Anda telah dikonfirmasi
+            subject: Your conference's registration has been confirmed
           pending_validation:
-            subject: Pendaftaran konferensi Anda sedang menunggu untuk dikonfirmasi
+            subject: Your conference's registration is pending to be confirmed
         invite_join_conference_mailer:
           invite:
-            subject: Undangan untuk bergabung dalam konferensi
+            subject: Invitation to join a conference
         send_conference_diploma_mailer:
           diploma:
-            subject: Sertifikat kehadiran konferensi Anda telah dikirim
+            subject: Your conference certificate of attendance has been sent
       models:
         conference_invite:
           fields:
-            email: E-mail
-            name: Nama
-            registration_type: Jenis pendaftaran
-            sent_at: Dikirim pada
+            email: Email
+            name: Name
+            registration_type: Registration type
+            sent_at: Sent at
             status: Status
           status:
-            accepted: Diterima (%{at})
-            rejected: Ditolak (%{at})
-            sent: Terkirim
+            accepted: Accepted (%{at})
+            rejected: Rejected (%{at})
+            sent: Sent
         conference_registration:
           fields:
-            email: E-mail
-            name: Nama
-            registration_type: Jenis pendaftaran
-            state: Negara
+            email: Email
+            name: Name
+            registration_type: Registration type
+            state: State
             states:
-              confirmed: Dikonfirmasi
-              pending: Menunggu keputusan
+              confirmed: Confirmed
+              pending: Pending
       pages:
         home:
           highlighted_conferences:
-            active_conferences: Konferensi aktif
-            see_all_conferences: Lihat semua konferensi
+            active_conferences: Active conferences
+            see_all_conferences: See all conferences
       photo:
         show:
-          close_modal: Tutup modal
-          photo: Foto
+          close_modal: Close modal
+          photo: Photo
       photos_list:
         show:
-          related_photos: Foto
+          related_photos: Photos
       registration_types:
         index:
-          choose_an_option: 'Pilih opsi pendaftaran Anda:'
-          login_as: Anda masuk sebagai %{name} <%{email}>
-          register: Daftar
-          title: Jenis pendaftaran
+          choose_an_option: 'Choose your registration option:'
+          login_as: You are logged in as %{name} <%{email}>
+          register: Register
+          title: Registration types
       shared:
         conference_user_login:
-          already_account: Apakah Anda sudah memiliki akun di desidim?
-          new_user: Pengguna baru?
-          sign_in: Login untuk mendaftar konferensi
-          sign_up: Buat akun di desidim untuk mendaftar konferensi
+          already_account: Do you already have an account in decidim?
+          new_user: New user?
+          sign_in: Login to register for the conference
+          sign_up: Create an account in decidim to register for the conference
       show:
-        details: Detail
-        introduction: pengantar
-        objectives: Tujuan
-        related_assemblies: Rakitan Terkait
-        related_consultations: Konsultasi Terkait
-        related_participatory_processes: Proses Partisipatif Terkait
+        details: Details
+        introduction: Introduction
+        objectives: Objectives
+        related_assemblies: Related Assemblies
+        related_consultations: Related Consultations
+        related_participatory_processes: Related Participatory Processes
       statistics:
-        answers_count: Jawaban
-        comments_count: Komentar
-        conference_count: Konferensi
-        debates_count: Perdebatan
-        endorsements_count: Endorsemen
-        headline: Aktivitas
-        meetings_count: Rapat
-        orders_count: Suara
-        pages_count: Halaman
-        posts_count: Kiriman
-        projects_count: Proyek
-        proposals_count: Proposal
-        results_count: Hasil
-        surveys_count: Survei
-        users_count: Peserta
-        votes_count: Suara
+        answers_count: Answers
+        comments_count: Comments
+        conference_count: Conferences
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        posts_count: Posts
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Pendaftaran Anda untuk konferensi <a href="%{resource_url}">%{resource_title}</a> masih menunggu untuk dikonfirmasi.
         conference_registration_confirmed:
-          notification_title: Pendaftaran Anda untuk konferensi <a href="%{resource_url}">%{resource_title}</a> telah dikonfirmasi.
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> has been confirmed.
+        conference_registration_validation_pending:
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> is pending to be confirmed.
         conference_registrations_over_percentage:
-          email_intro: Slot "%{resource_title}" konferensi yang ditempati lebih dari %{percentage}%.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah admin ruang partisipatif konferensi.
-          email_subject: Slot konferensi "%{resource_title}" lebih dari %{percentage}%
-          notification_title: Slot konferensi <a href="%{resource_path}">%{resource_title}</a> diduduki lebih dari %{percentage}%.
+          email_intro: The "%{resource_title}" conference occupied slots are over %{percentage}%.
+          email_outro: You have received this notification because you are an admin of the conference's participatory space.
+          email_subject: The "%{resource_title}" conference occupied slots are over %{percentage}%
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference occupied slots are over %{percentage}%.
         conference_updated:
-          email_intro: 'Konferensi "%{resource_title}" telah diperbarui. Anda dapat membaca versi baru dari halamannya:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti konferensi "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Konferensi "%{resource_title}" telah diperbarui
-          notification_title: Konferensi <a href="%{resource_path}">%{resource_title}</a> telah diperbarui.
+          email_intro: 'The "%{resource_title}" conference was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference was updated.
         registrations_enabled:
-          email_intro: 'Konferensi "%{resource_title}" telah memungkinkan pendaftaran. Anda dapat mendaftarkan diri Anda di halamannya:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti konferensi "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Konferensi "%{resource_title}" telah memungkinkan pendaftaran.
-          notification_title: Konferensi <a href="%{resource_path}">%{resource_title}</a> telah memungkinkan pendaftaran.
+          email_intro: 'The "%{resource_title}" conference has enabled registrations. You can register yourself on its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference has enabled registrations.
         upcoming_conference:
-          email_intro: 'Konferensi "%{resource_title}" berlangsung dalam 2 hari. Anda dapat membaca deskripsi dari halamannya:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti konferensi "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Konferensi "%{resource_title}" akan datang!
-          notification_title: Konferensi <a href="%{resource_path}">%{resource_title}</a> akan datang dalam 2 hari.
+          email_intro: 'The "%{resource_title}" conference is taking place in 2 days. You can read the description from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference is coming!
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference is coming in 2 days.
     log:
       value_types:
         conference_presenter:
-          not_found: 'Konferensi tidak ditemukan di database (ID: %{id})'
+          not_found: 'The conference was not found on the database (ID: %{id})'
     media:
       index:
-        description: Tautan tentang konferensi ini
-        title: Media dan Tautan
+        description: Links about this conference
+        title: Media and Links
     menu:
-      conferences: Konferensi
+      conferences: Conferences
   devise:
     mailer:
       join_conference:
-        subject: Undangan untuk bergabung dalam konferensi
+        subject: Invitation to join a conference
   layouts:
     decidim:
       conference_hero:
-        register: Daftar
+        register: Register
       conference_widgets:
         show:
-          take_part: Ambil bagian
+          take_part: Take part
       conferences:
         conference:
-          take_part: Ambil bagian
+          take_part: Take part
         index:
-          promoted_conferences: Konferensi yang dipromosikan
+          promoted_conferences: Promoted conferences
         order_by_conferences:
           conferences:
-            other: "%{count} konferensi"
+            one: "%{count} conference"
+            other: "%{count} conferences"
         promoted_conference:
-          more_info: Info lebih lanjut
-          take_part: Ambil bagian
+          more_info: More info
+          take_part: Take part
       conferences_nav:
-        conference_menu_item: Informasi
-        conference_partners_menu_item: Mitra
-        conference_speaker_menu_item: Pembicara
+        conference_menu_item: Information
+        conference_partners_menu_item: Partners
+        conference_speaker_menu_item: Speakers
         media: Media
         venues: Venues

--- a/decidim-conferences/config/locales/it.yml
+++ b/decidim-conferences/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ it:
         votes_count: voti
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: La tua registrazione per la conferenza <a href="%{resource_url}">%{resource_title}</a> è in attesa di conferma.
         conference_registration_confirmed:
           notification_title: La tua registrazione per la conferenza <a href="%{resource_url}">%{resource_title}</a> è stata confermata.
+        conference_registration_validation_pending:
+          notification_title: La tua registrazione per la conferenza <a href="%{resource_url}">%{resource_title}</a> è in attesa di conferma.
         conference_registrations_over_percentage:
           email_intro: Gli spazi occupati con la conferenza "%{resource_title}" sono superiori %{percentage}%.
           email_outro: Hai ricevuto questa notifica perché sei un amministratore dello spazio partecipativo della conferenza.

--- a/decidim-conferences/config/locales/nl.yml
+++ b/decidim-conferences/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ nl:
         votes_count: stemmen
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Uw registratie voor de conferentie <a href="%{resource_url}">%{resource_title}</a> is in afwachting van bevestiging.
         conference_registration_confirmed:
           notification_title: Uw registratie voor de conferentie <a href="%{resource_url}">%{resource_title}</a> is bevestigd.
+        conference_registration_validation_pending:
+          notification_title: Uw registratie voor de conferentie <a href="%{resource_url}">%{resource_title}</a> is in afwachting van bevestiging.
         conference_registrations_over_percentage:
           email_intro: De door de '%{resource_title}conferentie ingenomen slots zijn meer dan %{percentage}%.
           email_outro: U hebt deze melding ontvangen omdat u een beheerder bent van de participatieruimte van de conferentie.

--- a/decidim-conferences/config/locales/pl.yml
+++ b/decidim-conferences/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -37,19 +38,19 @@ pl:
   activerecord:
     models:
       decidim/conference:
-        one: Konferencja
         few: Konferencje
         many: Konferencje
+        one: Konferencja
         other: Konferencje
       decidim/conference_speaker:
-        one: Głośnik konferencyjny
         few: Głośniki konferencyjne
         many: Głośniki konferencyjne
+        one: Głośnik konferencyjny
         other: Głośniki konferencyjne
       decidim/conference_user_role:
-        one: Rola użytkownika konferencyjnego
         few: Rola użytkownika konferencyjnego
         many: Rola użytkownika konferencyjnego
+        one: Rola użytkownika konferencyjnego
         other: Rola użytkownika konferencyjnego
   decidim:
     admin:
@@ -334,9 +335,9 @@ pl:
           form:
             available_slots_help: Pozostaw to 0, jeśli masz dostęp do nieograniczonej liczby miejsc.
             registrations_count:
-              one: Nie było rejestracji 1.
               few: Zarejestrowano %{count} rejestracji.
               many: Zarejestrowano %{count} rejestracji.
+              one: Nie było rejestracji 1.
               other: Zarejestrowano %{count} rejestracji.
             slug_help: 'Strumienie adresów URL służą do generowania adresów URL wskazujących na tę konferencję. Akceptuje tylko litery, cyfry i łączniki i musi zaczynać się od litery. Przykład: %{url}'
         diplomas:
@@ -513,10 +514,10 @@ pl:
         votes_count: Głosy
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Twoja rejestracja na konferencję <a href="%{resource_url}">%{resource_title}</a> oczekuje na potwierdzenie.
         conference_registration_confirmed:
           notification_title: Twoja rejestracja na konferencję <a href="%{resource_url}">%{resource_title}</a> została potwierdzona.
+        conference_registration_validation_pending:
+          notification_title: Twoja rejestracja na konferencję <a href="%{resource_url}">%{resource_title}</a> oczekuje na potwierdzenie.
         conference_registrations_over_percentage:
           email_intro: Konferencje "%{resource_title}" zajmowane przez graczy zajmują ponad %{percentage}%.
           email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś administratorem przestrzeni partycypacyjnej konferencji.
@@ -535,6 +536,7 @@ pl:
         upcoming_conference:
           email_intro: 'Konferencja "%{resource_title}" odbywa się za 2 dni. Możesz przeczytać opis na swojej stronie:'
           email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz konferencję "%{resource_title}". Możesz przestać go obserwować z poprzedniego linku.
+          email_subject: The "%{resource_title}" conference is coming!
           notification_title: Konferencja <a href="%{resource_path}">%{resource_title}</a> nadchodzi za 2 dni.
     log:
       value_types:
@@ -564,9 +566,9 @@ pl:
           promoted_conferences: Promowane konferencje
         order_by_conferences:
           conferences:
-            one: "%{count} konferencji"
             few: "%{count} konferencji"
             many: "%{count} konferencji"
+            one: "%{count} konferencji"
             other: "%{count} konferencji"
         promoted_conference:
           more_info: Więcej informacji

--- a/decidim-conferences/config/locales/pt-BR.yml
+++ b/decidim-conferences/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ pt-BR:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Seu registro para a conferência <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registration_confirmed:
           notification_title: Sua inscrição para a conferência <a href="%{resource_url}">%{resource_title}</a> foi confirmada.
+        conference_registration_validation_pending:
+          notification_title: Seu registro para a conferência <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registrations_over_percentage:
           email_intro: Os espaços ocupados pela conferência "%{resource_title}" são superiores a %{percentage}%.
           email_outro: Você recebeu esta notificação porque é um administrador do espaço participativo da conferência.

--- a/decidim-conferences/config/locales/pt.yml
+++ b/decidim-conferences/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ pt:
         votes_count: Votos
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Seu registro para a conferência <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registration_confirmed:
           notification_title: Sua inscrição para a conferência <a href="%{resource_url}">%{resource_title}</a> foi confirmada.
+        conference_registration_validation_pending:
+          notification_title: Seu registro para a conferência <a href="%{resource_url}">%{resource_title}</a> está pendente de ser confirmado.
         conference_registrations_over_percentage:
           email_intro: Os espaços ocupados pela conferência "%{resource_title}" são superiores a %{percentage}%.
           email_outro: Você recebeu esta notificação porque é um administrador do espaço participativo da conferência.

--- a/decidim-conferences/config/locales/sv.yml
+++ b/decidim-conferences/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -505,10 +506,10 @@ sv:
         votes_count: Röster
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Din registrering för konferensen <a href="%{resource_url}">%{resource_title}</a> väntar på att bekräftas.
         conference_registration_confirmed:
           notification_title: Din registrering för konferensen <a href="%{resource_url}">%{resource_title}</a> har bekräftats.
+        conference_registration_validation_pending:
+          notification_title: Din registrering för konferensen <a href="%{resource_url}">%{resource_title}</a> väntar på att bekräftas.
         conference_registrations_over_percentage:
           email_intro: '"%{resource_title}" -konferensens upptagna platser är över %{percentage}%.'
           email_outro: Du har fått den här meddelandet eftersom du är en administratör för konferensens deltagande utrymme.

--- a/decidim-conferences/config/locales/tr-TR.yml
+++ b/decidim-conferences/config/locales/tr-TR.yml
@@ -1,570 +1,571 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       conference:
-        assemblies_ids: İlgili montajlar
-        banner_image: Banner resmi
-        consultations_ids: İlgili istişareler
-        copy_categories: Kategorileri kopyala
-        copy_components: Bileşenleri kopyala
-        copy_features: Özellikleri kopyala
-        decidim_scope_id: kapsam
-        description: Açıklama
-        hashtag: Başlık etiketi
-        hero_image: Ana resim
-        participatory_processes_ids: İlgili Katılımcı süreçler
-        promoted: Tanıtılan
-        published_at: Yayınlandı
-        scope_id: kapsam
-        scopes_enabled: Kapsamlar etkin
-        short_description: Kısa Açıklama
-        show_statistics: İstatistikleri göster
+        assemblies_ids: Related Assemblies
+        banner_image: Banner image
+        consultations_ids: Related Consultations
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_features: Copy features
+        decidim_scope_id: Scope
+        description: Description
+        hashtag: Hashtag
+        hero_image: Home image
+        participatory_processes_ids: Related Participatory processes
+        promoted: Promoted
+        published_at: Published at
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
         slogan: Slogan
-        slug: URL sümüklü böcek
-        title: Başlık
+        slug: URL slug
+        title: Title
       conference_speaker:
-        full_name: Ad Soyad
+        full_name: Full name
       conference_user_role:
-        email: E-posta
-        name: isim
-        role: rol
+        email: Email
+        name: Name
+        role: Role
     errors:
       models:
         conference_registration_invite:
           attributes:
             email:
-              already_invited: Bu e-posta zaten davet edildi
+              already_invited: This email has already been invited
   activerecord:
     models:
       decidim/conference:
-        one: Konferans
-        other: Konferanslar
+        one: Conference
+        other: Conferences
       decidim/conference_speaker:
-        one: Konferans konuşmacı
-        other: Konferans konuşmacıları
+        one: Conference speaker
+        other: Conference speakers
       decidim/conference_user_role:
-        one: Konferans kullanıcı rolü
-        other: Konferans kullanıcı rolleri
+        one: Conference user role
+        other: Conference user roles
   decidim:
     admin:
       actions:
-        confirm: Onaylamak
-        new_conference: Yeni konferans
-        send_diplomas: Katılım sertifikaları gönder
+        confirm: Confirm
+        new_conference: New Conference
+        send_diplomas: Send certificates of attendance
       conference_copies:
         new:
-          copy: kopya
-          select: Çoğaltmak istediğiniz verileri seçin
-          title: Yinelenen konferans
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate conference
       conference_publications:
         create:
-          error: Bu konferansı yayınlayan bir hata oluştu.
-          success: Konferans başarıyla yayınlandı.
+          error: There was an error publishing this conference.
+          success: Conference published successfully.
         destroy:
-          error: Bu konferansı yayından kaldırmada bir hata oluştu.
-          success: Konferans başarıyla yayından kaldırıldı.
+          error: There was an error unpublishing this conference.
+          success: Conference unpublished successfully.
       conference_registration:
         confirm:
-          error: Bu konferans kaydını onaylarken bir hata oluştu.
-          success: Konferans kaydı başarıyla onaylandı.
+          error: There was an error when confirm this conference registration.
+          success: Conference registration confirmed successfully.
       conference_speakers:
         create:
-          error: Bu konferans için bir hoparlör eklenirken bir hata oluştu.
-          success: Bu konferans için konuşmacı başarıyla oluşturuldu.
+          error: There was an error adding a speaker for this conference.
+          success: Speaker created successfully for this conference.
         destroy:
-          success: Bu konferans için konuşmacı başarıyla silindi.
+          success: Speaker deleted successfully for this conference.
         edit:
-          title: Konferans konuşmacısını güncelle.
-          update: Güncelleştirme
+          title: Update conference speaker.
+          update: Update
         index:
-          conference_speakers_title: Konferans konuşmacıları
+          conference_speakers_title: Conference speakers
         new:
-          create: yaratmak
-          title: Yeni konferans konuşmacı.
+          create: Create
+          title: New conference speaker.
         update:
-          error: Bu konferans için konuşmacı güncellenirken bir hata oluştu.
-          success: Bu konferans için konuşmacı başarıyla güncellendi.
+          error: There was an error updating the speaker for this conference.
+          success: Speaker updated successfully for this conference.
       conference_user_roles:
         create:
-          error: Bu konferans için bir kullanıcı eklenirken bir hata oluştu.
-          success: Kullanıcı bu konferansa başarıyla eklendi.
+          error: There was an error adding a user for this conference.
+          success: User added successfully to this conference.
         destroy:
-          success: Kullanıcı bu konferanstan başarıyla kaldırıldı.
+          success: User removed successfully from this conference.
         edit:
-          title: Konferans kullanıcısını güncelle.
-          update: Güncelleştirme
+          title: Update conference user.
+          update: Update
         index:
-          conference_admins_title: konferans kullanıcıları
+          conference_admins_title: conference users
         new:
-          create: yaratmak
-          title: Yeni konferans kullanıcısı.
+          create: Create
+          title: New conference user.
         update:
-          error: Bu konferans için bir kullanıcı güncellendi bir hata oluştu.
-          success: Kullanıcı bu konferans için başarıyla güncellendi.
+          error: There was an error updated a user for this conference.
+          success: User updated successfully for this conference.
       conferences:
         create:
-          error: Yeni bir konferans oluştururken bir hata oluştu.
-          success: Konferans başarıyla oluşturuldu.
+          error: There was an error creating a new conference.
+          success: Conference created successfully.
         edit:
-          update: Güncelleştirme
+          update: Update
         exports:
-          registrations: Kayıtlar
+          registrations: Registrations
         form:
-          title: Genel bilgi
+          title: General Information
         index:
-          not_published: Yayınlanmadı
-          published: Yayınlanan
+          not_published: Not published
+          published: Published
         new:
-          create: yaratmak
-          title: Konferans
+          create: Create
+          title: Conference
         update:
-          error: Bu konferans güncellenirken bir hata oluştu.
-          success: Konferans başarıyla güncellendi.
+          error: There was an error when updating this conference.
+          success: Conference updated successfully.
       conferences_copies:
         create:
-          error: Bu konferansı çoğaltırken bir hata oluştu.
-          success: Konferans başarıyla kopyalandı.
+          error: There was an error when duplicating this conference.
+          success: Conference duplicated successfully.
       media_links:
         create:
-          error: Yeni bir medya bağlantısı oluştururken bir hata oluştu.
-          success: Medya Bağlantısı başarıyla oluşturuldu.
+          error: There was an error creating a new media link.
+          success: Media Link created successfully.
         destroy:
-          success: Medya Bağlantısı başarıyla silindi.
+          success: Media Link deleted successfully.
         edit:
-          title: Medya bağlantısını güncelle.
-          update: Güncelleştirme
+          title: Update media link.
+          update: Update
         index:
-          media_links_title: Medya Bağlantıları
+          media_links_title: Media Links
         new:
-          create: yaratmak
-          title: Medya Bağlantısı
+          create: Create
+          title: Media Link
         update:
-          error: Bu medya bağlantısını güncellerken bir hata oluştu.
-          success: Medya Bağlantısı başarıyla güncellendi.
+          error: There was an error when updating this media link.
+          success: Media Link updated successfully.
       menu:
-        conferences: Konferanslar
+        conferences: Conferences
         conferences_submenu:
-          attachment_collections: Klasörler
-          attachment_files: Dosyalar
-          attachments: Ekler
-          categories: Kategoriler
-          components: Bileşenler
-          conference_admins: Konferans kullanıcıları
-          conference_invites: Davetler
-          conference_speakers: Hoparlörler
-          diploma: Katılım sertifikası
-          info: Bilgi
-          media_links: Medya Bağlantıları
-          moderations: Denetimler
-          partners: Ortaklar
-          registration_types: Kayıt Türleri
-          registrations: Kayıtlar
-          user_registrations: Kullanıcı Kayıtları
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
+          conference_admins: Conference users
+          conference_invites: Invites
+          conference_speakers: Speakers
+          diploma: Certificate of Attendance
+          info: Info
+          media_links: Media Links
+          moderations: Moderations
+          partners: Partners
+          registration_types: Registration Types
+          registrations: Registrations
+          user_registrations: User Registrations
       models:
         conference:
           fields:
-            created_at: Düzenlendi
-            promoted: Tanıtılan
-            published: Yayınlanan
-            title: Başlık
+            created_at: Created at
+            promoted: Promoted
+            published: Published
+            title: Title
         conference_speaker:
           fields:
-            affiliation: üyelik
-            full_name: Ad Soyad
-            position: pozisyon
-          name: Konferans konuşmacısı
+            affiliation: Affiliation
+            full_name: Full name
+            position: Position
+          name: Conference Speaker
         conference_user_role:
           fields:
-            email: E-posta
-            name: isim
-            role: rol
-          name: Konferans Kullanıcısı
+            email: Email
+            name: Name
+            role: Role
+          name: Conference User
           roles:
-            admin: yönetici
-            collaborator: işbirlikçi
-            moderator: arabulucu
+            admin: Administrator
+            collaborator: Collaborator
+            moderator: Moderator
         media_link:
           fields:
-            date: tarih
-            link: bağlantı
-            title: Başlık
-          name: Medya Bağlantısı
+            date: Date
+            link: Link
+            title: Title
+          name: Media Link
         partner:
           fields:
-            link: bağlantı
+            link: Link
             logo: Logo
-            name: isim
-            partner_type: tip
-          name: Ortak
+            name: Name
+            partner_type: Type
+          name: Partner
           types:
-            collaborator: işbirlikçi
-            main_promotor: Ana promotor
+            collaborator: Collaborator
+            main_promotor: Main promotor
         registration_type:
           fields:
-            conference_meetings: Konferans toplantıları
-            price: Fiyat
-            registrations_count: Kayıt sayısı
-            title: Başlık
-            weight: Ağırlık
-          name: Kayıt tipi
+            conference_meetings: Conference meetings
+            price: Price
+            registrations_count: Registrations count
+            title: Title
+            weight: Weight
+          name: Registration type
       partners:
         create:
-          error: Bu konferans için bir ortak eklenirken bir hata oluştu.
-          success: İş ortağı bu konferansa başarıyla eklendi.
+          error: There was an error adding a partner for this conference.
+          success: Partner added successfully to this conference.
         destroy:
-          success: İş ortağı bu konferanstan başarıyla kaldırıldı.
+          success: Partner removed successfully from this conference.
         edit:
-          title: İş ortağı güncelle.
-          update: Güncelleştirme
+          title: Update partner.
+          update: Update
         new:
-          create: yaratmak
-          title: Yeni ortak
+          create: Create
+          title: New partner
         update:
-          error: Bu konferans için bir ortak güncellendi bir hata oluştu.
-          success: Bu konferans için iş ortağı başarıyla güncellendi.
+          error: There was an error updated a partner for this conference.
+          success: Partner updated successfully for this conference.
       registration_type_publications:
         create:
-          error: Bu kayıt türünde bir hata oluştu.
-          success: Kayıt tipi başarıyla yayınlandı.
+          error: There was an error publishing this registration type.
+          success: Registration type published successfully.
         destroy:
-          error: Bu kayıt türünün yayından kaldırılmasıyla ilgili bir hata oluştu.
-          success: Kayıt türü başarıyla yayından kaldırıldı.
+          error: There was an error unpublishing this registration type.
+          success: Registration type unpublished successfully.
       registration_types:
         create:
-          error: Bu konferans için kayıt türü eklenirken bir hata oluştu.
-          success: Bu konferansa kayıt tipi başarıyla eklendi.
+          error: There was an error adding a registration type for this conference.
+          success: Registration type added successfully to this conference.
         destroy:
-          success: Kayıt türü bu konferanstan başarıyla kaldırıldı.
+          success: Registration type removed successfully from this conference.
         edit:
-          title: Kayıt türünü güncelle.
-          update: Güncelleştirme
+          title: Update registration type.
+          update: Update
         new:
-          create: yaratmak
-          title: Yeni kayıt türü
+          create: Create
+          title: New registration type
         update:
-          error: Bu konferans için bir kayıt türü güncellendiğinde bir hata oluştu.
-          success: Bu konferans için kayıt tipi başarıyla güncellendi.
+          error: There was an error updated a registration type for this conference.
+          success: Registration type updated successfully for this conference.
       titles:
-        conferences: Konferanslar
+        conferences: Conferences
     admin_log:
       conference:
-        create: "%{user_name} %{resource_name} konferansı oluşturdu"
-        publish: "%{user_name} %{resource_name} konferansı yayınladı"
-        send_conference_diplomas: "%{user_name} %{resource_name} konferans katılımcısına katılım sertifikası gönderdi"
-        unpublish: "%{user_name} %{resource_name} konferansı yayından kaldırıldı"
-        update: "%{user_name} %{resource_name} konferansı güncelledi"
-        update_diploma: "%{user_name} %{resource_name} konferans için katılım konfigürasyon sertifikaları güncellendi"
+        create: "%{user_name} created the %{resource_name} conference"
+        publish: "%{user_name} published the %{resource_name} conference"
+        send_conference_diplomas: "%{user_name} sent certificates of attendance to the %{resource_name} conference atendees"
+        unpublish: "%{user_name} unpublished the %{resource_name} conference"
+        update: "%{user_name} updated the %{resource_name} conference"
+        update_diploma: "%{user_name} updated the certificates of attendance configuration for %{resource_name} conference"
       conference_speaker:
-        create: "%{user_name} , %{space_name} konferansta %{resource_name} konuşmacıyı oluşturdu"
-        delete: "%{user_name} %{space_name} konferanstan %{resource_name} konuşmacıyı kaldırdı"
-        update: "%{user_name} , %{space_name} konferansta %{resource_name} konuşmacıyı güncelledi"
+        create: "%{user_name} created the %{resource_name} speaker in the %{space_name} conference"
+        delete: "%{user_name} removed the %{resource_name} speaker from the %{space_name} conference"
+        update: "%{user_name} updated the %{resource_name} speaker in the %{space_name} conference"
       conference_user_role:
-        create: "%{user_name} %{space_name} konferansa %{resource_name} davet edildi"
-        delete: "%{user_name} kullanıcı uzaklaştırıldı %{resource_name} den %{space_name} konferans"
-        update: "%{user_name} , %{space_name} konferanstaki %{resource_name} rolünü değiştirdi"
+        create: "%{user_name} invited %{resource_name} to the %{space_name} conference"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} conference"
+        update: "%{user_name} changed the role of %{resource_name} in the %{space_name} conference"
       conferences:
         conference_registration:
-          confirm: "%{user_name} , %{resource_name} konferansta bir konferans kaydını onayladı"
+          confirm: "%{user_name} confirmed a conference registration in %{resource_name} conference"
         partner:
-          create: "%{user_name} %{space_name} konferansa %{resource_name} oluşturuldu"
-          delete: "%{user_name} kullanıcı uzaklaştırıldı %{resource_name} den %{space_name} konferans"
-          update: "%{user_name} %{space_name} konferansta %{resource_name} güncellendi"
+          create: "%{user_name} created %{resource_name} to the %{space_name} conference"
+          delete: "%{user_name} removed the user %{resource_name} from the %{space_name} conference"
+          update: "%{user_name} updated %{resource_name} in the %{space_name} conference"
         registration_type:
-          create: "%{user_name} , %{space_name} konferansta %{resource_name} kayıt tipini oluşturdu"
-          publish: "%{user_name} , %{space_name} konferansta %{resource_name} kayıt tipini yayınladı"
-          unpublish: "%{user_name} %{space_name} konferansta %{resource_name} kayıt tipini yayından kaldırıldı"
-          update: "%{user_name} , %{space_name} konferansta %{resource_name} kayıt tipini güncelledi"
+          create: "%{user_name} created the %{resource_name} registration type in the %{space_name} conference"
+          publish: "%{user_name} published the %{resource_name} registration type in the %{space_name} conference"
+          unpublish: "%{user_name} unpublished the %{resource_name} registration type in the %{space_name} conference"
+          update: "%{user_name} updated the %{resource_name} registration type in the %{space_name} conference"
       media_link:
-        create: "%{user_name} , %{space_name} konferansta %{resource_name} medya bağlantısını oluşturdu"
-        delete: "%{user_name} , %{space_name} konferansın %{resource_name} medya bağlantısını kaldırdı"
-        update: "%{user_name} , %{space_name} konferanstaki %{resource_name} medya bağlantısını güncelledi"
+        create: "%{user_name} created the %{resource_name} media link in the %{space_name} conference"
+        delete: "%{user_name} removed the %{resource_name} media link from the %{space_name} conference"
+        update: "%{user_name} updated the %{resource_name} media link in the %{space_name} conference"
     conference_program:
       index:
-        title: program
+        title: Program
     conference_speakers:
       index:
-        title: Hoparlörler
+        title: Speakers
     conferences:
       admin:
         conference_copies:
           form:
-            slug_help: 'URL sümükleri, bu konferansa işaret eden URL’leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         conference_invites:
           create:
-            error: Kullanıcıyı konferansa katılmaya davet ederken bir sorun oluştu.
-            success: Kullanıcı konferansa katılmaya başarıyla davet edildi.
+            error: There's been a problem while inviting the user to join the conference.
+            success: User successfully invited to join the conference.
           form:
-            attendee_type: Katılımcı Tipi
-            existing_user: Mevcut kullanıcı
-            invite_explanation: Kullanıcı konferansa ve organizasyona da davet edilecektir.
-            non_user: Mevcut olmayan kullanıcı
-            select_user: Kullanıcı seç
+            attendee_type: Attendee type
+            existing_user: Existing user
+            invite_explanation: The user will be invited to join the conference and to the organization as well.
+            non_user: Non existing user
+            select_user: Select user
           index:
             filter:
-              accepted: Kabul edilmiş
-              all: Herşey
-              rejected: Reddedilen
-              sent: Gönderilen
-            filter_by: Tarafından filtre
-            invite_attendee: Katılımcı Davet Et
-            invites: Davetler
-            search: Arama
+              accepted: Accepted
+              all: All
+              rejected: Rejected
+              sent: Sent
+            filter_by: Filter by
+            invite_attendee: Invite Attendee
+            invites: Invites
+            search: Search
           new:
-            explanation: Kullanıcı bir konferansa katılmaya davet edilecek. E-posta kayıtlı değilse, organizasyona da davet edilecektir.
-            invite: Davet et
-            new_invite: Kullanıcı davet et
+            explanation: The user will be invited to join a conference. If the email is not registered they will be invited to the organization as well.
+            invite: Invite
+            new_invite: Invite user
         conference_registrations:
           index:
-            registrations: Kayıtlar
+            registrations: Registrations
         conference_speakers:
           form:
-            existing_user: Mevcut kullanıcı
-            non_user: Kullanıcı yok
-            select_user: Kullanıcı seç
-            user_type: Kullanıcı tipi
+            existing_user: Existing user
+            non_user: Non user
+            select_user: Select user
+            user_type: User type
           index:
-            search: Arama
+            search: Search
         conferences:
           form:
-            available_slots_help: Mevcut sınırsız yuvaya sahipseniz 0'a bırakın.
+            available_slots_help: Leave it to 0 if you have unlimited slots available.
             registrations_count:
-              one: 1 kayıt oldu.
-              other: '%{count} kayıt var.'
-            slug_help: 'URL sümükleri, bu konferansa işaret eden URL’leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
+              one: There has been 1 registration.
+              other: There has been %{count} registrations.
+            slug_help: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         diplomas:
           edit:
-            save: Kayıt etmek
-            title: Katılım sertifikası
+            save: Save
+            title: Certificate of Attendance
         invite_join_conference_mailer:
           invite:
-            decline: '''%{conference_title}'' davetiyesini reddet'
-            invited_you_to_join_a_conference: "%{invited_by} sizi %{application}bir konferansa katılmaya davet etti. Aşağıdaki bağlantılardan reddedebilir veya kabul edebilirsiniz."
-            registration: '''%{conference_title}'' için kayıt'
+            decline: Decline invitation '%{conference_title}'
+            invited_you_to_join_a_conference: "%{invited_by} has invited you to join a conference at %{application}. You can decline or accept it through the links below."
+            registration: Registration for '%{conference_title}'
         partners:
           index:
-            title: Ortaklar
+            title: Partners
         registration_types:
           form:
-            select_conference_meetings: Konferans toplantıları seçin
+            select_conference_meetings: Select conference meetings
           index:
-            title: Kayıt türleri
+            title: Registration types
         send_conference_diploma_mailer:
           diploma:
-            diploma_html: <a href="%{url}">%{title}</a> konferansına katılım belgesini ekte bulabilirsiniz.
+            diploma_html: You will be find the certificate of attendance for the conference <a href="%{url}">%{title}</a> in the attachments.
           diploma_user:
-            attendance_verified_by: Katılım onaylandı
-            certificate_of_attendance: Katılım sertifikası
-            certificate_of_attendance_description: Bu, <strong>%{user}</strong> <strong>%{start} - %{end}</strong><strong>%{location}</strong> tutulan <strong>%{title}</strong> katılıp katıldığını onaylamaktır.
+            attendance_verified_by: Attendance verified by
+            certificate_of_attendance: Certificate of Attendance
+            certificate_of_attendance_description: This is to certify that <strong>%{user}</strong> has attended and taken part in the <strong>%{title}</strong> held at the <strong>%{location}</strong> on <strong>%{start} - %{end}</strong>
         send_diploma:
-          error: Konferans diplomalarını gönderirken bir sorun oluştu.
-          success: Konferans Diplomatları doğru bir şekilde gönderildi
+          error: There's been a problem while sending the conference certificates of attendance.
+          success: Conference certificates of attendance sent correctly
       conference:
         registration_confirm:
-          cancel: İptal etmek
-          confirm: Onaylamak
+          cancel: Cancel
+          confirm: Confirm
         show:
-          free: Ücretsiz
-          going: Gidiyor
-          no_slots_available: Mevcut yuva yok
-          registration: kayıt
+          free: Free
+          going: Going
+          no_slots_available: No slots available
+          registration: Registration
       conference_program:
         program_meeting:
-          content: içerik
-          location: yer
-          speakers: Hoparlörler
-          streaming: Yayın Akışı
+          content: Content
+          location: Location
+          speakers: Speakers
+          streaming: Streaming
         show:
-          day: Gün
-          program: program
+          day: Day
+          program: Program
       conference_registration_mailer:
         confirmation:
-          confirmed_html: Konferans için kaydınız <a href="%{url}">%{title}</a> onaylandı.
-          details_1: '%{registration_type} tipi ile konferansa kayıt oldunuz. %{price} maliyeti vardır ve aşağıdaki etkinliklere katılabilirsiniz:'
-          details_2: Konferansın detaylarını ekte bulabilirsiniz.
+          confirmed_html: Your registration for the conference <a href="%{url}">%{title}</a> has been confirmed.
+          details_1: 'You are registered to the conference with %{registration_type} type. It has a cost of %{price} and you can attend to the following events:'
+          details_2: You will find the conference's details in the attachment.
         pending_validation:
-          confirmation_pending: Onayı kısa bir süre alacaksınız
-          details: '%{price} maliyetle %{registration_type} yazdınız ve aşağıdaki etkinliklere katılabilirsiniz:'
-          pending_html: Konferans için kaydınız <a href="%{url}">%{title}</a> teyit edilmeyi bekliyor.
+          confirmation_pending: You will receive the confirmation shortly
+          details: 'You have registered to %{registration_type} type with a cost of %{price} and you can attend to the following events:'
+          pending_html: Your registration for the conference <a href="%{url}">%{title}</a> is pending to be confirmed.
       conference_registrations:
         create:
-          invalid: Bu konferansa katılırken bir sorun oluştu.
-          success: Konferansa başarılı bir şekilde katıldınız.
+          invalid: There's been a problem joining this conference.
+          success: You have joined the conference successfully.
         decline_invitation:
-          invalid: Davetin reddedilmesiyle ilgili bir sorun oluştu.
-          success: Davetiyeyi başarıyla reddettiniz.
+          invalid: There's been a problem declining the invitation.
+          success: You have declined the invitation successfully.
         destroy:
-          invalid: Bu konferansı terk etmekle ilgili bir sorun oluştu.
-          success: Konferansı başarıyla terk ettiniz.
+          invalid: There's been a problem leaving this conference.
+          success: You have left the conference successfully.
       conference_speaker:
-        go_to_twitter: Twitter'a git
-        more_info: Daha fazla bilgi
-        personal_website: Kişisel web sitesi
+        go_to_twitter: Go to Twitter
+        more_info: more info
+        personal_website: Personal website
         show:
-          more_info: Daha fazla bilgi
+          more_info: more info
       conference_speaker_cell:
         personal_url:
-          personal_website: Kişisel web sitesi
+          personal_website: Personal website
         twitter_handle:
-          go_to_twitter: Twitter'a git
+          go_to_twitter: Go to Twitter
       conference_speakers:
         index:
-          speakers: Hoparlörler
+          speakers: Speakers
       conferences:
         partners:
-          collaborators: Ortaklar
-          main_promotors: Organizatörler
+          collaborators: Partners
+          main_promotors: Organizers
         show:
-          login_as: '%{name} <%{email}> olarak giriş yaptınız'
-          make_conference_registration: 'Kaydınızı konferansta yapın:'
-          register: Kayıt olmak
+          login_as: You are logged in as %{name} <%{email}>
+          make_conference_registration: 'Make your registration in the conference:'
+          register: Register
       content_blocks:
         highlighted_conferences:
-          name: Vurgulanan konferanslar
+          name: Highlighted conferences
       index:
-        title: Konferanslar
+        title: Conferences
       mailer:
         conference_registration_mailer:
           confirmation:
-            subject: Konferansınızın kaydı onaylandı
+            subject: Your conference's registration has been confirmed
           pending_validation:
-            subject: Konferansınızın kaydının onaylanması bekleniyor
+            subject: Your conference's registration is pending to be confirmed
         invite_join_conference_mailer:
           invite:
-            subject: Bir konferansa katılma daveti
+            subject: Invitation to join a conference
         send_conference_diploma_mailer:
           diploma:
-            subject: Konferansa katılım sertifikanız gönderildi
+            subject: Your conference certificate of attendance has been sent
       models:
         conference_invite:
           fields:
-            email: E-posta
-            name: isim
-            registration_type: Kayıt tipi
-            sent_at: Adresine gönderildi
-            status: durum
+            email: Email
+            name: Name
+            registration_type: Registration type
+            sent_at: Sent at
+            status: Status
           status:
-            accepted: Kabul edildi (%{at})
-            rejected: Reddedildi (%{at})
-            sent: Gönderilen
+            accepted: Accepted (%{at})
+            rejected: Rejected (%{at})
+            sent: Sent
         conference_registration:
           fields:
-            email: E-posta
-            name: isim
-            registration_type: Kayıt tipi
-            state: Belirtmek, bildirmek
+            email: Email
+            name: Name
+            registration_type: Registration type
+            state: State
             states:
-              confirmed: onaylı
-              pending: kadar
+              confirmed: Confirmed
+              pending: Pending
       pages:
         home:
           highlighted_conferences:
-            active_conferences: Aktif konferanslar
-            see_all_conferences: Tüm konferanslara bak
+            active_conferences: Active conferences
+            see_all_conferences: See all conferences
       photo:
         show:
-          close_modal: Yakın kalıcı
-          photo: Fotoğraf
+          close_modal: Close modal
+          photo: Photo
       photos_list:
         show:
-          related_photos: Fotoğraflar
+          related_photos: Photos
       registration_types:
         index:
-          choose_an_option: 'Kayıt seçeneğinizi seçin:'
-          login_as: '%{name} <%{email}> olarak giriş yaptınız'
-          register: Kayıt olmak
-          title: Kayıt türleri
+          choose_an_option: 'Choose your registration option:'
+          login_as: You are logged in as %{name} <%{email}>
+          register: Register
+          title: Registration types
       shared:
         conference_user_login:
-          already_account: Decidim'de hesabınız var mı?
-          new_user: Yeni kullanıcı?
-          sign_in: Konferansa kayıt olmak için giriş yapın
-          sign_up: Konferansa kayıt olmak için decidim'de bir hesap oluşturun
+          already_account: Do you already have an account in decidim?
+          new_user: New user?
+          sign_in: Login to register for the conference
+          sign_up: Create an account in decidim to register for the conference
       show:
-        details: ayrıntılar
-        introduction: Giriş
-        objectives: Hedefler
-        related_assemblies: İlgili montajlar
-        related_consultations: İlgili istişareler
-        related_participatory_processes: İlgili Katılımcı Süreçler
+        details: Details
+        introduction: Introduction
+        objectives: Objectives
+        related_assemblies: Related Assemblies
+        related_consultations: Related Consultations
+        related_participatory_processes: Related Participatory Processes
       statistics:
-        answers_count: Cevaplar
-        comments_count: Yorumlar
-        conference_count: Konferanslar
-        debates_count: Tartışmalar
-        endorsements_count: Cirolar
-        headline: Aktivite
-        meetings_count: Toplantılar
-        orders_count: oy
-        pages_count: Sayfalar
-        posts_count: Mesajlar
-        projects_count: Projeler
-        proposals_count: Teklif
-        results_count: Sonuçlar
-        surveys_count: Anketler
-        users_count: Katılımcılar
-        votes_count: oy
+        answers_count: Answers
+        comments_count: Comments
+        conference_count: Conferences
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        posts_count: Posts
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
     events:
       conferences:
-        conference_registration_validation_pending:
-          notification_title: Konferans için kaydınız <a href="%{resource_url}">%{resource_title}</a> teyit edilmeyi bekliyor.
         conference_registration_confirmed:
-          notification_title: Konferans için kaydınız <a href="%{resource_url}">%{resource_title}</a> onaylandı.
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> has been confirmed.
+        conference_registration_validation_pending:
+          notification_title: Your registration for the conference <a href="%{resource_url}">%{resource_title}</a> is pending to be confirmed.
         conference_registrations_over_percentage:
-          email_intro: '"%{resource_title}" konferansı işgal yuvaları% %{percentage}üzerindedir.'
-          email_outro: Bu bildirimi, konferansın katılımcı alanının bir yöneticisi olduğunuz için aldınız.
-          email_subject: '"%{resource_title}" konferansı dolu yuvalar% %{percentage}üzerindedir'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> konferans dolu yuvaları% %{percentage}üzerindedir.
+          email_intro: The "%{resource_title}" conference occupied slots are over %{percentage}%.
+          email_outro: You have received this notification because you are an admin of the conference's participatory space.
+          email_subject: The "%{resource_title}" conference occupied slots are over %{percentage}%
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference occupied slots are over %{percentage}%.
         conference_updated:
-          email_intro: '"%{resource_title}" konferansı güncellendi. Yeni sürümü kendi sayfasından okuyabilirsiniz:'
-          email_outro: '"%{resource_title}" konferansını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" konferansı güncellendi'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> konferans güncellendi.
+          email_intro: 'The "%{resource_title}" conference was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference was updated.
         registrations_enabled:
-          email_intro: '"%{resource_title}" konferansı kayıtları etkinleştirdi. Kendini kendi sayfasına kaydedebilirsin:'
-          email_outro: '"%{resource_title}" konferansını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" konferansı kayıtları etkinleştirdi.'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> konferansı kayıtları etkinleştirdi.
+          email_intro: 'The "%{resource_title}" conference has enabled registrations. You can register yourself on its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference has enabled registrations.
         upcoming_conference:
-          email_intro: '"%{resource_title}" konferansı 2 gün içinde gerçekleşiyor. Açıklamayı kendi sayfasından okuyabilirsiniz:'
-          email_outro: '"%{resource_title}" konferansını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" konferansı geliyor!'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> konferans 2 gün içinde geliyor.
+          email_intro: 'The "%{resource_title}" conference is taking place in 2 days. You can read the description from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" conference. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" conference is coming!
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> conference is coming in 2 days.
     log:
       value_types:
         conference_presenter:
-          not_found: 'Konferans veritabanında bulunamadı (ID: %{id})'
+          not_found: 'The conference was not found on the database (ID: %{id})'
     media:
       index:
-        description: Bu konferans hakkında bağlantılar
-        title: Medya ve Linkler
+        description: Links about this conference
+        title: Media and Links
     menu:
-      conferences: Konferanslar
+      conferences: Conferences
   devise:
     mailer:
       join_conference:
-        subject: Bir konferansa katılma daveti
+        subject: Invitation to join a conference
   layouts:
     decidim:
       conference_hero:
-        register: Kayıt olmak
+        register: Register
       conference_widgets:
         show:
-          take_part: Yer almak
+          take_part: Take part
       conferences:
         conference:
-          take_part: Yer almak
+          take_part: Take part
         index:
-          promoted_conferences: Tanıtılan konferanslar
+          promoted_conferences: Promoted conferences
         order_by_conferences:
           conferences:
-            one: "%{count} konferans"
-            other: "%{count} konferans"
+            one: "%{count} conference"
+            other: "%{count} conferences"
         promoted_conference:
-          more_info: Daha fazla bilgi
-          take_part: Yer almak
+          more_info: More info
+          take_part: Take part
       conferences_nav:
-        conference_menu_item: Bilgi
-        conference_partners_menu_item: Ortaklar
-        conference_speaker_menu_item: Hoparlörler
-        media: medya
-        venues: Mekanları
+        conference_menu_item: Information
+        conference_partners_menu_item: Partners
+        conference_speaker_menu_item: Speakers
+        media: Media
+        venues: Venues

--- a/decidim-consultations/config/locales/es.yml
+++ b/decidim-consultations/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -249,7 +250,7 @@ es:
         consultations:
           contextual: "<p>Las consultas son un espacio que permite realizar una pregunta clara a todas las personas que forman una organización, hacer un llamamiento a participar en la consulta, suscitar y ordenar el debate a favor o encontra de una respuesta. Llegada la fecha de la consulta permite votar y publicar los resultados de las votaciones.</p> <p>Ejemplos: Las consultas puede versar sobre casi cualquier aspecto que afecte a una organización: algunos ejemplos son cambiar el nombre o logotipo de la organización ofreciendo varias alternativas, decidir Sí o No a formar parte de una organización más grande, validar o rechazar un nuevo plan estratégico o el resultado de un grupo de trabajo, o definir si los cargos deben permanecer un máximo de 1, 2 ó 3 mandatos.</p>\n"
           page: "<p>Las consultas son un espacio que permite realizar una pregunta clara a todas las personas que forman una organización, hacer un llamamiento a participar en la consulta, suscitar y ordenar el debate a favor o encontra de una respuesta. Llegada la fecha de la consulta permite votar y publicar los resultados de las votaciones.</p> <p>Ejemplos: Las consultas puede versar sobre casi cualquier aspecto que afecte a una organización: algunos ejemplos son cambiar el nombre o logotipo de la organización ofreciendo varias alternativas, decidir Sí o No a formar parte de una organización más grande, validar o rechazar un nuevo plan estratégico o el resultado de un grupo de trabajo, o definir si los cargos deben permanecer un máximo de 1, 2 ó 3 mandatos.</p>\n"
-          title: '¿Qué son las consultas?'
+          title: "¿Qué son las consultas?"
     menu:
       consultations: Consultas
     pages:

--- a/decidim-consultations/config/locales/fi-pl.yml
+++ b/decidim-consultations/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:

--- a/decidim-consultations/config/locales/fr.yml
+++ b/decidim-consultations/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:

--- a/decidim-consultations/config/locales/id-ID.yml
+++ b/decidim-consultations/config/locales/id-ID.yml
@@ -1,286 +1,297 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       consultation:
-        banner_image: Gambar spanduk
-        decidim_highlighted_scope_id: Ruang lingkup yang disorot
-        description: Deskripsi
-        end_voting_date: Voting berakhir
-        introductory_image: Gambar perkenalan
-        introductory_video_url: URL video perkenalan
-        questions: Pertanyaan
-        slug: Siput URL
-        start_voting_date: Voting dimulai
+        banner_image: Banner image
+        decidim_highlighted_scope_id: Highlighted scope
+        description: Description
+        end_voting_date: Voting ends
+        introductory_image: Introductory image
+        introductory_video_url: Introductory video URL
+        questions: Questions
+        slug: URL slug
+        start_voting_date: Voting begins
         subtitle: Subtitle
-        title: Judul
+        title: Title
       question:
-        banner_image: Gambar spanduk
-        decidim_scope_id: Daerah kota
-        hashtag: Tanda pagar
-        hero_image: Gambar rumah
-        i_frame_url: URL sistem pemungutan suara eksternal
-        origin_scope: Cakupan
-        origin_title: Asal
-        origin_url: URL Asal
-        participatory_scope: Ruang lingkup partisipatif
-        promoter_group: Grup promotor
-        question_context: Konteks
-        reference: Referensi
-        scope: Daerah kota
-        slug: Siput URL
+        banner_image: Banner image
+        decidim_scope_id: Municipal area
+        hashtag: Hashtag
+        hero_image: Home image
+        i_frame_url: External voting system URL
+        origin_scope: Scope
+        origin_title: Origin
+        origin_url: Origin URL
+        participatory_scope: Participatory scope
+        promoter_group: Promoter group
+        question_context: Context
+        reference: Reference
+        scope: Municipal area
+        slug: URL slug
         subtitle: Subtitle
-        title: Judul
-        vote: Sistem pemungutan suara eksternal
-        what_is_decided: Apa yang diputuskan
+        title: Title
+        vote: External voting system
+        what_is_decided: What is decided
     errors:
       vote:
         decidim_consultations_response_id:
-          not_found: Tanggapan tidak ditemukan.
+          not_found: Response not found.
   activerecord:
     models:
       decidim/consultation:
-        other: Konsultasi
+        one: Consultation
+        other: Consultations
       decidim/consultations/question:
-        other: Pertanyaan
+        one: Question
+        other: Questions
       decidim/consultations/response:
-        other: Tanggapan
+        one: Response
+        other: Responses
       decidim/consultations/vote:
-        other: Voting
+        one: No votes
+        other: Votes
   decidim:
     admin:
       actions:
-        new_consultation: Konsultasi baru
-        new_question: Pertanyaan baru
-        new_response: Tanggapan baru
-        publish_results: Publikasikan hasil
-        unpublish_results: Jangan publikasikan hasil
+        new_consultation: New consultation
+        new_question: New question
+        new_response: New response
+        publish_results: Publish results
+        unpublish_results: Unpublish results
       consultation_publications:
         create:
-          error: Terjadi kesalahan saat memublikasikan konsultasi ini.
-          success: Konsultasi berhasil dipublikasikan.
+          error: There was an error publishing this consultation.
+          success: Consultation published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi konsultasi ini.
-          success: Konsultasi tidak berhasil dipublikasikan.
+          error: There was an error unpublishing this consultation.
+          success: Consultation unpublished successfully.
       consultation_results_publications:
         create:
-          error: Terjadi kesalahan saat memublikasikan hasil untuk konsultasi ini.
-          success: Hasil konsultasi berhasil dipublikasikan.
+          error: There was an error publishing the results for this consultation.
+          success: Consultation results published successfully.
         destroy:
-          error: Ada kesalahan membatalkan publikasi hasil untuk konsultasi ini.
-          success: Hasil konsultasi tidak berhasil dipublikasikan.
+          error: There was an error unpublishing the results for this consultation.
+          success: Consultation results unpublished successfully.
       consultations:
         create:
-          error: Ada kesalahan saat membuat konsultasi baru.
-          success: Konsultasi berhasil dibuat.
+          error: There was an error creating a new consultation.
+          success: Consultation successfully created.
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          slug_help: 'Siput URL digunakan untuk menghasilkan URL yang mengarah ke konsultasi ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
-          title: Informasi Umum
+          slug_help: 'URL slugs are used to generate the URLs that point to this consultation. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+          title: General information
         index:
-          not_published: Tidak diterbitkan
-          published: Diterbitkan
+          not_published: Not published
+          published: Published
         new:
-          create: Membuat
-          title: Konsultasi baru
+          create: Create
+          title: New consultation
         update:
-          error: Ada kesalahan saat memperbarui konsultasi ini.
-          success: Konsultasi berhasil diperbarui.
+          error: There was an error when updating this consultation.
+          success: Consultation updated successfully.
       menu:
-        consultations: Konsultasi
+        consultations: Consultations
         consultations_submenu:
-          info: Informasi
-          questions: Pertanyaan
+          info: Information
+          questions: Questions
         questions_submenu:
-          components: Komponen
-          consultation: Konsultasi
-          info: Informasi
-          responses: Tanggapan
+          components: Components
+          consultation: Consultation
+          info: Information
+          responses: Responses
       models:
         consultation:
           fields:
-            created_at: Dibuat di
-            published: Diterbitkan
-            title: Judul
+            created_at: Created at
+            published: Published
+            title: Title
           name:
-            other: Konsultasi
+            one: Consultation
+            other: Consultations
         question:
           fields:
-            created_at: Dibuat di
-            published: Diterbitkan
-            title: Judul
+            created_at: Created at
+            published: Published
+            title: Title
           name:
-            other: Pertanyaan
+            one: Question
+            other: Questions
         response:
           fields:
-            created_at: Dibuat di
-            title: Judul
+            created_at: Created at
+            title: Title
           name:
-            other: Tanggapan
+            one: Response
+            other: Responses
       question_publications:
         create:
-          error: Terjadi kesalahan saat memublikasikan pertanyaan ini.
-          success: Pertanyaan berhasil diterbitkan.
+          error: There was an error publishing this question.
+          success: Question published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi pertanyaan ini.
-          success: Pertanyaan tidak berhasil diterbitkan.
+          error: There was an error unpublishing this question.
+          success: Question unpublished successfully.
       questions:
         create:
-          error: Ada kesalahan saat membuat pertanyaan baru.
-          success: Pertanyaan berhasil dibuat.
+          error: There was an error creating a new question.
+          success: Question successfully created.
         destroy:
-          success: Pertanyaan berhasil dihapus.
+          success: Question successfully deleted.
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          title: Informasi Umum
+          title: General information
         index:
-          not_published: Tidak diterbitkan
-          published: Diterbitkan
+          not_published: Not published
+          published: Published
         new:
-          create: Membuat
-          title: Pertanyaan baru
+          create: Create
+          title: New question
         update:
-          error: Ada kesalahan saat memperbarui pertanyaan ini.
-          success: Pertanyaan berhasil diperbarui.
+          error: There was an error when updating this question.
+          success: Question updated successfully.
       responses:
         create:
-          error: Ada kesalahan saat membuat tanggapan baru.
-          success: Tanggapan berhasil dibuat.
+          error: There was an error creating a new response.
+          success: Response successfully created.
         destroy:
-          error: Ada kesalahan saat menghapus respons.
-          success: Tanggapan berhasil dihapus.
+          error: There was an error when removing the response.
+          success: Response successfully deleted.
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          title: Informasi Umum
+          title: General information
         new:
-          create: Membuat
-          title: Tanggapan baru
+          create: Create
+          title: New response
         update:
-          error: Terjadi kesalahan saat memperbarui tanggapan ini.
-          success: Tanggapan berhasil diperbarui.
+          error: There was an error when updating this response.
+          success: Response updated successfully.
       titles:
-        consultations: Konsultasi
-        questions: Pertanyaan
-        responses: Tanggapan
+        consultations: Consultations
+        questions: Questions
+        responses: Responses
     consultations:
       admin:
         content_blocks:
           highlighted_consultations:
-            max_results: Jumlah maksimum elemen untuk ditampilkan
+            max_results: Maximum amount of elements to show
       consultation:
-        start_voting_date: Voting dimulai
-        view_results: Lihat hasil
+        start_voting_date: Voting begins
+        view_results: View results
       consultation_card:
-        view_results: Lihat hasil
+        view_results: View results
       consultations:
         orders:
-          label: 'Urutkan konsultasi dengan:'
-          random: Acak
-          recent: Terbaru
+          label: 'Sort consultations by:'
+          random: Random
+          recent: Most recent
       content_blocks:
         highlighted_consultations:
-          name: Konsultasi yang disorot
+          name: Highlighted consultations
       count:
         title:
-          other: "%{count} konsultasi"
+          one: "%{count} consultation"
+          other: "%{count} consultations"
       filters:
-        active: Aktif
-        all: Semua
-        finished: Jadi
-        search: Pencarian
-        state: Negara
-        upcoming: Mendatang
+        active: Active
+        all: All
+        finished: Finished
+        search: Search
+        state: State
+        upcoming: Upcoming
       filters_small_view:
-        close_modal: Tutup jendela
+        close_modal: Close window
         filter: Filter
-        filter_by: Filter berdasarkan
-        unfold: Membuka
+        filter_by: Filter by
+        unfold: Unfold
       highlighted_questions:
-        title: Pertanyaan dari %{scope_name}
+        title: Questions from %{scope_name}
       index:
-        title: Konsultasi
+        title: Consultations
       last_activity:
-        new_consultation: Konsultasi baru
-        new_question_at_html: "<span>Pertanyaan baru pada %{link}</span>"
+        new_consultation: New consultation
+        new_question_at_html: "<span>New question at %{link}</span>"
       pages:
         home:
           highlighted_consultations:
-            active_consultations: Konsultasi aktif
-            see_all_consultations: Lihat semua konsultasi
+            active_consultations: Active consultations
+            see_all_consultations: See all consultations
             voting_ends_in:
-              other: Voting berakhir dalam <strong>%{count} hari</strong>
-            voting_ends_today: Voting berakhir <strong>hari ini</strong>
+              one: Voting ends <strong>tomorrow</strong>
+              other: Voting ends in <strong>%{count} days</strong>
+            voting_ends_today: Voting ends <strong>today</strong>
       question:
-        take_part: Ambil bagian
-        view_results: Lihat hasil
+        take_part: Take part
+        view_results: View results
         votes_out_of:
-          other: suara keluar
+          one: vote out of
+          other: votes out of
       question_votes:
         create:
-          error: Ada kesalahan saat memilih pertanyaan
+          error: There have been errors when voting the question
       regular_questions:
-        title: Pertanyaan untuk konsultasi ini
+        title: Questions for this consultation
       show:
         badge_name:
-          finished: Jadi
-          open: Buka
-          open_votes: Buka suara
-          published_results: Hasil dipublikasikan
+          finished: Finished
+          open: Open
+          open_votes: Open votes
+          published_results: Results published
         footer_button_text:
-          debate: Perdebatan
-          view: Melihat
-          view_results: Lihat hasil
-          vote: Memilih
-        unspecified: Tidak ditentukan
+          debate: Debate
+          view: View
+          view_results: View results
+          vote: Vote
+        unspecified: Not specified
     help:
       participatory_spaces:
         consultations:
-          contextual: "<p>Konsultasi adalah ruang yang memungkinkan Anda untuk mengajukan pertanyaan yang jelas untuk semua orang yang membentuk sebuah organisasi, membuat panggilan untuk berpartisipasi dalam konsultasi, percikan dan memesan perdebatan untuk atau terhadap tanggapan. Ketika tanggal konsultasi tiba, Anda dapat memilih dan mempublikasikan hasil suara.</p> <p>Contoh: Konsultasi dapat mengenai hampir semua aspek yang mempengaruhi organisasi: beberapa contoh mengubah nama atau logo organisasi yang menawarkan beberapa alternatif, memutuskan Ya atau Tidak untuk menjadi bagian dari organisasi yang lebih besar, memvalidasi atau menolak strategi baru merencanakan atau hasil dari kelompok kerja, atau menentukan apakah posisi harus tetap maksimal 1, 2 atau 3 mandat.</p>\n"
-          page: "<p>Konsultasi adalah ruang yang memungkinkan Anda untuk mengajukan pertanyaan yang jelas untuk semua orang yang membentuk sebuah organisasi, membuat panggilan untuk berpartisipasi dalam konsultasi, percikan dan memesan perdebatan untuk atau terhadap tanggapan. Ketika tanggal konsultasi tiba, Anda dapat memilih dan mempublikasikan hasil suara.</p> <p>Contoh: Konsultasi dapat mengenai hampir semua aspek yang mempengaruhi organisasi: beberapa contoh mengubah nama atau logo organisasi yang menawarkan beberapa alternatif, memutuskan Ya atau Tidak untuk menjadi bagian dari organisasi yang lebih besar, memvalidasi atau menolak strategi baru merencanakan atau hasil dari kelompok kerja, atau menentukan apakah posisi harus tetap maksimal 1, 2 atau 3 mandat.</p>ard dalam organisasi.</p>\n"
-          title: Apa itu konsultasi?
+          contextual: "<p>Consultations are a space that allows you to ask a clear question to all the people who form an organization, make a call to participate in the consultation, spark and order the debate for or against a response. When the consultation date arrives, you can vote and publish the results of the votes.</p> <p>Examples: The consultations can be about almost any aspect that affects an organization: some examples are changing the name or logo of the organization offering several alternatives, deciding Yes or No to become part of a larger organization, validating or rejecting a new strategic plan or the result of a working group, or defining whether the positions should remain a maximum of 1, 2 or 3 mandates.</p>\n"
+          page: "<p>Consultations are a space that allows you to ask a clear question to all the people who form an organization, make a call to participate in the consultation, spark and order the debate for or against a response. When the consultation date arrives, you can vote and publish the results of the votes.</p> <p>Examples: The consultations can be about almost any aspect that affects an organization: some examples are changing the name or logo of the organization offering several alternatives, deciding Yes or No to become part of a larger organization, validating or rejecting a new strategic plan or the result of a working group, or defining whether the positions should remain a maximum of 1, 2 or 3 mandates in the organization.</p>\n"
+          title: What are consultations?
     menu:
-      consultations: Konsultasi
+      consultations: Consultations
     pages:
       home:
         statistics:
-          consultations_count: Konsultasi
+          consultations_count: Consultations
     questions:
       results:
-        title: Hasil
+        title: Results
       show:
-        read_more: Baca lebih lajut
+        read_more: Read more
       statistics:
-        assistants_count_title: Asisten
-        comments_count_title: Komentar
-        meetings_count_title: Rapat
-        supports_count_title: Mendukung
+        assistants_count_title: Assistants
+        comments_count_title: Comments
+        meetings_count_title: Meetings
+        supports_count_title: Supports
       technical_info:
-        technical_data: Data teknis
+        technical_data: Technical data
       vote_button:
-        already_voted: Sudah memilih
-        already_voted_hover: Cabut dukungan
-        starting_from: Mulai dari %{date}
-        vote: Memilih
+        already_voted: Already voted
+        already_voted_hover: Revoke support
+        starting_from: Starting from %{date}
+        vote: Vote
       vote_modal:
-        contextual_help: Silakan, pilih opsi.
-        title: 'Konsultasi: dukungan pertanyaan'
+        contextual_help: Please, select an option.
+        title: 'Consultation: question support'
       vote_modal_confirm:
-        change: Perubahan
-        confirm: Memastikan
-        contextual_help: Harap konfirmasikan opsi yang dipilih.
-        title: 'Konsultasi: konfirmasi dukungan'
+        change: Change
+        confirm: Confirm
+        contextual_help: Please confirm the selected option.
+        title: 'Consultation: confirm support'
   layouts:
     decidim:
       admin:
         question:
-          attachments: Lampiran
-          categories: Kategori
+          attachments: Attachments
+          categories: Categories
       consultation_voting_data:
-        start_voting_date: Voting dimulai
+        start_voting_date: Voting begins
       question_components:
-        question_menu_item: Pertanyaan
-        unfold: Membuka
+        question_menu_item: The question
+        unfold: Unfold
       question_header:
-        back_to_consultation: Lihat semua konsultasi
+        back_to_consultation: See all consultations

--- a/decidim-consultations/config/locales/tr-TR.yml
+++ b/decidim-consultations/config/locales/tr-TR.yml
@@ -1,296 +1,297 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       consultation:
-        banner_image: Banner resmi
-        decidim_highlighted_scope_id: Vurgulanan kapsam
-        description: Açıklama
-        end_voting_date: Oylama biter
-        introductory_image: Tanıtım görüntü
-        introductory_video_url: Tanıtım videosu URL'si
-        questions: Sorular
-        slug: URL sümüklü böcek
-        start_voting_date: Oylama başlıyor
-        subtitle: Alt yazı
-        title: Başlık
+        banner_image: Banner image
+        decidim_highlighted_scope_id: Highlighted scope
+        description: Description
+        end_voting_date: Voting ends
+        introductory_image: Introductory image
+        introductory_video_url: Introductory video URL
+        questions: Questions
+        slug: URL slug
+        start_voting_date: Voting begins
+        subtitle: Subtitle
+        title: Title
       question:
-        banner_image: Banner resmi
-        decidim_scope_id: Belediye alanı
-        hashtag: Başlık etiketi
-        hero_image: Ana resim
-        i_frame_url: Harici oylama sistemi URL'si
-        origin_scope: kapsam
-        origin_title: Menşei
-        origin_url: Kökeni URL
-        participatory_scope: Katılımcı kapsamı
-        promoter_group: Tanıtım grubu
-        question_context: bağlam
-        reference: Referans
-        scope: Belediye alanı
-        slug: URL sümüklü böcek
-        subtitle: Alt yazı
-        title: Başlık
-        vote: Dış oylama sistemi
-        what_is_decided: Karar nedir
+        banner_image: Banner image
+        decidim_scope_id: Municipal area
+        hashtag: Hashtag
+        hero_image: Home image
+        i_frame_url: External voting system URL
+        origin_scope: Scope
+        origin_title: Origin
+        origin_url: Origin URL
+        participatory_scope: Participatory scope
+        promoter_group: Promoter group
+        question_context: Context
+        reference: Reference
+        scope: Municipal area
+        slug: URL slug
+        subtitle: Subtitle
+        title: Title
+        vote: External voting system
+        what_is_decided: What is decided
     errors:
       vote:
         decidim_consultations_response_id:
-          not_found: Yanıt bulunamadı.
+          not_found: Response not found.
   activerecord:
     models:
       decidim/consultation:
-        one: konsültasyon
-        other: istişareler
+        one: Consultation
+        other: Consultations
       decidim/consultations/question:
-        one: Soru
-        other: Sorular
+        one: Question
+        other: Questions
       decidim/consultations/response:
-        one: Tepki
-        other: Tepkiler
+        one: Response
+        other: Responses
       decidim/consultations/vote:
-        one: Oy
-        other: oy
+        one: No votes
+        other: Votes
   decidim:
     admin:
       actions:
-        new_consultation: Yeni danışma
-        new_question: Yeni soru
-        new_response: Yeni cevap
-        publish_results: Sonuçları yayınla
-        unpublish_results: Sonuçları yayından kaldır
+        new_consultation: New consultation
+        new_question: New question
+        new_response: New response
+        publish_results: Publish results
+        unpublish_results: Unpublish results
       consultation_publications:
         create:
-          error: Bu danışmada bir hata oluştu.
-          success: Danışmanlık başarıyla yayınlandı.
+          error: There was an error publishing this consultation.
+          success: Consultation published successfully.
         destroy:
-          error: Bu danışma işleminin yayından kaldırılmasıyla ilgili bir hata oluştu.
-          success: Danışmanlık başarıyla yayından kaldırıldı.
+          error: There was an error unpublishing this consultation.
+          success: Consultation unpublished successfully.
       consultation_results_publications:
         create:
-          error: Bu danışma için sonuçları yayınlayan bir hata oluştu.
-          success: Danışmanlık sonuçları başarıyla yayınlandı.
+          error: There was an error publishing the results for this consultation.
+          success: Consultation results published successfully.
         destroy:
-          error: Bu danışma için sonuçların yayından kaldırılmasıyla ilgili bir hata oluştu.
-          success: Danışmanlık sonuçları başarılı bir şekilde yayınlanmamıştır.
+          error: There was an error unpublishing the results for this consultation.
+          success: Consultation results unpublished successfully.
       consultations:
         create:
-          error: Yeni bir danışma oluştururken bir hata oluştu.
-          success: Danışmanlık başarıyla oluşturuldu.
+          error: There was an error creating a new consultation.
+          success: Consultation successfully created.
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          slug_help: 'URL sümükleri, bu danışmaya işaret eden URL''leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
-          title: Genel bilgi
+          slug_help: 'URL slugs are used to generate the URLs that point to this consultation. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+          title: General information
         index:
-          not_published: Yayınlanmadı
-          published: Yayınlanan
+          not_published: Not published
+          published: Published
         new:
-          create: yaratmak
-          title: Yeni danışma
+          create: Create
+          title: New consultation
         update:
-          error: Bu danışma hizmetini güncellerken bir hata oluştu.
-          success: Danışma başarıyla güncellendi.
+          error: There was an error when updating this consultation.
+          success: Consultation updated successfully.
       menu:
-        consultations: istişareler
+        consultations: Consultations
         consultations_submenu:
-          info: Bilgi
-          questions: Sorular
+          info: Information
+          questions: Questions
         questions_submenu:
-          components: Bileşenler
-          consultation: konsültasyon
-          info: Bilgi
-          responses: Tepkiler
+          components: Components
+          consultation: Consultation
+          info: Information
+          responses: Responses
       models:
         consultation:
           fields:
-            created_at: Düzenlendi
-            published: Yayınlanan
-            title: Başlık
+            created_at: Created at
+            published: Published
+            title: Title
           name:
-            one: konsültasyon
-            other: istişareler
+            one: Consultation
+            other: Consultations
         question:
           fields:
-            created_at: Düzenlendi
-            published: Yayınlanan
-            title: Başlık
+            created_at: Created at
+            published: Published
+            title: Title
           name:
-            one: Soru
-            other: Sorular
+            one: Question
+            other: Questions
         response:
           fields:
-            created_at: Düzenlendi
-            title: Başlık
+            created_at: Created at
+            title: Title
           name:
-            one: Tepki
-            other: Tepkiler
+            one: Response
+            other: Responses
       question_publications:
         create:
-          error: Bu soruyu yayınlarken bir hata oluştu.
-          success: Soru başarıyla basıldı.
+          error: There was an error publishing this question.
+          success: Question published successfully.
         destroy:
-          error: Bu soruyu yayından kaldırmada bir hata oluştu.
-          success: Soru başarıyla basıldı.
+          error: There was an error unpublishing this question.
+          success: Question unpublished successfully.
       questions:
         create:
-          error: Yeni bir soru oluşturulurken bir hata oluştu.
-          success: Soru başarıyla oluşturuldu.
+          error: There was an error creating a new question.
+          success: Question successfully created.
         destroy:
-          success: Soru başarıyla silindi.
+          success: Question successfully deleted.
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          title: Genel bilgi
+          title: General information
         index:
-          not_published: Yayınlanmadı
-          published: Yayınlanan
+          not_published: Not published
+          published: Published
         new:
-          create: yaratmak
-          title: Yeni soru
+          create: Create
+          title: New question
         update:
-          error: Bu soru güncellenirken bir hata oluştu.
-          success: Soru başarıyla güncellendi.
+          error: There was an error when updating this question.
+          success: Question updated successfully.
       responses:
         create:
-          error: Yeni bir yanıt oluştururken bir hata oluştu.
-          success: Yanıt başarıyla oluşturuldu.
+          error: There was an error creating a new response.
+          success: Response successfully created.
         destroy:
-          error: Yanıtı kaldırırken bir hata oluştu.
-          success: Yanıt başarıyla silindi.
+          error: There was an error when removing the response.
+          success: Response successfully deleted.
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          title: Genel bilgi
+          title: General information
         new:
-          create: yaratmak
-          title: Yeni cevap
+          create: Create
+          title: New response
         update:
-          error: Bu yanıtı güncellerken bir hata oluştu.
-          success: Yanıt başarıyla güncellendi.
+          error: There was an error when updating this response.
+          success: Response updated successfully.
       titles:
-        consultations: istişareler
-        questions: Sorular
-        responses: Tepkiler
+        consultations: Consultations
+        questions: Questions
+        responses: Responses
     consultations:
       admin:
         content_blocks:
           highlighted_consultations:
-            max_results: Gösterilecek maksimum öğe miktarı
+            max_results: Maximum amount of elements to show
       consultation:
-        start_voting_date: Oylama başlıyor
-        view_results: Sonuçları Görüntüle
+        start_voting_date: Voting begins
+        view_results: View results
       consultation_card:
-        view_results: Sonuçları Görüntüle
+        view_results: View results
       consultations:
         orders:
-          label: 'Danışmanlıklara göre sırala:'
-          random: rasgele
-          recent: En yeni
+          label: 'Sort consultations by:'
+          random: Random
+          recent: Most recent
       content_blocks:
         highlighted_consultations:
-          name: Vurgulanan istişareler
+          name: Highlighted consultations
       count:
         title:
-          one: "%{count} danışma"
-          other: "%{count} görüşme"
+          one: "%{count} consultation"
+          other: "%{count} consultations"
       filters:
-        active: Aktif
-        all: Herşey
-        finished: bitirdi
-        search: Arama
-        state: Belirtmek, bildirmek
-        upcoming: Yaklaşan
+        active: Active
+        all: All
+        finished: Finished
+        search: Search
+        state: State
+        upcoming: Upcoming
       filters_small_view:
-        close_modal: Pencereyi kapat
-        filter: filtre
-        filter_by: Tarafından filtre
-        unfold: açılmak
+        close_modal: Close window
+        filter: Filter
+        filter_by: Filter by
+        unfold: Unfold
       highlighted_questions:
-        title: '%{scope_name}soru'
+        title: Questions from %{scope_name}
       index:
-        title: istişareler
+        title: Consultations
       last_activity:
-        new_consultation: Yeni danışma
-        new_question_at_html: "<span>Yeni soru, %{link}</span>"
+        new_consultation: New consultation
+        new_question_at_html: "<span>New question at %{link}</span>"
       pages:
         home:
           highlighted_consultations:
-            active_consultations: Aktif istişareler
-            see_all_consultations: Tüm istişarelere bakın
+            active_consultations: Active consultations
+            see_all_consultations: See all consultations
             voting_ends_in:
-              one: Oylama bitiş <strong>yarın</strong>
-              other: Oylama <strong>%{count} gün içinde sona erer</strong>
-            voting_ends_today: Oylama bitiş <strong>bugün</strong>
+              one: Voting ends <strong>tomorrow</strong>
+              other: Voting ends in <strong>%{count} days</strong>
+            voting_ends_today: Voting ends <strong>today</strong>
       question:
-        take_part: Yer almak
-        view_results: Sonuçları Görüntüle
+        take_part: Take part
+        view_results: View results
         votes_out_of:
-          one: oy vermek
-          other: oy vermemek
+          one: vote out of
+          other: votes out of
       question_votes:
         create:
-          error: Soruya oy verirken hatalar oldu
+          error: There have been errors when voting the question
       regular_questions:
-        title: Bu danışma için sorular
+        title: Questions for this consultation
       show:
         badge_name:
-          finished: bitirdi
-          open: Açık
-          open_votes: Açık oylar
-          published_results: Sonuçlar yayınlandı
+          finished: Finished
+          open: Open
+          open_votes: Open votes
+          published_results: Results published
         footer_button_text:
-          debate: tartışma
-          view: Görünüm
-          view_results: Sonuçları Görüntüle
-          vote: Oy
-        unspecified: Belirtilmemiş
+          debate: Debate
+          view: View
+          view_results: View results
+          vote: Vote
+        unspecified: Not specified
     help:
       participatory_spaces:
         consultations:
-          contextual: "<p>İstişareler, bir organizasyon oluşturan tüm kişilere net bir soru sormanızı, görüşmelere katılmak için bir çağrı yapmanızı, bir sorgunun lehine veya aleyhinde tartışma başlatmanızı ve talep etmenizi sağlayan bir alandır. Danışma tarihi geldiğinde, oyların sonuçlarını oylayabilir ve yayınlayabilirsiniz.</p> <p>Örnekler: İstişareler, bir örgütü etkileyen hemen hemen her yönüyle ilgili olabilir: bazı örnekler, organizasyonun adını veya logosunu çeşitli alternatifler sunarak değiştirir, daha büyük bir organizasyonun parçası olmak için Evet veya Hayır'a karar verir, yeni bir stratejikin geçerliliğini onaylar veya reddeder. Bir çalışma grubunun sonucu veya planı veya pozisyonların en fazla 1, 2 veya 3 mandat kalması gerekip gerekmediğini tanımlamak.</p>\n"
-          page: "<p>İstişareler, bir organizasyon oluşturan tüm kişilere net bir soru sormanızı, görüşmelere katılmak için bir çağrı yapmanızı, bir sorgunun lehine veya aleyhinde tartışma başlatmanızı ve talep etmenizi sağlayan bir alandır. Danışma tarihi geldiğinde, oyların sonuçlarını oylayabilir ve yayınlayabilirsiniz.</p> <p>Örnekler: İstişareler, bir örgütü etkileyen hemen hemen her yönüyle ilgili olabilir: bazı örnekler, organizasyonun adını veya logosunu çeşitli alternatifler sunarak değiştirir, daha büyük bir organizasyonun parçası olmak için Evet veya Hayır'a karar verir, yeni bir stratejikin geçerliliğini onaylar veya reddeder. Bir çalışma grubunun sonucu veya planı veya pozisyonların en fazla 1, 2 veya 3 mandat kalması gerekip gerekmediğini tanımlamak. Organizasyonda</p>ard.</p>\n"
-          title: Danışmalar nelerdir?
+          contextual: "<p>Consultations are a space that allows you to ask a clear question to all the people who form an organization, make a call to participate in the consultation, spark and order the debate for or against a response. When the consultation date arrives, you can vote and publish the results of the votes.</p> <p>Examples: The consultations can be about almost any aspect that affects an organization: some examples are changing the name or logo of the organization offering several alternatives, deciding Yes or No to become part of a larger organization, validating or rejecting a new strategic plan or the result of a working group, or defining whether the positions should remain a maximum of 1, 2 or 3 mandates.</p>\n"
+          page: "<p>Consultations are a space that allows you to ask a clear question to all the people who form an organization, make a call to participate in the consultation, spark and order the debate for or against a response. When the consultation date arrives, you can vote and publish the results of the votes.</p> <p>Examples: The consultations can be about almost any aspect that affects an organization: some examples are changing the name or logo of the organization offering several alternatives, deciding Yes or No to become part of a larger organization, validating or rejecting a new strategic plan or the result of a working group, or defining whether the positions should remain a maximum of 1, 2 or 3 mandates in the organization.</p>\n"
+          title: What are consultations?
     menu:
-      consultations: istişareler
+      consultations: Consultations
     pages:
       home:
         statistics:
-          consultations_count: istişareler
+          consultations_count: Consultations
     questions:
       results:
-        title: Sonuçlar
+        title: Results
       show:
-        read_more: Daha fazla oku
+        read_more: Read more
       statistics:
-        assistants_count_title: Yardımcıları
-        comments_count_title: Yorumlar
-        meetings_count_title: Toplantılar
-        supports_count_title: Destekler
+        assistants_count_title: Assistants
+        comments_count_title: Comments
+        meetings_count_title: Meetings
+        supports_count_title: Supports
       technical_info:
-        technical_data: Teknik veri
+        technical_data: Technical data
       vote_button:
-        already_voted: Çoktan oy verildi
-        already_voted_hover: Desteği iptal et
-        starting_from: '%{date}başlayarak'
-        vote: Oy
+        already_voted: Already voted
+        already_voted_hover: Revoke support
+        starting_from: Starting from %{date}
+        vote: Vote
       vote_modal:
-        contextual_help: Lütfen bir seçenek seçin.
-        title: 'Danışma: soru desteği'
+        contextual_help: Please, select an option.
+        title: 'Consultation: question support'
       vote_modal_confirm:
-        change: Değişiklik
-        confirm: Onaylamak
-        contextual_help: Lütfen seçilen seçeneği onaylayın.
-        title: 'Danışma: teyit teyit'
+        change: Change
+        confirm: Confirm
+        contextual_help: Please confirm the selected option.
+        title: 'Consultation: confirm support'
   layouts:
     decidim:
       admin:
         question:
-          attachments: Ekler
-          categories: Kategoriler
+          attachments: Attachments
+          categories: Categories
       consultation_voting_data:
-        start_voting_date: Oylama başlıyor
+        start_voting_date: Voting begins
       question_components:
-        question_menu_item: Soru
-        unfold: açılmak
+        question_menu_item: The question
+        unfold: Unfold
       question_header:
-        back_to_consultation: Tüm istişarelere bakın
+        back_to_consultation: See all consultations

--- a/decidim-core/app/mailers/decidim/application_mailer.rb
+++ b/decidim-core/app/mailers/decidim/application_mailer.rb
@@ -5,8 +5,23 @@ module Decidim
   # mailers.
   class ApplicationMailer < ActionMailer::Base
     include LocalisedMailer
+    after_action :set_smtp
 
     default from: Decidim.config.mailer_sender
     layout "decidim/mailer"
+
+    private
+
+    def set_smtp
+      return if @organization.nil? || @organization.smtp_settings.blank?
+
+      mail.from = @organization.smtp_settings["from"] if @organization
+      mail.delivery_method.settings.merge!(
+        address: @organization.smtp_settings["address"],
+        port: @organization.smtp_settings["port"],
+        user_name: @organization.smtp_settings["user_name"],
+        password: Decidim::AttributeEncryptor.decrypt(@organization.smtp_settings["encrypted_password"])
+      ) { |_k, o, v| v.presence || o }.reject! { |_k, v| v.blank? }
+    end
   end
 end

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ ca:
         personal_url: URL personal
         remove_avatar: Elimina la imatge d'usuari
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Adjunt
       decidim/component_published_event: Component actiu
       decidim/demoted_membership: Ja no ets administrador de grup
@@ -46,7 +51,7 @@ ca:
         other: Grups d'usuaris
   booleans:
     'false': 'No'
-    'true': 'Sí'
+    'true': Sí
   carrierwave:
     errors:
       image_too_big: La imatge és massa gran
@@ -136,12 +141,12 @@ ca:
       amendable:
         amended_by: Esmenat per
         button: Esmenar %{model_name}
-        promote_button: Promocionar a %{model_name}
         error: S'ha produït un error en modificar aquest recurs.
         help_text: Milloreu aquest %{model_name} modificant la seva %{amendable_fields}
-        promote_help_text: Podeu publicar aquesta esmena com a proposta independent %{model_name}
         no_amenders: No hi ha cap esmenador
         no_amendments: No hi ha cap esmena
+        promote_button: Promocionar a %{model_name}
+        promote_help_text: Podeu publicar aquesta esmena com a proposta independent %{model_name}
         section_heading: Esmenes (%{count})
       created:
         error: S'ha produït un error en crear aquesta esmena, torneu-ho a provar més tard
@@ -155,8 +160,7 @@ ca:
           accepted: |-
             Aquesta modificació per al %{amendable_type} %{amendable_link} ha estat
             acceptada a <strong>%{announcement_date}</strong>.
-          evaluating: |-
-            S'està avaluant aquesta esmena del %{amendable_type} %{amendable_link}.
+          evaluating: S'està avaluant aquesta esmena del %{amendable_type} %{amendable_link}.
           rejected: |-
             Aquesta esmena del %{amendable_type} %{amendable_link}
             va ser rebutjada en <strong>%{announcement_date}</strong>.
@@ -169,12 +173,12 @@ ca:
         heading: Crea la teva esmena
         help_text: Estàs modificant el %{model_name}
         send: Enviar esmena
+      promoted:
+        error: Hi ha hagut errors en publicar l'esmena com a proposta
+        success: L'esmena s'ha publicat com a proposta correctament
       rejected:
         error: S'ha produït un error en rebutjar aquesta esmena, torna-ho a provar més tard
         success: L'esmena s'ha rebutjat correctament
-      promoted:
-        success: L'esmena s'ha publicat com a proposta correctament
-        error: Hi ha hagut errors en publicar l'esmena com a proposta
       review:
         back: Tornar
         heading: Revisa l'esmena
@@ -244,7 +248,7 @@ ca:
           title: L'autorització encara està en progrés
         unauthorized:
           explanation: No es pot realitzar aquesta acció ja que alguna de les teves dades d'autorització no coincideixen amb les requerides.
-          invalid_field: "El valor %{field} %{value} no és vàlid."
+          invalid_field: El valor %{field} %{value} no és vàlid.
           ok: D'acord
           title: Acció no autoritzada
         unconfirmed:
@@ -383,39 +387,6 @@ ca:
         title: No s'ha trobat la pàgina que busques
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'S''ha creat una nova esmena per a %{amendable_title}. La pots veure des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
-            email_subject: Una nova esmena per a %{amendable_title} de %{emendation_author_nickname}
-            notification_title: S'ha creat una <a href="%{emendation_path}">nova esmena</a> per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'S''ha creat una nova esmena per a %{amendable_title}. La pots veure des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-            email_subject: Una nova esmena per a %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nova esmena</a> ha estat creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'S''ha rebutjat una esmena per %{amendable_title}. La podeu veure des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
-            email_subject: Una esmena ha estat rebutjada per %{amendable_title} de l' %{emendation_author_nickname}
-            notification_title: La <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha estat rebutjada per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'S''ha rebutjat una esmena per %{amendable_title}. Podeu veure-ho des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-            email_subject: Una esmena rebutjada per %{amendable_title} de %{emendation_author_nickname}
-            notification_title: La <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha estat rebutjada per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho en aquesta pàgina:'
-            email_outro: Heu rebut aquesta notificació perquè n'ets l'autor/a de %{amendable_title}.
-            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
-            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho des d''aquesta pàgina:'
-            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
-            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'S''ha acceptat una esmena per %{amendable_title}. Pots veure-ho des d''aquesta pàgina:'
@@ -427,6 +398,39 @@ ca:
             email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
             email_subject: Una esmena acceptada per %{amendable_title} de %{emendation_author_nickname}
             notification_title: S'ha acceptat la <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'S''ha creat una nova esmena per a %{amendable_title}. La pots veure des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
+            email_subject: Una nova esmena per a %{amendable_title} de %{emendation_author_nickname}
+            notification_title: S'ha creat una <a href="%{emendation_path}">nova esmena</a> per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'S''ha creat una nova esmena per a %{amendable_title}. La pots veure des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
+            email_subject: Una nova esmena per a %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nova esmena</a> ha estat creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho en aquesta pàgina:'
+            email_outro: Heu rebut aquesta notificació perquè n'ets l'autor/a de %{amendable_title}.
+            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
+            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Una esmena rebutjada per %{amendable_title} ha estat promoguda a una d''independent %{amendable_type}. Pots veure-ho des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
+            email_subject: S'ha promogut una esmena de %{emendation_author_nickname}
+            notification_title: S'ha promogut una esmena de <a href="%{emendation_path}">rebuig</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} per part de <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'S''ha rebutjat una esmena per %{amendable_title}. La podeu veure des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè ets autor/a de %{amendable_title}.
+            email_subject: Una esmena ha estat rebutjada per %{amendable_title} de l' %{emendation_author_nickname}
+            notification_title: La <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha estat rebutjada per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'S''ha rebutjat una esmena per %{amendable_title}. Podeu veure-ho des d''aquesta pàgina:'
+            email_outro: Has rebut aquesta notificació perquè estàs seguint %{amendable_title}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
+            email_subject: Una esmena rebutjada per %{amendable_title} de %{emendation_author_nickname}
+            notification_title: La <a href="%{emendation_path}">esmena</a> creada per <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha estat rebutjada per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'S''ha afegit un nou document a %{resource_title}. Pots veure-ho des d''aquesta pàgina:'
@@ -497,7 +501,7 @@ ca:
         profile_updated:
           email_intro: El <a href="%{resource_url}">perfil</a> d'en/na %{name} (%{nickname}), a qui estàs seguint, s'ha actualitzat.
           email_outro: Has rebut aquesta notificació perquè estàs seguint en/na %{nickname}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
-          email_subject: "En/na %{nickname} ha actualitzat el seu perfil"
+          email_subject: En/na %{nickname} ha actualitzat el seu perfil
           notification_title: El <a href="%{resource_path}">perfil</a> d'en/na %{name} (%{nickname}), a qui estàs seguint, s'ha actualitzat.
     export_mailer:
       data_portability_export:
@@ -546,7 +550,7 @@ ca:
       badges:
         continuity:
           conditions:
-            - Vine aquí sovint
+          - Vine aquí sovint
           description: Aquest distintiu es concedeix al visitar la plataforma de forma regular. Ens agrada tenir-te per aquí!
           description_another: Aquesta usuària s'ha connectat durant %{score} dies consecutius en algun moment.
           description_own: T'has connectat durant %{score} dies consecutius en algun moment.
@@ -556,7 +560,7 @@ ca:
           unearned_own: No t'has connectat més d'un dia consecutiu.
         followers:
           conditions:
-            - Ser activa i seguir a altres persones segurament farà que altres persones et segueixin.
+          - Ser activa i seguir a altres persones segurament farà que altres persones et segueixin.
           description: Aquesta distinció es concedeix quan arribis a un cert nombre de seguidors. %{organization_name} és una xarxa social i política, teixeix la teva web per comunicar-te amb altres persones a la plataforma.
           description_another: Aquesta usuària té %{score} seguidors.
           description_own: "%{score} usuàries et segueixen."
@@ -571,9 +575,9 @@ ca:
           title: Distintius
         invitations:
           conditions:
-            - Utilitza l'enllaç "convidar amics/gues" a la teva pàgina d'usuari per convidar a les teves amistats.
-            - Personalitza, si vols, el missatge que envies
-            - Pujaràs per mitjà de l'enviament d'invitacions i de registrar-les.
+          - Utilitza l'enllaç "convidar amics/gues" a la teva pàgina d'usuari per convidar a les teves amistats.
+          - Personalitza, si vols, el missatge que envies
+          - Pujaràs per mitjà de l'enviament d'invitacions i de registrar-les.
           description: Aquest distintiu es concedeix quan has convidat a algunes persones i que passen una mica de temps per registrar-se a %{organization_name} i es converteixen en participants. Gràcies per donar a conèixer %{organization_name} als altres i ajudar a ampliar la comunitat!
           description_another: Aquest usuari ha convidat a %{score} usuaris.
           description_own: Has convidat %{score} usuaris.
@@ -786,8 +790,8 @@ ca:
       show:
         email_on_notification: Vull rebre un correu electrònic cada vegada que rebi una notificació.
         everything_followed: Tot el que segueixo
-        newsletters: Butlletins informatius
         newsletter_notifications: Vull rebre butlletins
+        newsletters: Butlletins informatius
         own_activity: La meva pròpia activitat, com quan algú fa comentaris a la meva proposta o em menciona
         receive_notifications_about: Vull rebre notificacions
         send_notifications_by_email: Enviar notificacions per correu electrònic
@@ -853,10 +857,6 @@ ca:
         subheading: Navega per les pàgines d'ajuda de %{name}
         title: Ajuda
         topics: Temes
-      participatory_space:
-        metrics:
-          headline: Participació en xifres
-          link: Mostra totes les estadístiques
       terms_and_conditions:
         accept:
           error: S'ha produït un error en acceptar els Termes i Condicions.
@@ -881,6 +881,7 @@ ca:
       deleted: Usuari eliminat
       view: Veure
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Aquest grup d'usuaris es verifica públicament, el teu nom s'ha verificat per correspondre amb el teu nom real
       default_officialization_text_for_users: Aquesta persona participant està verificada públicament. S'ha verificat que el seu nom o la seva funció es correspon amb el seu nom i funció reals
       show:
@@ -992,8 +993,8 @@ ca:
         no_activities_warning: Aquest usuari encara no ha tingut cap activitat.
     user_interests:
       show:
-        no_scopes: Aquesta organització encara no té cap abast!
         my_interests: Els meus interessos
+        no_scopes: Aquesta organització encara no té cap abast!
         select_your_interests: Selecciona els temes dels quals t'interessa rebre esdeveniments relacionats amb ells a la pestanya Timeline del perfil.
         update_my_interests: Actualitza els meus interessos
       update:
@@ -1167,13 +1168,26 @@ ca:
       too_short: És massa curt (menys de 15 caràcters)
   forms:
     required: Obligatori
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Si ets un humà, pots ignorar aquest camp
     timestamp_error_message: Ho sentim, has estat massa ràpid! Torna a enviar-ho.
   layouts:
     decidim:
       cookie_warning:
-        description_html: "Aquest lloc web fa servir cookies pròpies i de tercers per millorar l’experiència de navegació, i oferir continguts i serveis d’interès.\nEn continuar la navegació entenem que s’accepta la nostra política de cookies. Per a més informació consulta %{link}."
+        description_html: |-
+          Aquest lloc web fa servir cookies pròpies i de tercers per millorar l’experiència de navegació, i oferir continguts i serveis d’interès.
+          En continuar la navegació entenem que s’accepta la nostra política de cookies. Per a més informació consulta %{link}.
         link_label: aquí
         ok: Hi estic d'acord
       edit_link:

--- a/decidim-core/config/locales/de.yml
+++ b/decidim-core/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ de:
         personal_url: Persönliche URL
         remove_avatar: Avatar entfernen
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Anhang
       decidim/component_published_event: Aktive Komponente
       decidim/demoted_membership: Nicht mehr ein Gruppenadministrator
@@ -45,8 +50,8 @@ de:
         one: Benutzergruppe
         other: Benutzergruppen
   booleans:
-    'false': 'Nein'
-    'true': 'Ja'
+    'false': Nein
+    'true': Ja
   carrierwave:
     errors:
       image_too_big: Das Bild ist zu groß
@@ -135,13 +140,13 @@ de:
         success: Diese Ausgabe wurde erfolgreich akzeptiert.
       amendable:
         amended_by: Geändert durch
-        button: '%{model_name}ändern'
-        promote_button: Auf %{model_name}
+        button: "%{model_name}ändern"
         error: Bei der Änderung dieser Ressource ist ein Fehler aufgetreten.
         help_text: Verbessern Sie diese %{model_name} indem Sie ihre %{amendable_fields}ändern
-        promote_help_text: Sie können diese Erweiterung fördern und als unabhängige %{model_name}
         no_amenders: Es gibt keine Amender
         no_amendments: Es gibt keine Änderungen
+        promote_button: Auf %{model_name}
+        promote_help_text: Sie können diese Erweiterung fördern und als unabhängige %{model_name}
         section_heading: Änderungen (%{count})
       created:
         error: Beim Erstellen dieser Änderung ist ein Fehler aufgetreten. Versuchen Sie es später erneut
@@ -170,12 +175,12 @@ de:
         heading: Erstellen Sie Ihre Änderung
         help_text: Sie ändern die %{model_name}
         send: Änderung senden
+      promoted:
+        error: Es gab Fehler bei der Förderung der Emendation
+        success: Die Emendation wurde erfolgreich gefördert
       rejected:
         error: Beim Ablehnen dieser Änderung ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut
         success: Die Emendation wurde erfolgreich abgelehnt
-      promoted:
-        success: Die Emendation wurde erfolgreich gefördert
-        error: Es gab Fehler bei der Förderung der Emendation
       review:
         back: Zurück
         heading: Überprüfen Sie die Änderung
@@ -384,39 +389,6 @@ de:
         title: Die von Ihnen gesuchte Seite kann nicht gefunden werden
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Eine neue Ausgabe wurde für %{amendable_title}. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
-            email_subject: Eine neue Änderung für %{amendable_title} von %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">neue emendation</a> wird von geschaffen <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Eine neue Ausgabe wurde für %{amendable_title}. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
-            email_subject: Eine neue Änderung für %{amendable_title} von %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">neue emendation</a> wird von geschaffen <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Eine Ausgabe wurde für %{amendable_title}abgelehnt. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
-            email_subject: Ein Änderungsantrag wurde für %{amendable_title} von %{emendation_author_nickname}abgelehnt
-            notification_title: Die durch <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> erstellte <a href="%{emendation_path}">Änderung</a> wurde für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}abgelehnt.
-          follower:
-            email_intro: 'Eine Ausgabe wurde für %{amendable_title}abgelehnt. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
-            email_subject: Ein Änderungsantrag wurde für %{amendable_title} von %{emendation_author_nickname}abgelehnt
-            notification_title: Die durch <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> erstellte <a href="%{emendation_path}">Änderung</a> wurde für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}abgelehnt.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Eine für %{amendable_title} abgelehnte Ausgabe wurde zu einer unabhängigen %{amendable_type}. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
-            email_subject: Eine Erweiterung von %{emendation_author_nickname} wurde befördert
-            notification_title: A <a href="%{emendation_path}">abgelehnt emendation</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} wird von gefördert <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Eine für %{amendable_title} abgelehnte Ausgabe wurde zu einer unabhängigen %{amendable_type}. Sie können es auf dieser Seite sehen:'
-            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
-            email_subject: Eine Erweiterung von %{emendation_author_nickname} wurde befördert
-            notification_title: A <a href="%{emendation_path}">abgelehnt emendation</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} wird von gefördert <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Eine Emendation wurde für %{amendable_title}akzeptiert. Sie können es auf dieser Seite sehen:'
@@ -428,6 +400,39 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
             email_subject: Eine für %{amendable_title} angenommene Änderung von %{emendation_author_nickname}
             notification_title: Die durch <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> erzeugte <a href="%{emendation_path}">Änderung</a> wurde für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}akzeptiert.
+        amendment_created:
+          affected_user:
+            email_intro: 'Eine neue Ausgabe wurde für %{amendable_title}. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
+            email_subject: Eine neue Änderung für %{amendable_title} von %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">neue emendation</a> wird von geschaffen <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Eine neue Ausgabe wurde für %{amendable_title}. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
+            email_subject: Eine neue Änderung für %{amendable_title} von %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">neue emendation</a> wird von geschaffen <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Eine für %{amendable_title} abgelehnte Ausgabe wurde zu einer unabhängigen %{amendable_type}. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
+            email_subject: Eine Erweiterung von %{emendation_author_nickname} wurde befördert
+            notification_title: A <a href="%{emendation_path}">abgelehnt emendation</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} wird von gefördert <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Eine für %{amendable_title} abgelehnte Ausgabe wurde zu einer unabhängigen %{amendable_type}. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
+            email_subject: Eine Erweiterung von %{emendation_author_nickname} wurde befördert
+            notification_title: A <a href="%{emendation_path}">abgelehnt emendation</a> für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} wird von gefördert <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Eine Ausgabe wurde für %{amendable_title}abgelehnt. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von %{amendable_title}.
+            email_subject: Ein Änderungsantrag wurde für %{amendable_title} von %{emendation_author_nickname}abgelehnt
+            notification_title: Die durch <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> erstellte <a href="%{emendation_path}">Änderung</a> wurde für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}abgelehnt.
+          follower:
+            email_intro: 'Eine Ausgabe wurde für %{amendable_title}abgelehnt. Sie können es auf dieser Seite sehen:'
+            email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{amendable_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
+            email_subject: Ein Änderungsantrag wurde für %{amendable_title} von %{emendation_author_nickname}abgelehnt
+            notification_title: Die durch <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> erstellte <a href="%{emendation_path}">Änderung</a> wurde für <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}abgelehnt.
       attachments:
         attachment_created:
           email_intro: 'Ein neues Dokument wurde zu %{resource_title} hinzugefügt. Sie können es auf dieser Seite sehen:'
@@ -547,7 +552,7 @@ de:
       badges:
         continuity:
           conditions:
-            - Komm oft hierher
+          - Komm oft hierher
           description: Dieses Abzeichen wird gewährt, wenn Sie die Plattform regelmäßig besuchen. Wir möchten dich hier in der Nähe haben!
           description_another: Dieser Benutzer hat sich irgendwann einmal für %{score} aufeinanderfolgende Tage verbunden.
           description_own: Sie haben an einem bestimmten Punkt für %{score} aufeinanderfolgende Tage verbunden.
@@ -557,7 +562,7 @@ de:
           unearned_own: Sie haben seit mehr als einem aufeinanderfolgenden Tag keine Verbindung hergestellt.
         followers:
           conditions:
-            - Aktiv zu sein und anderen Menschen zu folgen, wird sicherlich andere Menschen dazu bringen, dir zu folgen.
+          - Aktiv zu sein und anderen Menschen zu folgen, wird sicherlich andere Menschen dazu bringen, dir zu folgen.
           description: Dieses Abzeichen wird gewährt, wenn Sie eine bestimmte Anzahl von Followern erreichen. %{organization_name} ist ein soziales und politisches Netzwerk, weben Sie Ihr Web, um mit anderen Menschen auf der Plattform zu kommunizieren.
           description_another: Diese*r Benutzer*in hat %{score} Follower.
           description_own: "%{score} Benutzer*innen folgen dir."
@@ -572,9 +577,9 @@ de:
           title: Abzeichen
         invitations:
           conditions:
-            - Verwenden Sie den Link "Freunde einladen" auf Ihrer Nutzerseite, um Ihre Freunde einzuladen
-            - Passen Sie, wenn Sie möchten, die gesendete Nachricht an
-            - Sie werden auf den neuesten Stand gebracht, indem Sie Einladungen senden und sie registrieren lassen.
+          - Verwenden Sie den Link "Freunde einladen" auf Ihrer Nutzerseite, um Ihre Freunde einzuladen
+          - Passen Sie, wenn Sie möchten, die gesendete Nachricht an
+          - Sie werden auf den neuesten Stand gebracht, indem Sie Einladungen senden und sie registrieren lassen.
           description: Dieses Abzeichen wird gewährt, wenn Sie einige Personen eingeladen haben und sie sich ein wenig Zeit genommen haben, um sich in %{organization_name} zu registrieren und Teilnehmer zu werden. Vielen Dank für die Herstellung von %{organization_name} anderen bekannt und helfen , die Gemeinschaft zu erweitern!
           description_another: Diese*r Benutzer*in hat %{score} Benutzer*innen eingeladen.
           description_own: Sie haben %{score} Benutzer*innen eingeladen.
@@ -787,8 +792,8 @@ de:
       show:
         email_on_notification: Ich möchte jedes Mal eine E-Mail erhalten, wenn ich eine Benachrichtigung erhalte.
         everything_followed: Alles was ich folge
-        newsletters: Newsletter
         newsletter_notifications: Ich möchte Newsletter erhalten
+        newsletters: Newsletter
         own_activity: Meine eigene Tätigkeit, etwa wenn sich jemand in meinem Vorschlag äußert oder mich erwähnt
         receive_notifications_about: Ich möchte Benachrichtigungen erhalten über
         send_notifications_by_email: Senden Sie Benachrichtigungen per E-Mail
@@ -854,10 +859,6 @@ de:
         subheading: Navigieren Sie durch die Hilfeseiten von %{name}
         title: Hilfe
         topics: Themen
-      participatory_space:
-        metrics:
-          headline: Teilnahme an Zahlen
-          link: Alle Statistiken anzeigen
       terms_and_conditions:
         accept:
           error: Beim Akzeptieren der Nutzungsbedingungen ist ein Fehler aufgetreten.
@@ -882,6 +883,7 @@ de:
       deleted: Gelöschte*r Benutzer*in
       view: Anzeigen
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Diese Benutzergruppe wurde öffentlich überprüft, ihr Name wurde mit dem tatsächlichen Namen verifiziert
       default_officialization_text_for_users: Dieser Teilnehmer wird öffentlich überprüft, sein Name oder seine Rolle wurde nachweislich seinem tatsächlichen Namen und seiner Rolle zugeordnet
       show:
@@ -993,8 +995,8 @@ de:
         no_activities_warning: Dieser Benutzer hat noch keine Aktivität gehabt.
     user_interests:
       show:
-        no_scopes: Diese Organisation hat noch keinen Spielraum!
         my_interests: Meine Interessen
+        no_scopes: Diese Organisation hat noch keinen Spielraum!
         select_your_interests: Wählen Sie die Themen aus, an denen Sie interessiert sind, um Ereignisse, die sich auf sie beziehen, auf der Registerkarte "Zeitleiste" Ihres Profils zu erhalten.
         update_my_interests: Aktualisieren Sie meine Interessen
       update:
@@ -1168,6 +1170,17 @@ de:
       too_short: ist zu kurz (unter 15 Zeichen)
   forms:
     required: Erforderlich
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Wenn Sie ein Mensch sind, ignorieren Sie dieses Feld
     timestamp_error_message: Entschuldigung, das war zu schnell! Bitte erneut einreichen

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1174,6 +1174,17 @@ en:
       too_short: is too short (under 15 characters)
   forms:
     required: Required
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: If you are human, ignore this field
     timestamp_error_message: Sorry, that was too quick! Please resubmit.

--- a/decidim-core/config/locales/es-PY.yml
+++ b/decidim-core/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ es-PY:
         personal_url: URL personal
         remove_avatar: Eliminar imagen de perfil
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Archivo adjunto
       decidim/component_published_event: Componente activo
       decidim/demoted_membership: Ya no es un administrador de grupo.
@@ -46,7 +51,7 @@ es-PY:
         other: Grupos de usuarios
   booleans:
     'false': 'No'
-    'true': 'Sí'
+    'true': Sí
   carrierwave:
     errors:
       image_too_big: La imagen es demasiado grande
@@ -69,7 +74,7 @@ es-PY:
         confirm:
           close: Cerrar ventana
           ok: Sí, quiero eliminar mi cuenta
-          question: '¿Seguro que quieres eliminar tu cuenta?'
+          question: "¿Seguro que quieres eliminar tu cuenta?"
           title: Eliminar mi cuenta
         explanation: Por favor, rellena el motivo por el que deseas eliminar tu cuenta (opcional).
       destroy:
@@ -136,12 +141,12 @@ es-PY:
       amendable:
         amended_by: Enmendado por
         button: Enmendar %{model_name}
-        promote_button: Promocionar a %{model_name}
         error: Se ha producido un error al modificar este recurso.
         help_text: Mejora este %{model_name} modificando su %{amendable_fields}
-        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         no_amenders: No hay enmendadores
         no_amendments: No hay enmiendas
+        promote_button: Promocionar a %{model_name}
+        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         section_heading: Enmiendas (%{count})
       created:
         error: Se ha producido un error creando esta enmienda, inténtalo de nuevo más tarde
@@ -170,12 +175,12 @@ es-PY:
         heading: Crea tu enmienda
         help_text: Estás modificando el %{model_name}
         send: Enviar enmienda
+      promoted:
+        error: Ha habido errores al promocionar la enmienda.
+        success: La enmienda se promociona con éxito.
       rejected:
         error: Se ha producido un error al rechazar esta enmienda. Inténtalo de nuevo más tarde.
         success: La enmienda ha sido rechazada con éxito.
-      promoted:
-        success: La enmienda se promociona con éxito.
-        error: Ha habido errores al promocionar la enmienda.
       review:
         back: Volver
         heading: Revisar la enmienda
@@ -324,7 +329,7 @@ es-PY:
           username_help: Nombre público que aparece en tus mensajes. Con el objetivo de garantizar el anonimato, puede ser cualquier nombre.
       registrations:
         new:
-          already_have_an_account?: '¿Ya tienes una cuenta?'
+          already_have_an_account?: "¿Ya tienes una cuenta?"
           newsletter: Quiero recibir un boletín ocasional con información relevante
           newsletter_title: Permiso de contacto
           nickname_help: Su identificador corto y único en %{organization}
@@ -339,7 +344,7 @@ es-PY:
           username_help: Nombre público que aparecerá en tus publicaciones. Con el objetivo de garantizar el anonimato puede ser cualquier nombre.
       sessions:
         new:
-          are_you_new?: '¿Eres nuevo en la plataforma?'
+          are_you_new?: "¿Eres nuevo en la plataforma?"
           register: Créate una cuenta
           sign_in_disabled: Puedes acceder con una cuenta externa.
           sign_up_disabled: El registro está deshabilitado, puede usar un usuario existente para acceder
@@ -384,39 +389,6 @@ es-PY:
         title: No se ha encontrado la página que buscas
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
-            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
-            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
@@ -428,6 +400,39 @@ es-PY:
             email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
             email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
             notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
+            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres un autor de %{amendable_title}.
+            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Se ha agregado un nuevo documento a %{resource_title}. Puedes verlo desde esta página:'
@@ -447,30 +452,30 @@ es-PY:
         email_subject: Una actualización de %{resource_title}
       gamification:
         badge_earned:
-          email_intro: '¡Enhorabuena! Has obtenido <a href="%{resource_path}">%{badge_name} insignia</a> (nivel %{current_level}).'
+          email_intro: ¡Enhorabuena! Has obtenido <a href="%{resource_path}">%{badge_name} insignia</a> (nivel %{current_level}).
           email_outro: Has recibido esta notificación porque has realizado actividad en nuestro sitio web.
-          email_subject: '¡Has ganado una nueva insignia: %{badge_name}!'
-          notification_title: '¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).'
+          email_subject: "¡Has ganado una nueva insignia: %{badge_name}!"
+          notification_title: ¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).
         level_up:
-          email_intro: '¡Enhorabuena! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!'
+          email_intro: ¡Enhorabuena! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!
           email_outro: Has recibido esta notificación porque has generado actividad en nuestro sitio web.
-          email_subject: '¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!'
-          notification_title: '¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!'
+          email_subject: "¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!"
+          notification_title: ¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!
       groups:
         demoted_membership:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha eliminado sus derechos de administrador para ese grupo.
           email_outro: Has recibido esta notificación porque eres miembro de ese grupo.
-          email_subject: '¡Ya no eres un administrador del grupo %{user_group_name}!'
+          email_subject: "¡Ya no eres un administrador del grupo %{user_group_name}!"
           notification_title: Ya no eres administrador del grupo <a href="%{resource_path}">%{user_group_name}</a>.
         invited_to_group:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha invitado a unirse a él.
           email_outro: Has recibido esta notificación porque has sido invitado a un grupo. Por favor, revise la pestaña Grupos en su perfil para aprobarlo.
-          email_subject: '¡Has sido invitado a unirte al grupo %{user_group_name}!'
+          email_subject: "¡Has sido invitado a unirte al grupo %{user_group_name}!"
           notification_title: Te han invitado a unirte al grupo <a href="%{resource_path}">%{user_group_name}</a> . ¡Revisa la página</a> <a href="%{groups_profile_tab_path}">grupos en tu perfil para aprobarlo!
         join_request_accepted:
-          email_intro: '¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado su solicitud para unirse a él.'
+          email_intro: ¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado su solicitud para unirse a él.
           email_outro: Has recibido esta notificación porque tu solicitud de incorporación se ha actualizado.
-          email_subject: '¡Has sido aceptado en el grupo %{user_group_name}!'
+          email_subject: "¡Has sido aceptado en el grupo %{user_group_name}!"
           notification_title: Has sido aceptado en el grupo <a href="%{resource_path}">%{user_group_name}</a>.
         join_request_created:
           email_intro: Alguien pidió unirse al grupo %{user_group_name} . Puedes aceptarlo o rechazarlo desde <a href="%{resource_url}">miembros del grupo en la página</a>.
@@ -485,12 +490,12 @@ es-PY:
         promoted_to_admin:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha otorgado derechos de administrador a ese grupo.
           email_outro: Has recibido esta notificación porque eres miembro de ese grupo.
-          email_subject: '¡Ahora eres un administrador del grupo %{user_group_name}!'
+          email_subject: "¡Ahora eres un administrador del grupo %{user_group_name}!"
           notification_title: Ahora eres un administrador del grupo <a href="%{resource_path}">%{user_group_name}</a>.
         removed_from_group:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha eliminado de él.
           email_outro: Ha recibido esta notificación porque era miembro de ese grupo.
-          email_subject: '¡Has sido eliminado del grupo %{user_group_name}!'
+          email_subject: "¡Has sido eliminado del grupo %{user_group_name}!"
           notification_title: Has sido eliminado del grupo <a href="%{resource_path}">%{user_group_name}</a>.
       notification_event:
         notification_title: Un evento ha ocurrido en <a href="%{resource_path}">%{resource_title}</a>.
@@ -547,39 +552,39 @@ es-PY:
       badges:
         continuity:
           conditions:
-            - Viene aquí a menudo
+          - Viene aquí a menudo
           description: Este distintivo se otorga cuando visitas la plataforma de forma regular. ¡Nos gusta tenerte por aquí!
           description_another: Este usuario se ha conectado durante %{score} días consecutivos en algún momento.
           description_own: Te has conectado por %{score} días consecutivos en algún momento.
           name: Continuidad
-          next_level_in: '¡Conéctate durante %{score} días consecutivos alcanzar al siguiente nivel!'
+          next_level_in: "¡Conéctate durante %{score} días consecutivos alcanzar al siguiente nivel!"
           unearned_another: Este usuario no ha entrado durante más de un día consecutivo.
           unearned_own: No te has conectado por más de un día consecutivo.
         followers:
           conditions:
-            - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
+          - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
           description: Este distintivo se otorga cuando alcanzas un cierto número de seguidores. %{organization_name} es una red social y política, teje tu web para comunicarte con otras personas en la plataforma.
           description_another: Este usuario tiene %{score} seguidores.
           description_own: "%{score} usuarios te están siguiendo."
           name: Seguidores
-          next_level_in: '¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!'
+          next_level_in: "¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!"
           unearned_another: Este usuario no tiene seguidores todavía.
           unearned_own: Aún no tienes seguidores
         index:
-          badge_title: "Distintivo %{name}"
+          badge_title: Distintivo %{name}
           how: Como puedes conseguirlo
           page_description: Los distintivos son reconocimientos a las acciones de los participantes y al progreso en la plataforma. A medida que comiences a descubrir, participar e interactuar en la plataforma, conseguirlo diferentes distintivo. Aquí está la lista de distintivos y algunas formas en que puedes conseguirlas.
           title: Distintivos
         invitations:
           conditions:
-            - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
-            - Personaliza, si quieres, el mensaje que estás enviando.
-            - Supera este nivel enviando invitaciones y registrándolas.
+          - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
+          - Personaliza, si quieres, el mensaje que estás enviando.
+          - Supera este nivel enviando invitaciones y registrándolas.
           description: Este distintivo se consigue cuando has invitado a algunas personas y han pasado un poco de tiempo para registrarse en %{organization_name} y se converten en participantes. ¡Gracias por dar a conocer %{organization_name} a otros y ayudar a ampliar la comunidad!
           description_another: Este usuario ha invitado a %{score} usuarios.
           description_own: Has invitado a %{score} usuarios.
           name: Invitaciones
-          next_level_in: '¡Invita %{score} usuarios más a alcanzar el siguiente nivel!'
+          next_level_in: "¡Invita %{score} usuarios más a alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha invitado a ningún usuario.
           unearned_own: No has invitado aún a ningún usuario.
       description: Las insignias son reconocimientos de las acciones de los participantes y el progreso en la plataforma. A medida que comienzas a descubrir, participar e interactuar en la plataforma, ganarás diferentes insignias.
@@ -587,7 +592,7 @@ es-PY:
       reached_top: Has alcanzado el nivel superior para esta insignia.
     group_admins:
       actions:
-        are_you_sure: '¿Estás seguro? Esto no eliminará al usuario del grupo.'
+        are_you_sure: "¿Estás seguro? Esto no eliminará al usuario del grupo."
         demote_admin: Quitar admin
       demote:
         error: Se ha producido un error al eliminar este usuario de la lista de administradores.
@@ -616,7 +621,7 @@ es-PY:
         error: Se ha producido un error al aceptar esta solicitud de unión.
         success: Únase a la solicitud aceptada con éxito
       actions:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
         promote_to_admin: Hacer administrador
         remove_from_group: Eliminar usuario
       index:
@@ -633,7 +638,7 @@ es-PY:
         success: Usuario eliminado del grupo con éxito
     groups:
       actions:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
       create:
         error: Ha habido un problema creando el grupo.
         success: Grupo creado exitosamente
@@ -673,7 +678,7 @@ es-PY:
       main_topic:
         default_page:
           content: "<p>En %{organization} puede participar y decidir sobre diferentes temas, a través de los espacios que ve en el menú superior: Procesos, Asambleas, Iniciativas, Consultas.</p> <p>Dentro de cada una encontrará diferentes opciones para participar: hacer propuestas, individualmente o con otras personas, participar en debates, priorizar proyectos para implementar, asistir a reuniones cara a cara y otras acciones.</p>\n"
-          title: '¿Qué puedo hacer en %{organization}?'
+          title: "¿Qué puedo hacer en %{organization}?"
         description: Leer más sobre %{organization}
         title: Ayuda general
     last_activities:
@@ -714,12 +719,12 @@ es-PY:
         new_conversation:
           greeting: Hola, %{recipient}!
           intro: "%{sender} ha iniciado una nueva conversación contigo. Haz click aquí para verla:"
-          outro: '¡Disfruta de decidim!'
+          outro: "¡Disfruta de decidim!"
           subject: "%{sender} ha iniciado una conversación contigo"
         new_message:
-          greeting: '¡Hola, %{recipient}!'
+          greeting: "¡Hola, %{recipient}!"
           intro: "%{sender} ha publicado nuevos mensajes en tu conversación. Haz clic aquí para verlos:"
-          outro: '¡Disfruta de decidim!'
+          outro: "¡Disfruta de decidim!"
           subject: Tienes nuevos mensajes de %{sender}
       conversations:
         create:
@@ -755,7 +760,7 @@ es-PY:
     newsletter_mailer:
       newsletter:
         note: Has recibido este mensaje porque estás suscrito a boletines de noticias en %{organization_name}. Puedes cambiar la configuración en tu <a href="%{link}">página de notificaciones</a>.
-        see_on_website: '¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.'
+        see_on_website: ¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.
         unsubscribe: Si no quieres recibir este tipo de correo electrónico, <a href="%{link}" target="_blank" class="unsubscribe">unsubscríbete</a>.
     newsletters:
       unsubscribe:
@@ -772,12 +777,12 @@ es-PY:
     newsletters_opt_in_mailer:
       notify:
         body_1: El procesamiento de datos personales y su protección es cada vez más importante para todos nosotros. Con el nuevo Reglamento General de Protección de Datos (RGPD) del 25 de mayo de 2018, las personas tienen un mejor control sobre sus datos personales. Por este motivo, necesitamos tu "OK" para seguir enviando información relevante sobre las actividades del %{organization_name}.
-        body_2: '¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:'
+        body_2: "¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:"
         body_3: Con este consentimiento, podrá continuar recibiendo información sobre los servicios de la plataforma. Si, por el contrario, no recibimos una confirmación positiva de su parte, dejaremos de enviarle nuestros mensajes. Si confirma que desea mantenerse informado, siempre tendrá la opción de cancelar en cualquier momento.
         button: Sí, deseo continuar recibiendo información relevante
         greetings: Saludos,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hola,
-        subject: '¿Desea seguir recibiendo información relevante sobre %{organization_name}?'
+        subject: "¿Desea seguir recibiendo información relevante sobre %{organization_name}?"
     notification_mailer:
       shared:
         note: You received this message because you're subscribed to notification by email on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
@@ -787,8 +792,8 @@ es-PY:
       show:
         email_on_notification: Quiero recibir un correo electrónico cada vez que recibo una notificación.
         everything_followed: Todo lo que sigo
-        newsletters: Boletines de noticias
         newsletter_notifications: Quiero recibir boletines informativos
+        newsletters: Boletines de noticias
         own_activity: Mi propia actividad, como cuando alguien comenta en mi propuesta o me menciona.
         receive_notifications_about: Quiero recibir notificaciones sobre
         send_notifications_by_email: Enviar notificaciones por correo electrónico
@@ -812,7 +817,7 @@ es-PY:
         extended:
           debates: Debates
           debates_explanation: Debate y discute, comparte tus opiniones y enriquece los temas relevantes.
-          how_to_participate: '¿Cómo tomo parte en un proceso?'
+          how_to_participate: "¿Cómo tomo parte en un proceso?"
           meetings: Encuentros
           meetings_explanation: Averigua dónde y cuándo puedes participar en encuentros públicos.
           more_info: Más información
@@ -854,14 +859,10 @@ es-PY:
         subheading: Navegar por las páginas de ayuda de %{name}
         title: Ayuda
         topics: Temas
-      participatory_space:
-        metrics:
-          headline: Participación en cifras.
-          link: Mostrar todas las estadísticas
       terms_and_conditions:
         accept:
           error: Ha habido un error al aceptar los Términos y Condiciones.
-          success: '¡Estupendo! Has aceptado los Términos y Condiciones.'
+          success: "¡Estupendo! Has aceptado los Términos y Condiciones."
         form:
           agreement: Estoy de acuerdo con estos términos
           legend: Aceptar los Términos y Condiciones de uso
@@ -871,7 +872,7 @@ es-PY:
           modal_btn_exit: Lo revisaré más tarde
           modal_button: Rechazar los términos
           modal_close: Cerrar modal
-          modal_title: '¿Confirmas que no aceptas los Términos y Condiciones actualizados?'
+          modal_title: "¿Confirmas que no aceptas los Términos y Condiciones actualizados?"
         required_review:
           alert: Hemos actualizado nuestros Términos de Servicio, por favor revísalos.
           body: Por favor dedica un momento a revisar la actualización de nuestras Términos de Servicio. De lo contrario, no podrás usar la plataforma.
@@ -882,6 +883,7 @@ es-PY:
       deleted: Usuario eliminado
       view: Ver
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Este grupo de usuarios se verifica públicamente, tu nombre se ha verificado para que se corresponda con tu nombre real
       default_officialization_text_for_users: Esta persona participante está verificada públicamente. Se ha verificado que su nombre o cargo corresponde con su nombre real y rol
       show:
@@ -993,8 +995,8 @@ es-PY:
         no_activities_warning: Este usuario no ha tenido ninguna actividad todavía.
     user_interests:
       show:
-        no_scopes: '¡Esta organización aún no tiene ningún alcance!'
         my_interests: Mis intereses
+        no_scopes: "¡Esta organización aún no tiene ningún alcance!"
         select_your_interests: Seleccione los temas que le interesan para recibir eventos relacionados con ellos en la pestaña Línea de tiempo de su perfil.
         update_my_interests: Actualizar mis intereses
       update:
@@ -1013,11 +1015,11 @@ es-PY:
     failure:
       already_authenticated: Ya has iniciado sesión.
       inactive: Tu cuenta aún no está activada.
-      invalid: '%{authentication_keys} inválido o contraseña.'
+      invalid: "%{authentication_keys} inválido o contraseña."
       invited: Tienes una invitación pendiente, acéptala para terminar de crear tu cuenta.
       last_attempt: Tienes un intento más antes de que tu cuenta se bloquee.
       locked: Tu cuenta esta bloqueada.
-      not_found_in_database: '%{authentication_keys} inválido o contraseña.'
+      not_found_in_database: "%{authentication_keys} inválido o contraseña."
       timeout: Su sesión expiró Por favor, inicia sesión de nuevo para continuar.
       unauthenticated: Debes iniciar sesión o registrarte antes de continuar.
     invitations:
@@ -1027,7 +1029,7 @@ es-PY:
         submit_button: Guardar
         subtitle: Si aceptas la invitación, por favor establece tu nombre de usuario/a y contraseña.
       invitation_removed: Tu invitación fue eliminada.
-      invitation_token_invalid: '¡El token de invitación proporcionado no es válido!'
+      invitation_token_invalid: "¡El token de invitación proporcionado no es válido!"
       new:
         header: Enviar invitacion
         submit_button: Envia una invitacion
@@ -1068,7 +1070,7 @@ es-PY:
       organization_admin_invitation_instructions:
         subject: Has sido invitado para gestionar %{organization}
       password_change:
-        greeting: '¡Hola %{recipient}!'
+        greeting: "¡Hola %{recipient}!"
         message: Nos ponemos en contacto contigo para notificarte que tu contraseña ha sido cambiada correctamente.
         subject: Contraseña modificada
       reset_password_instructions:
@@ -1094,7 +1096,7 @@ es-PY:
         confirm_new_password: Confirmar nueva contraseña
         new_password: Contraseña
       new:
-        forgot_your_password: '¿Olvidaste tu contraseña?'
+        forgot_your_password: "¿Olvidaste tu contraseña?"
         send_me_reset_password_instructions: Enviarme instrucciones para restablecer la contraseña
       no_token: No puede acceder a esta página sin venir de un correo electrónico de restablecimiento de contraseña. Si proviene de un correo electrónico de restablecimiento de contraseña, asegúrese de haber utilizado la URL completa provista.
       send_instructions: Recibirá un correo electrónico con instrucciones sobre cómo restablecer su contraseña en unos minutos.
@@ -1102,19 +1104,19 @@ es-PY:
       updated: Tu contraseña ha sido cambiada exitosamente. Ya has iniciado sesión.
       updated_not_active: Tu contraseña ha sido cambiada exitosamente.
     registrations:
-      destroyed: '¡Adiós! Su cuenta ha sido cancelada exitosamente. Esperamos volver a verte pronto.'
+      destroyed: "¡Adiós! Su cuenta ha sido cancelada exitosamente. Esperamos volver a verte pronto."
       edit:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
         cancel_my_account: Cancelar mi cuenta
         currently_waiting_confirmation_for_email: 'En espera de confirmación para: %{email}'
         leave_blank_if_you_don_t_want_to_change_it: déjelo en blanco si no quiere cambiarlo
         title: Editar %{resource}
-        unhappy: '¿Infeliz?'
+        unhappy: "¿Infeliz?"
         update: Actualizar
         we_need_your_current_password_to_confirm_your_changes: necesitamos su contraseña actual para confirmar sus cambios
       new:
         sign_up: Regístrate
-      signed_up: '¡Bienvenido! Usted se ha registrado exitosamente.'
+      signed_up: "¡Bienvenido! Usted se ha registrado exitosamente."
       signed_up_but_inactive: Usted se ha registrado exitosamente. Sin embargo, no pudimos iniciar sesión porque su cuenta aún no está activada.
       signed_up_but_locked: Usted se ha registrado exitosamente. Sin embargo, no pudimos iniciar sesión porque su cuenta está bloqueada.
       signed_up_but_unconfirmed: Se ha enviado un mensaje con un enlace de confirmación a su dirección de correo electrónico. Por favor, siga el enlace para activar su cuenta.
@@ -1129,9 +1131,9 @@ es-PY:
     shared:
       links:
         back: Espalda
-        didn_t_receive_confirmation_instructions: '¿No recibió las instrucciones de confirmación?'
-        didn_t_receive_unlock_instructions: '¿No recibió instrucciones de desbloqueo?'
-        forgot_your_password: '¿Olvidaste tu contraseña?'
+        didn_t_receive_confirmation_instructions: "¿No recibió las instrucciones de confirmación?"
+        didn_t_receive_unlock_instructions: "¿No recibió instrucciones de desbloqueo?"
+        forgot_your_password: "¿Olvidaste tu contraseña?"
         sign_in: Iniciar sesión
         sign_in_with_provider: Inicia sesión con %{provider}
         sign_up: Regístrate
@@ -1168,6 +1170,17 @@ es-PY:
       too_short: es demasiado corto (menos de 15 caracteres)
   forms:
     required: Obligatorio
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Si eres humano, ignora este campo
     timestamp_error_message: Lo siento, has sido demasiado rápido! Por favor, vuelva a enviar.

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ es:
         personal_url: URL personal
         remove_avatar: Eliminar imagen de perfil
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Archivo adjunto
       decidim/component_published_event: Componente activo
       decidim/demoted_membership: Ya no es un administrador de grupo
@@ -46,7 +51,7 @@ es:
         other: Grupos de usuarios
   booleans:
     'false': 'No'
-    'true': 'Sí'
+    'true': Sí
   carrierwave:
     errors:
       image_too_big: La imagen es demasiado grande
@@ -69,7 +74,7 @@ es:
         confirm:
           close: Cerrar ventana
           ok: Sí, quiero eliminar mi cuenta
-          question: '¿Seguro que quieres eliminar tu cuenta?'
+          question: "¿Seguro que quieres eliminar tu cuenta?"
           title: Eliminar mi cuenta
         explanation: Por favor, rellena el motivo por el que deseas eliminar tu cuenta (opcional).
       destroy:
@@ -136,12 +141,12 @@ es:
       amendable:
         amended_by: Enmendado por
         button: Enmendar %{model_name}
-        promote_button: Promocionar a %{model_name}
         error: Se ha producido un error al modificar este recurso.
         help_text: Mejora este %{model_name} modificando su %{amendable_fields}
-        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         no_amenders: No hay enmendadores
         no_amendments: No hay enmiendas
+        promote_button: Promocionar a %{model_name}
+        promote_help_text: Puedes promocionar esta enmienda y publicarla como un %{model_name}independiente.
         section_heading: Enmiendas (%{count})
       created:
         error: Se ha producido un error creando esta enmienda, inténtalo de nuevo más tarde
@@ -170,12 +175,12 @@ es:
         heading: Crea tu enmienda
         help_text: Estás modificando el %{model_name}
         send: Enviar enmienda
+      promoted:
+        error: Ha habido errores al promocionar la enmienda.
+        success: La enmienda se promociona con éxito.
       rejected:
         error: Se ha producido un error al rechazar esta enmienda. Inténtalo de nuevo más tarde.
         success: La enmienda ha sido rechazada con éxito.
-      promoted:
-        success: La enmienda se promociona con éxito.
-        error: Ha habido errores al promocionar la enmienda.
       review:
         back: Volver
         heading: Revisar la enmienda
@@ -324,7 +329,7 @@ es:
           username_help: Nombre público que aparece en tus mensajes. Con el objetivo de garantizar el anonimato, puede ser cualquier nombre.
       registrations:
         new:
-          already_have_an_account?: '¿Ya tienes una cuenta?'
+          already_have_an_account?: "¿Ya tienes una cuenta?"
           newsletter: Quiero recibir un boletín ocasional con información relevante
           newsletter_title: Permiso de contacto
           nickname_help: Su identificador corto y único en %{organization}
@@ -339,7 +344,7 @@ es:
           username_help: Nombre público que aparecerá en tus publicaciones. Con el objetivo de garantizar el anonimato puede ser cualquier nombre.
       sessions:
         new:
-          are_you_new?: '¿Eres nuevo en la plataforma?'
+          are_you_new?: "¿Eres nuevo en la plataforma?"
           register: Créate una cuenta
           sign_in_disabled: Puedes acceder con una cuenta externa
           sign_up_disabled: El registro está deshabilitado, puedes usar un usuario existente para acceder
@@ -384,39 +389,6 @@ es:
         title: No se ha encontrado la página que buscas
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
-            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
-            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
-            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
-            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Se ha aceptado una enmienda para %{amendable_title}. Puedes verlo desde esta página:'
@@ -428,6 +400,39 @@ es:
             email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
             email_subject: Una enmienda aceptada para %{amendable_title} de %{emendation_author_nickname}
             notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido aceptado para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
+            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Se ha creado una nueva enmienda para %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Una nueva enmienda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nueva enmienda</a> ha sido creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Una enmienda rechazada por %{amendable_title} ha sido promovida a %{amendable_type}independiente. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Se ha promocionado una enmienda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">rechazaron enmienda</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} ha sido promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque eres una autora de %{amendable_title}.
+            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Una enmienda ha sido rechazada por %{amendable_title}. Puedes verlo desde esta página:'
+            email_outro: Has recibido esta notificación porque estás siguiendo a %{amendable_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
+            email_subject: Una enmienda rechazada por %{amendable_title} de %{emendation_author_nickname}
+            notification_title: El <a href="%{emendation_path}">enmienda</a> creado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> ha sido rechazada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Se ha agregado un nuevo documento a %{resource_title}. Puedes verlo desde esta página:'
@@ -447,15 +452,15 @@ es:
         email_subject: Una actualización de %{resource_title}
       gamification:
         badge_earned:
-          email_intro: '¡Gran trabajo! Has obtenido la insignia "<a href="%{resource_url}">%{badge_name}</a>" (nivel %{current_level}).'
+          email_intro: ¡Gran trabajo! Has obtenido la insignia "<a href="%{resource_url}">%{badge_name}</a>" (nivel %{current_level}).
           email_outro: Has recibido esta notificación porque has realizado actividad en nuestro sitio web.
-          email_subject: '¡Has ganado una nueva insignia: %{badge_name}!'
-          notification_title: '¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).'
+          email_subject: "¡Has ganado una nueva insignia: %{badge_name}!"
+          notification_title: ¡Enhorabuena! Has obtenido la insignia <a href="%{resource_path}">%{badge_name}</a> (nivel %{current_level}).
         level_up:
-          email_intro: '¡Gran trabajo! ¡Has alcanzado el nivel %{current_level} en la insignia "<a href="%{resource_url}">%{badge_name}</a>"!'
+          email_intro: ¡Gran trabajo! ¡Has alcanzado el nivel %{current_level} en la insignia "<a href="%{resource_url}">%{badge_name}</a>"!
           email_outro: Has recibido esta notificación porque has generado actividad en nuestro sitio web.
-          email_subject: '¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!'
-          notification_title: '¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!'
+          email_subject: "¡Has conseguido el nivel %{current_level} en la insignia %{badge_name}!"
+          notification_title: ¡Gran trabajo! ¡Has conseguido el nivel %{current_level} en la insignia <a href="%{resource_path}">%{badge_name}</a>!
       groups:
         demoted_membership:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha eliminado tus permisos de administración para ese grupo.
@@ -468,7 +473,7 @@ es:
           email_subject: Te han invitado a unirte al grupo %{user_group_name}
           notification_title: Te han invitado a unirte al grupo <a href="%{resource_path}">%{user_group_name}</a> . Revisa la pestaña <a href="%{groups_profile_tab_path}">Grupos</a> en tu perfil para aceptar la invitación.
         join_request_accepted:
-          email_intro: '¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado tu solicitud para unirte a él.'
+          email_intro: ¡Felicidades! Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> ha aceptado tu solicitud para unirte a él.
           email_outro: Has recibido esta notificación porque tu solicitud de incorporación se ha actualizado.
           email_subject: Tu solicitud para unirte al grupo %{user_group_name} ha sido aceptada
           notification_title: Tu solicitud para unirte al grupo <a href="%{resource_path}">%{user_group_name}</a> ha sido aceptada.
@@ -485,12 +490,12 @@ es:
         promoted_to_admin:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> te ha otorgado permisos de administración para ese grupo.
           email_outro: Has recibido esta notificación porque eres miembro de ese grupo.
-          email_subject: '¡Ahora eres administrador/a del grupo %{user_group_name}!'
+          email_subject: "¡Ahora eres administrador/a del grupo %{user_group_name}!"
           notification_title: Ahora eres administrador/a del grupo <a href="%{resource_path}">%{user_group_name}</a>.
         removed_from_group:
           email_intro: Un administrador del grupo <a href="%{resource_url}">%{user_group_name}</a> te ha eliminado del mismo.
           email_outro: Has recibido esta notificación porque eras miembro de ese grupo.
-          email_subject: '¡Has sido eliminado del grupo %{user_group_name}!'
+          email_subject: "¡Has sido eliminado del grupo %{user_group_name}!"
           notification_title: Has sido eliminado del grupo <a href="%{resource_path}">%{user_group_name}</a>.
       notification_event:
         notification_title: Un evento ha ocurrido en <a href="%{resource_path}">%{resource_title}</a>.
@@ -547,39 +552,39 @@ es:
       badges:
         continuity:
           conditions:
-            - Viene aquí a menudo
+          - Viene aquí a menudo
           description: Este distintivo se otorga cuando visitas la plataforma de forma regular. ¡Nos gusta tenerte por aquí!
           description_another: Este usuario se ha conectado durante %{score} días consecutivos en algún momento.
           description_own: Te has conectado durante %{score} días consecutivos en algún momento.
           name: Continuidad
-          next_level_in: '¡Conéctate durante %{score} días consecutivos para alcanzar el siguiente nivel!'
+          next_level_in: "¡Conéctate durante %{score} días consecutivos para alcanzar el siguiente nivel!"
           unearned_another: Este usuario no ha entrado durante más de un día consecutivo.
           unearned_own: No te has conectado por más de un día consecutivo.
         followers:
           conditions:
-            - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
+          - Estar activo y seguir a otras personas seguramente hará que otras personas te sigan.
           description: Este distintivo se otorga cuando alcanzas un cierto número de seguidores. %{organization_name} es una red social y política, teje tu web para comunicarte con otras personas en la plataforma.
           description_another: Este usuario tiene %{score} seguidores.
           description_own: "%{score} usuarios te están siguiendo."
           name: Seguidores
-          next_level_in: '¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!'
+          next_level_in: "¡Consigue %{score} usuarios más para seguirte y alcanzar el siguiente nivel!"
           unearned_another: Este usuario no tiene seguidores todavía.
           unearned_own: Aún no tienes seguidores.
         index:
-          badge_title: "Distintivo %{name}"
+          badge_title: Distintivo %{name}
           how: Como puedes conseguirlo
           page_description: Los distintivos son reconocimientos a las acciones de los participantes y al progreso en la plataforma. A medida que comiences a descubrir, participar e interactuar en la plataforma, conseguirlo diferentes distintivo. Aquí está la lista de distintivos y algunas formas en que puedes conseguirlas.
           title: Distintivos
         invitations:
           conditions:
-            - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
-            - Personaliza, si quieres, el mensaje que estás enviando.
-            - Supera este nivel enviando invitaciones y registrándolas.
+          - Usa el enlace "invitar amigos" en tu página de usuario para invitar a tus amistades
+          - Personaliza, si quieres, el mensaje que estás enviando.
+          - Supera este nivel enviando invitaciones y registrándolas.
           description: Este distintivo se consigue cuando has invitado a algunas personas y han pasado un poco de tiempo para registrarse en %{organization_name} y se converten en participantes. ¡Gracias por dar a conocer %{organization_name} a otros y ayudar a ampliar la comunidad!
           description_another: Este usuario ha invitado a %{score} usuarios.
           description_own: Has invitado a %{score} usuarios.
           name: Invitaciones
-          next_level_in: '¡Invita %{score} usuarios más a alcanzar el siguiente nivel!'
+          next_level_in: "¡Invita %{score} usuarios más a alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha invitado a ningún usuario.
           unearned_own: No has invitado aún a ningún usuario.
       description: Las insignias son reconocimientos de las acciones de los participantes y el progreso en la plataforma. A medida que comienzas a descubrir, participar e interactuar en la plataforma, ganarás diferentes insignias.
@@ -587,7 +592,7 @@ es:
       reached_top: Has alcanzado el nivel superior para esta insignia.
     group_admins:
       actions:
-        are_you_sure: '¿Estás seguro? Esto no eliminará al usuario del grupo.'
+        are_you_sure: "¿Estás seguro? Esto no eliminará al usuario del grupo."
         demote_admin: Eliminar permisos de administración
       demote:
         error: Se ha producido un error al eliminar este usuario de la lista de administradores.
@@ -616,7 +621,7 @@ es:
         error: Se ha producido un error al aceptar esta solicitud de incorporación al grupo
         success: Solicitud aceptada con éxito
       actions:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
         promote_to_admin: Hacer administrador
         remove_from_group: Eliminar usuario
       index:
@@ -633,7 +638,7 @@ es:
         success: Usuario eliminado del grupo correctamente
     groups:
       actions:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
       create:
         error: Ha habido un problema al crear el grupo
         success: Grupo creado correctamente
@@ -673,7 +678,7 @@ es:
       main_topic:
         default_page:
           content: "<p>En %{organization} puedes participar y decidir sobre diferentes temas, a través de los espacios que ves en el menú superior: Procesos, Asambleas, Iniciativas, Consultas.</p> <p>Dentro de cada uno encontrarás diferentes opciones para participar: hacer propuestas - a nivel individual o con otras personas -, tomar parte en debates, priorizar proyectos a ejecutar, asistir a encuentros presenciales y otras acciones.</p>\n"
-          title: '¿Qué puedo hacer en %{organization}?'
+          title: "¿Qué puedo hacer en %{organization}?"
         description: Leer más sobre %{organization}
         title: Ayuda general
     last_activities:
@@ -714,12 +719,12 @@ es:
         new_conversation:
           greeting: Hola, %{recipient}!
           intro: "%{sender} ha iniciado una nueva conversación contigo. Haz click aquí para verla:"
-          outro: '¡Disfruta de decidim!'
+          outro: "¡Disfruta de decidim!"
           subject: "%{sender} ha iniciado una conversación contigo"
         new_message:
-          greeting: '¡Hola, %{recipient}!'
+          greeting: "¡Hola, %{recipient}!"
           intro: "%{sender} ha publicado nuevos mensajes en tu conversación. Haz clic aquí para verlos:"
-          outro: '¡Disfruta de decidim!'
+          outro: "¡Disfruta de decidim!"
           subject: Tienes nuevos mensajes de %{sender}
       conversations:
         create:
@@ -755,7 +760,7 @@ es:
     newsletter_mailer:
       newsletter:
         note: Has recibido este mensaje porque estás suscrito a boletines de noticias en %{organization_name}. Puedes cambiar la configuración en tu <a href="%{link}">página de notificaciones</a>.
-        see_on_website: '¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.'
+        see_on_website: ¿No puedes ver este correo electrónico correctamente? Accede a su <a href="%{link}" target="_blank">versión web</a>.
         unsubscribe: Si no quieres recibir este tipo de correo electrónico, <a href="%{link}" target="_blank" class="unsubscribe">unsubscríbete</a>.
     newsletters:
       unsubscribe:
@@ -772,12 +777,12 @@ es:
     newsletters_opt_in_mailer:
       notify:
         body_1: El procesamiento de datos personales y su protección es cada vez más importante para todos nosotros. Con el nuevo Reglamento General de Protección de Datos (RGPD) del 25 de mayo de 2018, las personas tienen un mejor control sobre sus datos personales. Por este motivo, necesitamos tu "OK" para seguir enviando información relevante sobre las actividades del %{organization_name}.
-        body_2: '¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:'
+        body_2: "¿Cómo puedes darnos tu consentimiento? Simplemente haz clic en el siguiente botón:"
         body_3: Con este consentimiento, podrás continuar recibiendo información sobre los servicios de la plataforma. Si, por el contrario, no recibimos una confirmación positiva de tu parte, dejaremos de enviarte nuestros mensajes. Si confirmas que deseas mantenerte informado, siempre tendrás la opción de cancelar en cualquier momento.
         button: Sí, deseo continuar recibiendo información relevante
         greetings: Saludos,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hola,
-        subject: '¿Deseas seguir recibiendo información relevante sobre %{organization_name}?'
+        subject: "¿Deseas seguir recibiendo información relevante sobre %{organization_name}?"
     notification_mailer:
       shared:
         note: Recibió este mensaje porque está suscrito a la notificación por correo electrónico en% {organization_name}. Puede cambiar la configuración en su <a href="%{link}"> página de notificaciones </a>.
@@ -787,8 +792,8 @@ es:
       show:
         email_on_notification: Quiero recibir un correo electrónico cada vez que recibo una notificación.
         everything_followed: Todo lo que sigo
-        newsletters: Boletines de noticias
         newsletter_notifications: Quiero recibir boletines informativos
+        newsletters: Boletines de noticias
         own_activity: Mi propia actividad, como cuando alguien comenta en mi propuesta o me menciona.
         receive_notifications_about: Quiero recibir notificaciones sobre
         send_notifications_by_email: Enviar notificaciones por correo electrónico
@@ -812,7 +817,7 @@ es:
         extended:
           debates: Debates
           debates_explanation: Debate y discute, comparte tus opiniones y enriquece los temas relevantes.
-          how_to_participate: '¿Cómo tomo parte en un proceso?'
+          how_to_participate: "¿Cómo tomo parte en un proceso?"
           meetings: Encuentros
           meetings_explanation: Averigua dónde y cuándo puedes participar en encuentros públicos.
           more_info: Más información
@@ -861,7 +866,7 @@ es:
       terms_and_conditions:
         accept:
           error: Ha habido un error al aceptar los Términos y Condiciones.
-          success: '¡Estupendo! Has aceptado los Términos y Condiciones.'
+          success: "¡Estupendo! Has aceptado los Términos y Condiciones."
         form:
           agreement: Estoy de acuerdo con estos términos
           legend: Aceptar los Términos y Condiciones de uso
@@ -871,7 +876,7 @@ es:
           modal_btn_exit: Lo revisaré más tarde
           modal_button: Rechazar los términos
           modal_close: Cerrar modal
-          modal_title: '¿Confirmas que no aceptas los Términos y Condiciones actualizados?'
+          modal_title: "¿Confirmas que no aceptas los Términos y Condiciones actualizados?"
         required_review:
           alert: Hemos actualizado nuestros Términos de Servicio, por favor revísalos.
           body: Por favor dedica un momento a revisar la actualización de nuestras Términos de Servicio. De lo contrario, no podrás usar la plataforma.
@@ -882,6 +887,7 @@ es:
       deleted: Usuario eliminado
       view: Ver
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Este grupo de usuarios se verifica públicamente, tu nombre se ha verificado para que se corresponda con tu nombre real
       default_officialization_text_for_users: Esta persona participante está verificada públicamente. Se ha verificado que su nombre o cargo corresponde con su nombre real y rol
       show:
@@ -993,8 +999,8 @@ es:
         no_activities_warning: Este usuario no ha tenido ninguna actividad todavía.
     user_interests:
       show:
-        no_scopes: '¡Esta organización aún no tiene ningún ámbito!'
         my_interests: Mis intereses
+        no_scopes: "¡Esta organización aún no tiene ningún ámbito!"
         select_your_interests: Selecciona los temas que te interesan para recibir eventos relacionados con ellos en la pestaña Timeline de tu perfil.
         update_my_interests: Actualizar mis intereses
       update:
@@ -1013,11 +1019,11 @@ es:
     failure:
       already_authenticated: Ya has iniciado sesión.
       inactive: Tu cuenta aún no está activada.
-      invalid: '%{authentication_keys} o contraseña inválida.'
+      invalid: "%{authentication_keys} o contraseña inválida."
       invited: Tienes una invitación pendiente, acéptala para terminar de crear tu cuenta.
       last_attempt: Tienes un intento más antes de que tu cuenta se bloquee.
       locked: Tu cuenta está bloqueada.
-      not_found_in_database: '%{authentication_keys} o contraseña inválida.'
+      not_found_in_database: "%{authentication_keys} o contraseña inválida."
       timeout: Tu sesión expiró Por favor, inicia sesión de nuevo para continuar.
       unauthenticated: Debes iniciar sesión o registrarte antes de continuar.
     invitations:
@@ -1027,7 +1033,7 @@ es:
         submit_button: Guardar
         subtitle: Si aceptas la invitación, por favor establece tu nombre de usuario/a y contraseña.
       invitation_removed: Tu invitación fue eliminada.
-      invitation_token_invalid: '¡El token de invitación proporcionado no es válido!'
+      invitation_token_invalid: "¡El token de invitación proporcionado no es válido!"
       new:
         header: Enviar invitación
         submit_button: Enviar una invitación
@@ -1068,19 +1074,19 @@ es:
       organization_admin_invitation_instructions:
         subject: Has sido invitado para gestionar %{organization}
       password_change:
-        greeting: '¡Hola %{recipient}!'
+        greeting: "¡Hola %{recipient}!"
         message: Nos ponemos en contacto contigo para notificarte que tu contraseña ha sido cambiada correctamente.
         subject: Contraseña modificada
       reset_password_instructions:
         action: Cambiar mi contraseña
-        greeting: '¡Hola %{recipient}!'
+        greeting: "¡Hola %{recipient}!"
         instruction: Alguien ha solicitado un enlace para cambiar tu contraseña, y puede hacerlo a través del siguiente enlace.
         instruction_2: Si no lo solicitaste, ignora este correo electrónico.
         instruction_3: Tu contraseña no cambiará hasta que accedas al enlace de arriba y crees una nueva.
         subject: Restablecer instrucciones de contraseña
       unlock_instructions:
         action: Desbloquear mi cuenta
-        greeting: '¡Hola %{recipient}!'
+        greeting: "¡Hola %{recipient}!"
         instruction: 'Haz clic en el siguiente enlace para desbloquear tu cuenta:'
         message: Tu cuenta ha sido bloqueada debido a una cantidad excesiva de intentos de inicio de sesión fallidos.
         subject: Desbloquear instrucciones
@@ -1094,7 +1100,7 @@ es:
         confirm_new_password: Confirmar la nueva contraseña
         new_password: Contraseña
       new:
-        forgot_your_password: '¿Olvidaste tu contraseña?'
+        forgot_your_password: "¿Olvidaste tu contraseña?"
         send_me_reset_password_instructions: Enviarme instrucciones para restablecer la contraseña
       no_token: No puedes acceder a esta página sin venir de un correo electrónico de restablecimiento de contraseña. Si vienes de un correo electrónico de restablecimiento de contraseña, asegúrate de haber utilizado la URL provista completa.
       send_instructions: Recibirás un correo electrónico con instrucciones sobre cómo restablecer tu contraseña en unos minutos.
@@ -1102,19 +1108,19 @@ es:
       updated: Tu contraseña ha sido cambiada con éxito. Ya has iniciado sesión.
       updated_not_active: Tu contraseña ha sido cambiada con éxito.
     registrations:
-      destroyed: '¡Adiós! Tu cuenta ha sido cancelada exitosamente. Esperamos volverte a ver pronto.'
+      destroyed: "¡Adiós! Tu cuenta ha sido cancelada exitosamente. Esperamos volverte a ver pronto."
       edit:
-        are_you_sure: '¿Estás seguro?'
+        are_you_sure: "¿Estás seguro?"
         cancel_my_account: Cancelar mi cuenta
         currently_waiting_confirmation_for_email: 'Esperando de confirmación para: %{email}'
         leave_blank_if_you_don_t_want_to_change_it: Déjalo en blanco si no quieres cambiarlo
         title: Editar %{resource}
-        unhappy: '¿Infeliz?'
+        unhappy: "¿Infeliz?"
         update: Actualizar
         we_need_your_current_password_to_confirm_your_changes: Necesitamos tu contraseña actual para confirmar sus cambios
       new:
         sign_up: Regístrate
-      signed_up: '¡Bienvenido/a! Te has registrado con éxito.'
+      signed_up: "¡Bienvenido/a! Te has registrado con éxito."
       signed_up_but_inactive: Te has registrado con éxito. Sin embargo, no pudimos iniciar sesión porque tu cuenta aún no está activada.
       signed_up_but_locked: Te has registrado con éxito. Sin embargo, no pudimos iniciar sesión porque tu cuenta está bloqueada.
       signed_up_but_unconfirmed: Se ha enviado un mensaje con un enlace de confirmación a tu dirección de correo electrónico. Por favor, sigue el enlace para activar tu cuenta.
@@ -1129,9 +1135,9 @@ es:
     shared:
       links:
         back: Atrás
-        didn_t_receive_confirmation_instructions: '¿No has recibido las instrucciones de confirmación?'
-        didn_t_receive_unlock_instructions: '¿No has recibido instrucciones de desbloqueo?'
-        forgot_your_password: '¿Olvidaste tu contraseña?'
+        didn_t_receive_confirmation_instructions: "¿No has recibido las instrucciones de confirmación?"
+        didn_t_receive_unlock_instructions: "¿No has recibido instrucciones de desbloqueo?"
+        forgot_your_password: "¿Olvidaste tu contraseña?"
         sign_in: Iniciar sesión
         sign_in_with_provider: Inicia sesión con %{provider}
         sign_up: Regístrate
@@ -1168,6 +1174,17 @@ es:
       too_short: Es demasiado corto (menos de 15 caracteres)
   forms:
     required: Obligatorio
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Si eres humano, ignora este campo
     timestamp_error_message: Lo siento, has sido demasiado rápido! Por favor, vuelva a enviar.

--- a/decidim-core/config/locales/eu.yml
+++ b/decidim-core/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ eu:
         personal_url: URL pertsonala
         remove_avatar: Kendu avatar-a
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: eranskina
       decidim/component_published_event: Osagai aktiboa
       decidim/demoted_membership: Ez da talde admin gehiago
@@ -45,8 +50,8 @@ eu:
         one: Erabiltzaile taldea
         other: Erabiltzaile taldeak
   booleans:
-    'false': 'Ez'
-    'true': 'Bai'
+    'false': Ez
+    'true': Bai
   carrierwave:
     errors:
       image_too_big: Irudia pisuegia da
@@ -136,12 +141,12 @@ eu:
       amendable:
         amended_by: Aldatua
         button: Aldatu %{model_name}
-        promote_button: '%{model_name}suspertzea'
         error: Errore bat gertatu da baliabidea aldatzen.
         help_text: Hobetu %{model_name} hau bere %{amendable_fields}aldatuz
-        promote_help_text: Aldaketa hori sustatzeko eta argitaratzeko %{model_name}independente gisa
         no_amenders: Ez dago murrizketarik
         no_amendments: Ez dago zuzenketarik
+        promote_button: "%{model_name}suspertzea"
+        promote_help_text: Aldaketa hori sustatzeko eta argitaratzeko %{model_name}independente gisa
         section_heading: Aldaketak (%{count})
       created:
         error: Errore bat gertatu da aldaketa hau sortzean, saiatu berriro geroago
@@ -168,18 +173,18 @@ eu:
         amendment_author: Egile aldaketa
         back: Back
         heading: Sortu zure aldaketa
-        help_text: '%{model_name}aldatzen ari zara'
+        help_text: "%{model_name}aldatzen ari zara"
         send: Bidali aldaketa
+      promoted:
+        error: Akatsak izan dira emendifikazioa sustatzen denean
+        success: Emendazioa arrakastaz sustatu da
       rejected:
         error: Errore bat gertatu da aldaketa hori arbuiatzearekin. Saiatu berriro geroago
         success: Aldaketa ongi baztertu da
-      promoted:
-        success: Emendazioa arrakastaz sustatu da
-        error: Akatsak izan dira emendifikazioa sustatzen denean
       review:
         back: Back
         heading: Aldaketa berrikustea
-        help_text: '%{model_name}aldatzen ari zara'
+        help_text: "%{model_name}aldatzen ari zara"
         send: Onartu aldaketa
     anonymous_user: Anonimoa
     application:
@@ -211,8 +216,8 @@ eu:
         name: Dummy baimena eragiketa
       errors:
         duplicate_authorization: Badago erabiltzaile bat, datu berberekin baimendua.
-      expired_at: '%{timestamp} iraungita dago'
-      expires_at: '%{timestamp} iraungitzen da'
+      expired_at: "%{timestamp} iraungita dago"
+      expires_at: "%{timestamp} iraungitzen da"
       foo_authorization:
         fields:
           bar: Bar
@@ -384,39 +389,6 @@ eu:
         title: Ez dugu aurkitu bilatzen duzun orria!
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Zuzenketa berri bat izan da sortu %{amendable_title}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
-            email_subject: Aldaketa berri bat %{amendable_title} %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">berrien aldaketa</a> sortu da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Zuzenketa berri bat izan da sortu %{amendable_title}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-            email_subject: Aldaketa berri bat %{amendable_title} %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">berrien aldaketa</a> sortu da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Aldaketa baztertu egin da %{amendable_title}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
-            email_subject: Aldaketa baztertua %{amendable_title} %{emendation_author_nickname}
-            notification_title: The <a href="%{emendation_path}">Zuzenketa</a> sortutako <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> izan da baztertzen <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Aldaketa baztertu egin da %{amendable_title}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-            email_subject: Aldaketa baztertua %{amendable_title} %{emendation_author_nickname}
-            notification_title: The <a href="%{emendation_path}">Zuzenketa</a> sortutako <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> izan da baztertzen <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Aldaketak %{amendable_title} baztertu ditu independente bat sustatu du %{amendable_type}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
-            email_subject: Aldaketa %{emendation_author_nickname} aurrera sustatu da
-            notification_title: A <a href="%{emendation_path}">errebindikazio aldatzea</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>sustatu du.
-          follower:
-            email_intro: 'Aldaketak %{amendable_title} baztertu ditu independente bat sustatu du %{amendable_type}. Orrialde hau ikusi dezakezu:'
-            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-            email_subject: Aldaketa %{emendation_author_nickname} aurrera sustatu da
-            notification_title: A <a href="%{emendation_path}">errebindikazio aldatzea</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>sustatu du.
         amendment_accepted:
           affected_user:
             email_intro: 'Zuzenketa bat bertan bera onartu %{amendable_title}. Orrialde hau ikusi dezakezu:'
@@ -428,23 +400,56 @@ eu:
             email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
             email_subject: Aldaketa onartzen %{amendable_title} %{emendation_author_nickname}
             notification_title: The <a href="%{emendation_path}">Zuzenketa</a> sortutako <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> izan da onartu <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Zuzenketa berri bat izan da sortu %{amendable_title}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
+            email_subject: Aldaketa berri bat %{amendable_title} %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">berrien aldaketa</a> sortu da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Zuzenketa berri bat izan da sortu %{amendable_title}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
+            email_subject: Aldaketa berri bat %{amendable_title} %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">berrien aldaketa</a> sortu da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Aldaketak %{amendable_title} baztertu ditu independente bat sustatu du %{amendable_type}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
+            email_subject: Aldaketa %{emendation_author_nickname} aurrera sustatu da
+            notification_title: A <a href="%{emendation_path}">errebindikazio aldatzea</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>sustatu du.
+          follower:
+            email_intro: 'Aldaketak %{amendable_title} baztertu ditu independente bat sustatu du %{amendable_type}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
+            email_subject: Aldaketa %{emendation_author_nickname} aurrera sustatu da
+            notification_title: A <a href="%{emendation_path}">errebindikazio aldatzea</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>sustatu du.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Aldaketa baztertu egin da %{amendable_title}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}delako egileak zarelako.
+            email_subject: Aldaketa baztertua %{amendable_title} %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">Zuzenketa</a> sortutako <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> izan da baztertzen <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Aldaketa baztertu egin da %{amendable_title}. Orrialde hau ikusi dezakezu:'
+            email_outro: Jakinarazpen hau jaso duzu %{amendable_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
+            email_subject: Aldaketa baztertua %{amendable_title} %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">Zuzenketa</a> sortutako <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> izan da baztertzen <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Dokumentu berri bat gehitu zaio %{resource_title}. Orrialde hau ikusi dezakezu:'
           email_outro: Jakinarazpen hau jaso duzulako %{resource_title} jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-          email_subject: '%{resource_title} eguneratzea'
+          email_subject: "%{resource_title} eguneratzea"
           notification_title: <a href="%{resource_path}"> dokumentu berri bat</a> gehitu zaio <a href="%{attached_to_url}">%{resource_title}</a>
       components:
         component_published:
-          email_intro: '%{resource_title} osagaia %{participatory_space_title}da aktibo dagoenean. Orrialde hau ikusi dezakezu:'
+          email_intro: "%{resource_title} osagaia %{participatory_space_title}da aktibo dagoenean. Orrialde hau ikusi dezakezu:"
           email_outro: Jakinarazpena jaso duzu %{participatory_space_title}jarraituz gero. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-          email_subject: '%{participatory_space_title} eguneratze bat'
+          email_subject: "%{participatory_space_title} eguneratze bat"
           notification_title: '%{resource_title} osagaia aktibo dago <a href="%{resource_path}">%{participatory_space_title}</a>'
       email_event:
         email_greeting: Kaixo, %{user_name},
         email_intro: 'Eguneratze da "%{resource_title}". Orri honetan ikus daiteke:'
         email_outro: Jakinarazpen hau jaso duzu "%{resource_title}” jarraitzen duzulako. Jarraitzeari utzi diezaiokezu aurreko estekan.
-        email_subject: '%{resource_title} eguneratzea'
+        email_subject: "%{resource_title} eguneratzea"
       gamification:
         badge_earned:
           email_intro: Lan handia! <a href="%{resource_path}">%{badge_name} txapela irabazi duzu</a> ( %{current_level}maila).
@@ -465,12 +470,12 @@ eu:
         invited_to_group:
           email_intro: <a href="%{resource_url}">%{user_group_name}</a> taldeko administratzaileak gonbidatu zaitu.
           email_outro: Jakinarazpen hau jaso duzu talde honetara gonbidatuta zaudelako. Egiaztatu Taldeak fitxan zure profilean onartzeko.
-          email_subject: '%{user_group_name} taldean sartzeko gonbidatu zaituzte!'
+          email_subject: "%{user_group_name} taldean sartzeko gonbidatu zaituzte!"
           notification_title: <a href="%{resource_path}">%{user_group_name}</a> taldean sartzera gonbidatu zaituzte. Begiratu <a href="%{groups_profile_tab_path}">Taldeak orrialdeko</a> zure profilean onartzeko!
         join_request_accepted:
           email_intro: Zorionak! <a href="%{resource_url}">%{user_group_name}</a> taldearen administratzaileak zure eskaera onartu du.
           email_outro: Jakinarazpen hau jaso duzu zure eskaera bateratu delako.
-          email_subject: '%{user_group_name} taldean onartu duzu!'
+          email_subject: "%{user_group_name} taldean onartu duzu!"
           notification_title: <a href="%{resource_path}">%{user_group_name}</a> taldean onartu zaituzte.
         join_request_created:
           email_intro: Norbaitek %{user_group_name} taldean parte hartzeko eskatu du. <a href="%{resource_url}">taldeko kideen</a>orrialdea onartu edo ukatu dezakezu.
@@ -480,7 +485,7 @@ eu:
         join_request_rejected:
           email_intro: <a href="%{resource_url}">%{user_group_name}</a> taldeko administratzaileak zure eskaera ukatu egin du.
           email_outro: Jakinarazpen hau jaso duzu zure eskaera bateratu delako.
-          email_subject: '%{user_group_name} taldera sartzeko eskaera baztertu egin da!'
+          email_subject: "%{user_group_name} taldera sartzeko eskaera baztertu egin da!"
           notification_title: <a href="%{resource_path}">%{user_group_name}</a> taldera sartzeko eskaera baztertu egin da.
         promoted_to_admin:
           email_intro: <a href="%{resource_url}">%{user_group_name}</a> taldeko administratzaileak talde horren administrazio-eskubideak eman dizkizu.
@@ -490,7 +495,7 @@ eu:
         removed_from_group:
           email_intro: Taldeak <a href="%{resource_url}">%{user_group_name}</a> taldearen administratzaileak kendu egin zaitu.
           email_outro: Jakinarazpen hori jaso duzu talde horretako kide zarelako.
-          email_subject: '%{user_group_name} taldetik kendu duzu!'
+          email_subject: "%{user_group_name} taldetik kendu duzu!"
           notification_title: <a href="%{resource_path}">%{user_group_name}</a> taldetik kendu zaituzte.
       notification_event:
         notification_title: 'Gertaera bat gertatu da hemen: <a href="%{resource_path}">%{resource_title}</a>.'
@@ -547,7 +552,7 @@ eu:
       badges:
         continuity:
           conditions:
-            - Zatoz hemen sarritan
+          - Zatoz hemen sarritan
           description: Txartela hau modu erregularrean bisitatzen duzunean ematen da. Gustatzen zait hemen!
           description_another: Erabiltzaile honek une batez %{score} egunez konektatua dago.
           description_own: Zenbait puntutan eguneko %{score} egunetarako konektatuta zaude.
@@ -557,7 +562,7 @@ eu:
           unearned_own: Ez duzu egun bat baino gehiagoz konektaturik.
         followers:
           conditions:
-            - Beste pertsona batzuei aktibo eta jarraitzen zaien ziurgabetasuna beste pertsona batzuek segituko dute.
+          - Beste pertsona batzuei aktibo eta jarraitzen zaien ziurgabetasuna beste pertsona batzuek segituko dute.
           description: Idazmahaia jarraitzaile kopuru jakin batera iristen zarenean ematen da. %{organization_name} sare sozial eta politikoa da, zure weba plataforman beste pertsona batzuekin komunikatzeko ehundu.
           description_another: Erabiltzaile honek %{score} jarraitzaile ditu.
           description_own: "%{score} erabiltzaile jarraitzen zaituzte."
@@ -572,18 +577,18 @@ eu:
           title: Badges
         invitations:
           conditions:
-            - Erabili "gonbidatu lagunak" esteka erabiltzaile-orrian zure lagunak gonbidatzeko
-            - Pertsonalizatu, nahi baduzu, bidaltzen ari zaren mezua
-            - Gonbidapenak bidaltzea eta inskribatzea lortuko duzu.
+          - Erabili "gonbidatu lagunak" esteka erabiltzaile-orrian zure lagunak gonbidatzeko
+          - Pertsonalizatu, nahi baduzu, bidaltzen ari zaren mezua
+          - Gonbidapenak bidaltzea eta inskribatzea lortuko duzu.
           description: Idazmahaia ematen zaie pertsona batzuk gonbidatu dituzunean eta denbora pixka bat pasatu dute %{organization_name} erregistratu eta parte-hartzaile bihurtu. Eskerrik asko egiteko %{organization_name} besteei ezaguna eta komunitatea zabaltzeko laguntzen!
           description_another: Erabiltzaile honek %{score} erabiltzaile gonbidatu ditu.
-          description_own: '%{score} erabiltzaile gonbidatu dituzu.'
+          description_own: "%{score} erabiltzaile gonbidatu dituzu."
           name: Gonbidapenak
           next_level_in: Gonbidatu %{score} erabiltzaile gehiago hurrengo mailara iristeko!
           unearned_another: Erabiltzaile honek ez du oraindik gonbidatu erabiltzaileak.
           unearned_own: Erabiltzaile ez da gonbidatu oraindik.
       description: Badiak partaideen ekintzak eta plataforma aurrerapenean aitortzen dira. Plataforman ezagutzeko, parte hartu eta elkarreraginean hasten zarenean, txapak irabazten dituzu.
-      level: '%{level}maila'
+      level: "%{level}maila"
       reached_top: Idatzi honen goialdean iritsi zara.
     group_admins:
       actions:
@@ -720,7 +725,7 @@ eu:
           greeting: Kaixo, %{recipient}!
           intro: "%{sender} elkarrizketan mezu berriak argitaratu ditu. Egin klik hemen ikusteko:"
           outro: Gozatu erabaki!
-          subject: '%{sender}-tik mezu berriak dituzu'
+          subject: "%{sender}-tik mezu berriak dituzu"
       conversations:
         create:
           error: Ez da elkarrizketa hasi. Saiatu berriro geroago
@@ -777,7 +782,7 @@ eu:
         button: Bai, informazio garrantzitsua jasotzen jarraitu nahi dut
         greetings: Agurrak,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Kaixo,
-        subject: '%{organization_name}inguruko informazio garrantzitsua jasotzen jarraitu nahi al duzu?'
+        subject: "%{organization_name}inguruko informazio garrantzitsua jasotzen jarraitu nahi al duzu?"
     notification_mailer:
       shared:
         note: Mezu hau jaso duzu jakinarazpenean harpidetuta zaudelako% {organization_name} helbidean. Zure ezarpenak alda ditzakezu <a href="%{link}"> jakinarazpenen orrian </a>.
@@ -787,8 +792,8 @@ eu:
       show:
         email_on_notification: Mezu elektroniko bat jaso nahi dut jakinarazpen bat jasotzen dudan bakoitzean.
         everything_followed: Jarraitzen dudan guztia
-        newsletters: Buletinak
         newsletter_notifications: Buletinak jaso nahi ditut
+        newsletters: Buletinak
         own_activity: Nire jarduera, norbaiti nire proposamena iruzkindu edo aipatzen dudanean
         receive_notifications_about: Jakinarazpenak jaso nahi ditut
         send_notifications_by_email: Bidali jakinarazpenak posta elektronikoz
@@ -834,7 +839,7 @@ eu:
           conferences_count: Jardunaldiak
           debates_count: Eztabaidak
           endorsements_count: Oniritziak
-          headline: '%{organization} erakundearen egungo egoera'
+          headline: "%{organization} erakundearen egungo egoera"
           meetings_count: Bilerak
           orders_count: Euskarriak
           pages_count: Orriak
@@ -854,10 +859,6 @@ eu:
         subheading: Laguntza orrietan nabigatzeko %{name}
         title: Laguntza
         topics: Gaiak
-      participatory_space:
-        metrics:
-          headline: Zifretan parte hartzea
-          link: Erakutsi estatistiken guztiak
       terms_and_conditions:
         accept:
           error: Errore bat gertatu da terminoak eta baldintzak onartzen dituzunean.
@@ -882,6 +883,7 @@ eu:
       deleted: Erabiltzailea ezabatua
       view: ikusi
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Erabiltzaile talde hau publikoki egiaztatua dago, bere izena benetako izenarekin lotzeko egiaztatu da
       default_officialization_text_for_users: Partehartzaile hau publikoki egiaztatua dago, bere izena edo rol egiaztatua dago bere benetako izena eta rolarekin bat etorriz
       show:
@@ -993,8 +995,8 @@ eu:
         no_activities_warning: Erabiltzaile honek ez du oraindik jarduera izan.
     user_interests:
       show:
-        no_scopes: Antolakuntza honek ez du inongo esparrurik!
         my_interests: Nire interesak
+        no_scopes: Antolakuntza honek ez du inongo esparrurik!
         select_your_interests: Aukeratu interesatzen zaizkizun gaiak zure profileko Timeline fitxan erlazionatutako gertaerak jasotzeko.
         update_my_interests: Eguneratu nire interesak
       update:
@@ -1013,11 +1015,11 @@ eu:
     failure:
       already_authenticated: Saioa hasi zara.
       inactive: Zure kontua ez dago oraindik aktibatuta.
-      invalid: '%{authentication_keys} edo pasahitza baliogabea.'
+      invalid: "%{authentication_keys} edo pasahitza baliogabea."
       invited: Gonbidapen bat dago zain, onartu zure kontua sortzerakoan.
       last_attempt: Zure kontua blokeatuta dago aurretik zure saiakera gehiago duzu.
       locked: Zure kontua blokeatuta dago.
-      not_found_in_database: '%{authentication_keys} edo pasahitza baliogabea.'
+      not_found_in_database: "%{authentication_keys} edo pasahitza baliogabea."
       timeout: Zure saioa iraungi da. Hasi saioa berriro jarraitzeko.
       unauthenticated: Saioa hasi edo saioa hasi behar duzu jarraitu aurretik.
     invitations:
@@ -1086,7 +1088,7 @@ eu:
         subject: Desblokeatu argibideak
     omniauth_callbacks:
       failure: Ezin izan da autentifikatu %{kind} "%{reason}" delako.
-      success: '%{kind} kontutik behar bezala egiaztatua.'
+      success: "%{kind} kontutik behar bezala egiaztatua."
     passwords:
       edit:
         change_my_password: Aldatu nire pasahitza
@@ -1150,7 +1152,7 @@ eu:
   errors:
     messages:
       already_confirmed: dagoeneko baieztatu da. Saiatu saioa hasi
-      confirmation_period_expired: '%{period}barruan baieztatu behar da, eskatu beste bat'
+      confirmation_period_expired: "%{period}barruan baieztatu behar da, eskatu beste bat"
       content_type_whitelist_error: fitxategiaren mota ez da baliozkoa
       cycle_detected: Esparruko guraso bat ezin da bere ondorengoetako bat izan
       expired: iraungi egin da, eskatu beste bat
@@ -1168,6 +1170,17 @@ eu:
       too_short: laburra da (15 karaktere baino gutxiago)
   forms:
     required: Nahitaezkoa da
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Gizaki bat bazara, ez egin kasu eremu honi
     timestamp_error_message: Barkatu, baina azkarregi aritu zara! Mesedez, bidali.

--- a/decidim-core/config/locales/fi-pl.yml
+++ b/decidim-core/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ fi-pl:
         personal_url: Henkilökohtainen URL-osoite
         remove_avatar: Poista profiilikuva
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Liite
       decidim/component_published_event: Aktiivinen komponentti
       decidim/demoted_membership: Ei enää ryhmän ylläpitäjä
@@ -45,8 +50,8 @@ fi-pl:
         one: Käyttäjäryhmä
         other: Käyttäjäryhmät
   booleans:
-    'false': 'Ei'
-    'true': 'Kyllä'
+    'false': Ei
+    'true': Kyllä
   carrierwave:
     errors:
       image_too_big: Kuva on liian suuri
@@ -136,12 +141,12 @@ fi-pl:
       amendable:
         amended_by: 'Muuttanut:'
         button: Muuta %{model_name}
-        promote_button: Korosta kohteeksi %{model_name}
         error: Tämän resurssin muuttamisessa tapahtui virhe.
         help_text: Paranna tätä %{model_name} kohdetta muuttamalla sen kenttiä %{amendable_fields}
-        promote_help_text: Voit korostaa tämän muutoksen ja julkaista sen uutena %{model_name} -kohteena
         no_amenders: Ei muutoksia tehneitä
         no_amendments: Ei muutoksia
+        promote_button: Korosta kohteeksi %{model_name}
+        promote_help_text: Voit korostaa tämän muutoksen ja julkaista sen uutena %{model_name} -kohteena
         section_heading: Muutokset (%{count})
       created:
         error: Virhe luotaessa muutosta, yritä myöhemmin uudelleen
@@ -170,12 +175,12 @@ fi-pl:
         heading: Luo muutos
         help_text: Olet muuttamassa kohdetta %{model_name}
         send: Lähetä muutos
+      promoted:
+        error: Muutoksen korostamisessa tapahtui virheitä
+        success: Muutos korostettu onnistuneesti
       rejected:
         error: Tämän muutoksen, hylkäämisessä tapahtui virhe, yritä myöhemmin uudelleen
         success: Muutos on hylätty onnistuneesti
-      promoted:
-        success: Muutos korostettu onnistuneesti
-        error: Muutoksen korostamisessa tapahtui virheitä
       review:
         back: Takaisin
         heading: Tarkastele muutosta
@@ -245,7 +250,7 @@ fi-pl:
           title: Varmennus on edelleen kesken
         unauthorized:
           explanation: Pahoittelut, et voi suorittaa tätä toimintoa, koska varmennustietosi eivät täsmää.
-          invalid_field: "Kentän %{field} arvo %{value} ei kelpaa."
+          invalid_field: Kentän %{field} arvo %{value} ei kelpaa.
           ok: Ok
           title: Ei varmennettu
         unconfirmed:
@@ -384,39 +389,6 @@ fi-pl:
         title: Etsimääsi sivua ei löydy
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
-            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjä <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
-            email_outro: Olet saanut tämän ilmoituksen, koska olet kirjailija %{amendable_title}.
-            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
-            email_subject: Käyttäjän %{emendation_author_nickname} tekemä muutos on korostettu
-            notification_title: <a href="%{emendation_path}">Hylätty ehdotus</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
-          follower:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Käyttäjän %{emendation_author_nickname} luoma muutos on korostettu
-            notification_title: <a href="%{emendation_path}">Hylätty muutos</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
         amendment_accepted:
           affected_user:
             email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hyväksytty. Näet sen tältä sivulta:'
@@ -428,6 +400,39 @@ fi-pl:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
             email_subject: Kohdetta %{amendable_title} koskeva muutos on hyväksytty käyttäjältä %{emendation_author_nickname}
             notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hyväksytty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
+            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjä <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
+            email_subject: Käyttäjän %{emendation_author_nickname} tekemä muutos on korostettu
+            notification_title: <a href="%{emendation_path}">Hylätty ehdotus</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
+          follower:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Käyttäjän %{emendation_author_nickname} luoma muutos on korostettu
+            notification_title: <a href="%{emendation_path}">Hylätty muutos</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
+            email_outro: Olet saanut tämän ilmoituksen, koska olet kirjailija %{amendable_title}.
+            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Uusi asiakirja on lisätty kohteeseen %{resource_title}. Voit nähdä sen täältä:'
@@ -436,7 +441,7 @@ fi-pl:
           notification_title: <a href="%{resource_path}">Uusi dokumentti</a> on lisätty kohteeseen <a href="%{attached_to_url}">%{resource_title}</a>
       components:
         component_published:
-          email_intro: '%{resource_title} -komponentti on nyt käytössä kohteessa %{participatory_space_title}. Näet sen tältä sivulta:'
+          email_intro: "%{resource_title} -komponentti on nyt käytössä kohteessa %{participatory_space_title}. Näet sen tältä sivulta:"
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{participatory_space_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
           email_subject: Päivitys kohteessa %{participatory_space_title}
           notification_title: Komponentti %{resource_title} on nyt aktiivinen kohteessa <a href="%{resource_path}">%{participatory_space_title}</a>
@@ -547,7 +552,7 @@ fi-pl:
       badges:
         continuity:
           conditions:
-            - Käy täällä usein
+          - Käy täällä usein
           description: Tämä kunniamerkki myönnetään, kun vierailet alustalla säännöllisesti. Mukavaa, että olet mukana!
           description_another: Tämä käyttäjä on vieraillut alustalla %{score} peräkkäisenä päivänä jossakin vaiheessa.
           description_own: Olet vieraillut alustalla %{score} peräkkäisenä päivänä jossakin vaiheessa.
@@ -557,7 +562,7 @@ fi-pl:
           unearned_own: Et ole kirjautunut palveluun kuin yhtenä peräkkäisenä päivänä.
         followers:
           conditions:
-            - Saat varmasti muut seuraamaan sinua ollessasi aktiivinen ja seuraamalla itse muita ihmisiä.
+          - Saat varmasti muut seuraamaan sinua ollessasi aktiivinen ja seuraamalla itse muita ihmisiä.
           description: Tämä kunniamerkki myönnetään, kun tavoitat tietyn määrän seuraajia. %{organization_name} on sosiaalinen ja poliittinen verkosto, muodosta oma verkostosi keskustellaksesi muiden ihmisten kanssa tässä palvelussa.
           description_another: Tällä käyttäjällä on %{score} seuraajaa.
           description_own: "%{score} käyttäjää seuraa sinua."
@@ -572,9 +577,9 @@ fi-pl:
           title: Kunniamerkit
         invitations:
           conditions:
-            - Käytä profiilisivullasi olevaa "kutsua ystäviä" -linkkiä kutsuaksesi ystäviäsi palveluun
-            - Muokkaa lähetettävää viestiä halutessasi
-            - Pääset seuraavalle tasolle lähettämällä kutsuja ja saadessasi kyseiset ihmiset rekisteröitymään palveluun.
+          - Käytä profiilisivullasi olevaa "kutsua ystäviä" -linkkiä kutsuaksesi ystäviäsi palveluun
+          - Muokkaa lähetettävää viestiä halutessasi
+          - Pääset seuraavalle tasolle lähettämällä kutsuja ja saadessasi kyseiset ihmiset rekisteröitymään palveluun.
           description: Tämä kunniamerkki myönnetään, kun olet kutsunut ihmisiä %{organization_name} -palveluun ja nämä ihmiset rekisteröityvät palvelun käyttäjiksi. Kiitos, että autat tekemään %{organization_name} -palvelusta tunnetumpaa ja laajentamaan yhteisöä!
           description_another: Tämä käyttäjä on kutsunut %{score} käyttäjää.
           description_own: Olet kutsunut %{score} käyttäjää.
@@ -778,14 +783,17 @@ fi-pl:
         greetings: Tervehdys,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hei,
         subject: Haluatko jatkaa olennaisen tiedon vastaanottamista koskien %{organization_name} -palvelua?
+    notification_mailer:
+      shared:
+        note: You received this message because you're subscribed to notification by email on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
     notifications:
       no_notifications: Ei vielä ilmoituksia.
     notifications_settings:
       show:
         email_on_notification: Haluan saada sähköpostia aina, kun saan ilmoituksen.
         everything_followed: Kaikki mitä seuraan
-        newsletters: Uutiskirjeet
         newsletter_notifications: Haluan vastaanottaa uutiskirjeitä
+        newsletters: Uutiskirjeet
         own_activity: Oma toiminta, kuten omia ehdotuksia koskevat kommentit tai maininnat
         receive_notifications_about: Haluan saada ilmoituksia
         send_notifications_by_email: Lähetä ilmoitukset sähköpostitse
@@ -831,7 +839,7 @@ fi-pl:
           conferences_count: Konferenssit
           debates_count: Keskustelua
           endorsements_count: Suosituksia
-          headline: '%{organization} numeroina'
+          headline: "%{organization} numeroina"
           meetings_count: Tapahtumat
           orders_count: Ääntä
           pages_count: Sivua
@@ -879,6 +887,7 @@ fi-pl:
       deleted: Poistettu käyttäjä
       view: Näytä
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Tämä käyttäjäryhmä on julkisesti vahvistettu, sen nimi vastaa oikeaa nimeä
       default_officialization_text_for_users: Tämä osallistuja on julkisesti vahvistettu. Hänen nimensä tai roolinsa on varmistettu vastaamaan hänen oikeaa nimeään ja rooliaan
       show:
@@ -990,8 +999,8 @@ fi-pl:
         no_activities_warning: Tämä käyttäjä ei ole vielä ollut aktiivinen.
     user_interests:
       show:
-        no_scopes: Tällä organisaatiolla ei ole vielä teemaa!
         my_interests: Omat kiinnostuksen kohteet
+        no_scopes: Tällä organisaatiolla ei ole vielä teemaa!
         select_your_interests: Valitse ne aiheet, joista olet kiinnostunut vastaanottamaan tapahtumia profiilisi aikajana-välilehdellä.
         update_my_interests: Päivitä omat kiinnostuksen kohteet
       update:
@@ -1036,7 +1045,7 @@ fi-pl:
       confirmation_instructions:
         action: Vahvista käyttäjätilini
         greeting: Tervetuloa %{recipient}!
-        instruction: 'Voit vahvistaa käyttäjätiliisi kytketyn sähköpostiosoitteen alla olevan linkin kautta.'
+        instruction: Voit vahvistaa käyttäjätiliisi kytketyn sähköpostiosoitteen alla olevan linkin kautta.
         subject: Vahvistusohjeet
       email_changed:
         greeting: Hei %{recipient}!
@@ -1165,6 +1174,17 @@ fi-pl:
       too_short: liian lyhyt (alle 15 merkkiä)
   forms:
     required: Vaadittu
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Jos olet ihminen, jätä tämä kenttä huomiotta
     timestamp_error_message: Pahoittelut, olit liian nopea! Lähetä lomake uudestaan.

--- a/decidim-core/config/locales/fi.yml
+++ b/decidim-core/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ fi:
         personal_url: Henkilökohtainen URL-osoite
         remove_avatar: Poista profiilikuva
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Liite
       decidim/component_published_event: Aktiivinen komponentti
       decidim/demoted_membership: Ei enää ryhmän ylläpitäjä
@@ -45,8 +50,8 @@ fi:
         one: Käyttäjäryhmä
         other: Käyttäjäryhmät
   booleans:
-    'false': 'Ei'
-    'true': 'Kyllä'
+    'false': Ei
+    'true': Kyllä
   carrierwave:
     errors:
       image_too_big: Kuva on liian suuri
@@ -136,12 +141,12 @@ fi:
       amendable:
         amended_by: 'Muuttanut:'
         button: Muuta %{model_name}
-        promote_button: Korosta kohteeksi %{model_name}
         error: Tämän resurssin muuttamisessa tapahtui virhe.
         help_text: Paranna tätä %{model_name} kohdetta muuttamalla sen kenttiä %{amendable_fields}
-        promote_help_text: Voit korostaa tämän muutoksen ja julkaista sen uutena %{model_name} -kohteena
         no_amenders: Ei muutoksia tehneitä
         no_amendments: Ei muutoksia
+        promote_button: Korosta kohteeksi %{model_name}
+        promote_help_text: Voit korostaa tämän muutoksen ja julkaista sen uutena %{model_name} -kohteena
         section_heading: Muutokset (%{count})
       created:
         error: Virhe luotaessa muutosta, yritä myöhemmin uudelleen
@@ -170,12 +175,12 @@ fi:
         heading: Luo muutos
         help_text: Olet muuttamassa kohdetta %{model_name}
         send: Lähetä muutos
+      promoted:
+        error: Muutoksen korostamisessa tapahtui virheitä
+        success: Muutos korostettu onnistuneesti
       rejected:
         error: Tämän muutoksen, hylkäämisessä tapahtui virhe, yritä myöhemmin uudelleen
         success: Muutos on hylätty onnistuneesti
-      promoted:
-        success: Muutos korostettu onnistuneesti
-        error: Muutoksen korostamisessa tapahtui virheitä
       review:
         back: Takaisin
         heading: Tarkastele muutosta
@@ -245,7 +250,7 @@ fi:
           title: Varmennus on edelleen kesken
         unauthorized:
           explanation: Pahoittelut, et voi suorittaa tätä toimintoa, koska varmennustietosi eivät täsmää.
-          invalid_field: "Kentän %{field} arvo %{value} ei kelpaa."
+          invalid_field: Kentän %{field} arvo %{value} ei kelpaa.
           ok: Ok
           title: Ei varmennettu
         unconfirmed:
@@ -384,39 +389,6 @@ fi:
         title: Etsimääsi sivua ei löydy
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
-            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjä <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
-            email_outro: Olet saanut tämän ilmoituksen, koska olet kirjailija %{amendable_title}.
-            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
-            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
-            email_subject: Käyttäjän %{emendation_author_nickname} tekemä muutos on korostettu
-            notification_title: <a href="%{emendation_path}">Hylätty ehdotus</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
-          follower:
-            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
-            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-            email_subject: Käyttäjän %{emendation_author_nickname} luoma muutos on korostettu
-            notification_title: <a href="%{emendation_path}">Hylätty muutos</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
         amendment_accepted:
           affected_user:
             email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hyväksytty. Näet sen tältä sivulta:'
@@ -428,6 +400,39 @@ fi:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
             email_subject: Kohdetta %{amendable_title} koskeva muutos on hyväksytty käyttäjältä %{emendation_author_nickname}
             notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hyväksytty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
+            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uusi muutos on luotu kohteelle %{amendable_title}. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Uusi muutos kohteelle %{amendable_title} käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjä <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> on luotu <a href="%{emendation_path}">uuden muutoksen</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen %{amendable_title}.
+            email_subject: Käyttäjän %{emendation_author_nickname} tekemä muutos on korostettu
+            notification_title: <a href="%{emendation_path}">Hylätty ehdotus</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
+          follower:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on korostettu omaksi %{amendable_type} -kohteeksi. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Käyttäjän %{emendation_author_nickname} luoma muutos on korostettu
+            notification_title: <a href="%{emendation_path}">Hylätty muutos</a> kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} on korostettu käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> toimesta.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
+            email_outro: Olet saanut tämän ilmoituksen, koska olet kirjailija %{amendable_title}.
+            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Kohdetta %{amendable_title} koskeva muutos on hylätty. Näet sen tältä sivulta:'
+            email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta %{amendable_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
+            email_subject: Kohdetta %{amendable_title} koskeva muutos on hylätty käyttäjältä %{emendation_author_nickname}
+            notification_title: Käyttäjän <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> luoma <a href="%{emendation_path}">muutos</a> on hylätty kohteelle <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Uusi asiakirja on lisätty kohteeseen %{resource_title}. Näet sen tältä sivulta:'
@@ -547,7 +552,7 @@ fi:
       badges:
         continuity:
           conditions:
-            - Käy täällä usein
+          - Käy täällä usein
           description: Tämä kunniamerkki myönnetään, kun vierailet alustalla säännöllisesti. Mukavaa, että olet mukana!
           description_another: Tämä käyttäjä on vieraillut alustalla %{score} peräkkäisenä päivänä jossakin vaiheessa.
           description_own: Olet vieraillut alustalla %{score} peräkkäisenä päivänä jossakin vaiheessa.
@@ -557,7 +562,7 @@ fi:
           unearned_own: Et ole kirjautunut palveluun kuin yhtenä peräkkäisenä päivänä.
         followers:
           conditions:
-            - Saat varmasti muut seuraamaan sinua ollessasi aktiivinen ja seuraamalla itse muita ihmisiä.
+          - Saat varmasti muut seuraamaan sinua ollessasi aktiivinen ja seuraamalla itse muita ihmisiä.
           description: Tämä kunniamerkki myönnetään, kun tavoitat tietyn määrän seuraajia. %{organization_name} on sosiaalinen ja poliittinen verkosto, muodosta oma verkostosi keskustellaksesi muiden ihmisten kanssa tässä palvelussa.
           description_another: Tällä käyttäjällä on %{score} seuraajaa.
           description_own: "%{score} käyttäjää seuraa sinua."
@@ -572,9 +577,9 @@ fi:
           title: Kunniamerkit
         invitations:
           conditions:
-            - Käytä profiilisivullasi olevaa "kutsua ystäviä" -linkkiä kutsuaksesi ystäviäsi palveluun
-            - Muokkaa lähetettävää viestiä halutessasi
-            - Pääset seuraavalle tasolle lähettämällä kutsuja ja saadessasi kyseiset ihmiset rekisteröitymään palveluun.
+          - Käytä profiilisivullasi olevaa "kutsua ystäviä" -linkkiä kutsuaksesi ystäviäsi palveluun
+          - Muokkaa lähetettävää viestiä halutessasi
+          - Pääset seuraavalle tasolle lähettämällä kutsuja ja saadessasi kyseiset ihmiset rekisteröitymään palveluun.
           description: Tämä kunniamerkki myönnetään, kun olet kutsunut ihmisiä %{organization_name} -palveluun ja nämä ihmiset rekisteröityvät palvelun käyttäjiksi. Kiitos, että autat tekemään %{organization_name} -palvelusta tunnetumpaa ja laajentamaan yhteisöä!
           description_another: Tämä käyttäjä on kutsunut %{score} käyttäjää.
           description_own: Olet kutsunut %{score} käyttäjää.
@@ -787,8 +792,8 @@ fi:
       show:
         email_on_notification: Haluan saada sähköpostia aina, kun saan ilmoituksen.
         everything_followed: Kaikki mitä seuraan
-        newsletters: Uutiskirjeet
         newsletter_notifications: Haluan vastaanottaa uutiskirjeitä
+        newsletters: Uutiskirjeet
         own_activity: Oma toiminta, kuten omia ehdotuksia koskevat kommentit tai maininnat
         receive_notifications_about: Haluan saada ilmoituksia
         send_notifications_by_email: Lähetä ilmoitukset sähköpostitse
@@ -834,7 +839,7 @@ fi:
           conferences_count: Konferensseja
           debates_count: Keskusteluja
           endorsements_count: Suosituksia
-          headline: '%{organization} numeroina'
+          headline: "%{organization} numeroina"
           meetings_count: Tapahtumia
           orders_count: Ääniä
           pages_count: Sivuja
@@ -854,10 +859,6 @@ fi:
         subheading: Selaa palvelun %{name} tietosivuja
         title: Tietoa
         topics: Aiheet
-      participatory_space:
-        metrics:
-          headline: Osallistuminen lukuina
-          link: Näytä kaikki tilastot
       terms_and_conditions:
         accept:
           error: Ehtojen hyväksymisessä tapahtui virhe.
@@ -882,6 +883,7 @@ fi:
       deleted: Poistettu käyttäjä
       view: Näytä
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Tämä käyttäjäryhmä on julkisesti vahvistettu, sen nimi vastaa oikeaa nimeä
       default_officialization_text_for_users: Tämä osallistuja on julkisesti vahvistettu. Hänen nimensä tai roolinsa on varmistettu vastaamaan hänen oikeaa nimeään ja rooliaan
       show:
@@ -993,8 +995,8 @@ fi:
         no_activities_warning: Tämä käyttäjä ei ole vielä ollut aktiivinen.
     user_interests:
       show:
-        no_scopes: Tällä organisaatiolla ei ole vielä teemaa!
         my_interests: Omat kiinnostuksen kohteet
+        no_scopes: Tällä organisaatiolla ei ole vielä teemaa!
         select_your_interests: Valitse ne aiheet, joista olet kiinnostunut vastaanottamaan tapahtumia profiilisi aikajana-välilehdellä.
         update_my_interests: Päivitä omat kiinnostuksen kohteet
       update:
@@ -1039,7 +1041,7 @@ fi:
       confirmation_instructions:
         action: Vahvista käyttäjätilini
         greeting: Tervetuloa %{recipient}!
-        instruction: 'Voit vahvistaa käyttäjätiliisi kytketyn sähköpostiosoitteen alla olevan linkin kautta.'
+        instruction: Voit vahvistaa käyttäjätiliisi kytketyn sähköpostiosoitteen alla olevan linkin kautta.
         subject: Vahvistusohjeet
       email_changed:
         greeting: Hei %{recipient}!
@@ -1168,6 +1170,17 @@ fi:
       too_short: liian lyhyt (alle 15 merkkiä)
   forms:
     required: Vaadittu
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Jos olet ihminen, jätä tämä kenttä huomiotta
     timestamp_error_message: Pahoittelut, olit liian nopea! Lähetä lomake uudestaan.

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -49,8 +50,8 @@ fr:
         one: Groupe d'utilisateurs
         other: Groupes d'utilisateurs
   booleans:
-    'false': 'Non'
-    'true': 'Oui'
+    'false': Non
+    'true': Oui
   carrierwave:
     errors:
       image_too_big: L'image est trop grande
@@ -354,8 +355,7 @@ fr:
             check: Oui, je souhaite m'inscrire à la newsletter
             close_modal: Fermer la fenêtre
             uncheck: Non merci, je m'informerai autrement
-          notice: |-
-            La newsletter vous permet de suivre tous les évènements importants sur la plateforme (lancement de nouvelles concertations, annonce des résultats, etc.). Souhaitez-vous vous y inscrire ?
+          notice: La newsletter vous permet de suivre tous les évènements importants sur la plateforme (lancement de nouvelles concertations, annonce des résultats, etc.). Souhaitez-vous vous y inscrire ?
           title: Newsletter
         omniauth_buttons:
           or: Ou
@@ -442,7 +442,7 @@ fr:
           notification_title: La fonctionnalité %{resource_title} est maintenant active pour <a href="%{resource_path}">%{participatory_space_title}</a>
       email_event:
         email_greeting: Bonjour %{user_name},
-        email_intro: '« %{resource_title} » a été mis à jour. Vous pouvez y accéder ici :'
+        email_intro: "« %{resource_title} » a été mis à jour. Vous pouvez y accéder ici :"
         email_outro: Vous recevez cet notification car vous suivez « %{resource_title} ». Vous pouvez cesser de le suivre en allant sur le lien précédent.
         email_subject: Mise à jour de %{resource_title}
       gamification:
@@ -547,7 +547,7 @@ fr:
       badges:
         continuity:
           conditions:
-            - Viens ici souvent
+          - Viens ici souvent
           description: Ce badge est attribué lorsque vous visitez la plate-forme de manière régulière. Nous aimons vous avoir ici!
           description_another: Cet utilisateur s'est connecté pendant %{score} jours consécutifs à un moment donné.
           description_own: Vous vous êtes connecté pendant %{score} jours consécutifs à un moment donné.
@@ -557,7 +557,7 @@ fr:
           unearned_own: Vous n'êtes pas connecté depuis plus d'un jour consécutif.
         followers:
           conditions:
-            - Être actif et suivre les autres incitera sûrement les autres à vous suivre.
+          - Être actif et suivre les autres incitera sûrement les autres à vous suivre.
           description: Ce badge est attribué lorsque vous atteignez un certain nombre d'adeptes. %{organization_name} est un réseau social et politique, tissez votre site Web pour communiquer avec les autres personnes de la plate-forme.
           description_another: Cet utilisateur a %{score} abonnés.
           description_own: "%{score} utilisateurs vous suivent."
@@ -566,15 +566,15 @@ fr:
           unearned_another: Cet utilisateur n'a pas encore de suiveurs.
           unearned_own: Vous n'avez pas encore de followers.
         index:
-          badge_title: "Badge : %{name}"
+          badge_title: 'Badge : %{name}'
           how: Comment pouvez-vous le gagner
           page_description: Les badges sont une reconnaissance des actions des participants et des progrès de la plate-forme. Lorsque vous commencerez à découvrir, à participer et à interagir avec la plateforme, vous obtiendrez différents badges. Voici la liste des badges et des moyens de les gagner.
           title: Insignes
         invitations:
           conditions:
-            - Utilisez le lien "inviter des amis" sur votre page utilisateur pour inviter vos amis.
-            - Personnalisez, si vous le souhaitez, le message que vous envoyez
-            - Vous augmenterez votre niveau en envoyant des invitations et en les faisant enregistrer.
+          - Utilisez le lien "inviter des amis" sur votre page utilisateur pour inviter vos amis.
+          - Personnalisez, si vous le souhaitez, le message que vous envoyez
+          - Vous augmenterez votre niveau en envoyant des invitations et en les faisant enregistrer.
           description: Ce badge est attribué lorsque vous avez invité des personnes qui ont passé un peu de temps à s’inscrire à %{organization_name} et devenir des participants. Merci de faire connaître %{organization_name} aux autres et d’aider à élargir la communauté!
           description_another: Cet utilisateur a invité %{score} utilisateurs.
           description_own: Vous avez invité %{score} utilisateurs.
@@ -1010,11 +1010,11 @@ fr:
     failure:
       already_authenticated: Vous êtes déjà connecté.
       inactive: Votre compte n'est pas encore activé.
-      invalid: '%{authentication_keys} ou mot de passe invalide.'
+      invalid: "%{authentication_keys} ou mot de passe invalide."
       invited: Vous avez une invitation en attente, acceptez-la pour terminer la création de votre compte.
       last_attempt: Vous avez encore une tentative avant que votre compte soit verrouillé.
       locked: Ton compte est bloqué.
-      not_found_in_database: '%{authentication_keys} ou mot de passe invalide.'
+      not_found_in_database: "%{authentication_keys} ou mot de passe invalide."
       timeout: Votre session a expiré. Veuillez vous connecter à nouveau pour continuer.
       unauthenticated: Vous devez vous connecter ou vous inscrire avant de continuer.
     invitations:
@@ -1165,6 +1165,17 @@ fr:
       too_short: est trop court (moins de 15 caractères)
   forms:
     required: Champs obligatoires
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Si vous êtes humain, ignorez ce champ
     timestamp_error_message: Désolé, c'était trop rapide ! Veuillez le renvoyer.
@@ -1178,7 +1189,7 @@ fr:
         edit: Modifier
       footer:
         download_open_data: Télécharger les fichiers de données ouvertes
-        made_with_open_source: 'Site réalisé par <a target="_blank" href="https://www.opensourcepolitics.eu">Open Source Politics</a> grâce à <a target="_blank" href="https://opensourcepolitics.eu/#decidim">Decidim, le logiciel libre</a> de <a target="_blank" href="https://www.opensourcepolitics.eu">démocratie participative</a>.'
+        made_with_open_source: Site réalisé par <a target="_blank" href="https://www.opensourcepolitics.eu">Open Source Politics</a> grâce à <a target="_blank" href="https://opensourcepolitics.eu/#decidim">Decidim, le logiciel libre</a> de <a target="_blank" href="https://www.opensourcepolitics.eu">démocratie participative</a>.
       header:
         close_menu: Fermer le menu
         navigation: Navigation

--- a/decidim-core/config/locales/gl.yml
+++ b/decidim-core/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ gl:
         personal_url: URL persoal
         remove_avatar: Eliminar avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Anexo
       decidim/component_published_event: Compoñente activo
       decidim/demoted_membership: Xa non é un administrador de grupo
@@ -45,8 +50,8 @@ gl:
         one: Grupo de usuarios
         other: Grupos de usuarios
   booleans:
-    'false': 'Non'
-    'true': 'Si'
+    'false': Non
+    'true': Si
   carrierwave:
     errors:
       image_too_big: A imaxe é demasiado grande
@@ -110,7 +115,7 @@ gl:
         create: "%{user_name} invitados %{resource_name} para ser un usuario privado"
         delete: "%{user_name} eliminou o usuario %{resource_name} como usuario privado"
       scope:
-        create: "O %{user_name} creou o alcance %{resource_name}"
+        create: O %{user_name} creou o alcance %{resource_name}
         create_with_parent: "%{user_name} creou o alcance %{resource_name} no ámbito %{parent_scope}"
         delete: "%{user_name} eliminou o alcance %{resource_name}"
         delete_with_parent: "%{user_name} eliminou o alcance %{resource_name} no ámbito %{parent_scope}"
@@ -136,12 +141,12 @@ gl:
       amendable:
         amended_by: Modificado por
         button: Modificar %{model_name}
-        promote_button: Promoción a %{model_name}
         error: Produciuse un erro ao modificar este recurso.
         help_text: Mellora este %{model_name} modificando o seu %{amendable_fields}
-        promote_help_text: Pode promover esta modificación e publicala como un %{model_name}independente
         no_amenders: Non hai amortidores
         no_amendments: Non hai emendas
+        promote_button: Promoción a %{model_name}
+        promote_help_text: Pode promover esta modificación e publicala como un %{model_name}independente
         section_heading: Enmendas (%{count})
       created:
         error: Produciuse un erro ao crear esta emenda, téntao de novo máis tarde
@@ -170,12 +175,12 @@ gl:
         heading: Crea a túa emenda
         help_text: Está a modificar o %{model_name}
         send: Enviar a emenda
+      promoted:
+        error: Houbo erros ao promover a modificación
+        success: Emendación promovida con éxito
       rejected:
         error: Produciuse un erro ao rexeitar esta emenda, téntao de novo máis tarde
         success: A emenda foi rexeitada con éxito
-      promoted:
-        success: Emendación promovida con éxito
-        error: Houbo erros ao promover a modificación
       review:
         back: De volta
         heading: Revisa a modificación
@@ -245,7 +250,7 @@ gl:
           title: A autorización aínda está en progreso
         unauthorized:
           explanation: Non podes realizar esta acción porque algúns dos teus datos de autorización non coinciden.
-          invalid_field: "O %{field} valor %{value} non é válido."
+          invalid_field: O %{field} valor %{value} non é válido.
           ok: Ok
           title: Non autorizado
         unconfirmed:
@@ -384,39 +389,6 @@ gl:
         title: Non se pode atopar a páxina que buscas
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Creouse unha nova emenda para %{amendable_title}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
-            email_subject: Unha nova enmenda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nova emenda</a> foi creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Creouse unha nova emenda para %{amendable_title}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
-            email_subject: Unha nova enmenda para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">nova emenda</a> foi creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Rexeitouse unha modificación para %{amendable_title}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
-            email_subject: Unha enmenda rexeitada para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendación</a> creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rexeitada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Rexeitouse unha modificación para %{amendable_title}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
-            email_subject: Unha enmenda rexeitada para %{amendable_title} de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendación</a> creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rexeitada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Unha enmenda rexeitada para %{amendable_title} foi promovida a unha independente %{amendable_type}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
-            email_subject: Engadiuse unha emenda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendación rexeitada</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Unha enmenda rexeitada para %{amendable_title} foi promovida a unha independente %{amendable_type}. Podes velo desde esta páxina:'
-            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
-            email_subject: Engadiuse unha emenda de %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendación rexeitada</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'A emenda foi aceptada para %{amendable_title}. Podes velo desde esta páxina:'
@@ -428,6 +400,39 @@ gl:
             email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
             email_subject: Unha enmenda aceptada para %{amendable_title} de %{emendation_author_nickname}
             notification_title: A <a href="%{emendation_path}">emendación</a> creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi aceptada para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Creouse unha nova emenda para %{amendable_title}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
+            email_subject: Unha nova enmenda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nova emenda</a> foi creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Creouse unha nova emenda para %{amendable_title}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
+            email_subject: Unha nova enmenda para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">nova emenda</a> foi creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Unha enmenda rexeitada para %{amendable_title} foi promovida a unha independente %{amendable_type}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
+            email_subject: Engadiuse unha emenda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emendación rexeitada</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Unha enmenda rexeitada para %{amendable_title} foi promovida a unha independente %{amendable_type}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
+            email_subject: Engadiuse unha emenda de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emendación rexeitada</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Rexeitouse unha modificación para %{amendable_title}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque es un autor de %{amendable_title}.
+            email_subject: Unha enmenda rexeitada para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emendación</a> creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rexeitada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Rexeitouse unha modificación para %{amendable_title}. Podes velo desde esta páxina:'
+            email_outro: Recibiches esta notificación porque estás seguindo %{amendable_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
+            email_subject: Unha enmenda rexeitada para %{amendable_title} de %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emendación</a> creada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rexeitada por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Engadiuse un novo documento a %{resource_title}. Podes velo desde esta páxina:'
@@ -547,7 +552,7 @@ gl:
       badges:
         continuity:
           conditions:
-            - Veña aquí a miúdo
+          - Veña aquí a miúdo
           description: Este distintivo concedeuse cando visitas a plataforma dun xeito regular. Gústanos de telo por aquí.
           description_another: Este usuario conectouse por %{score} días consecutivos nalgún momento.
           description_own: Conectado por %{score} días consecutivos nalgún momento.
@@ -557,7 +562,7 @@ gl:
           unearned_own: Non estás conectado por máis dun día consecutivo.
         followers:
           conditions:
-            - Ser activo e seguir a outras persoas seguramente fará que outras persoas sigan contigo.
+          - Ser activo e seguir a outras persoas seguramente fará que outras persoas sigan contigo.
           description: Este distintivo é concedido cando chega a un certo número de seguidores. %{organization_name} é unha rede social e política, tece a súa web para comunicarse con outras persoas na plataforma.
           description_another: Este usuario ten %{score} seguidores.
           description_own: "%{score} seguidores están seguindo."
@@ -572,9 +577,9 @@ gl:
           title: Insignias
         invitations:
           conditions:
-            - Utiliza a ligazón "invitar amigos" na túa páxina de usuario para invitar aos teus amigos
-            - Personaliza, se queres, a mensaxe que estás enviando
-            - Subirás ao enviar invitacións e obtelos rexistrados.
+          - Utiliza a ligazón "invitar amigos" na túa páxina de usuario para invitar aos teus amigos
+          - Personaliza, se queres, a mensaxe que estás enviando
+          - Subirás ao enviar invitacións e obtelos rexistrados.
           description: Este distintivo concedeuse cando convidou a algunhas persoas e pasaron un pouco de tempo para inscribirse en %{organization_name} e converterse en participantes. Grazas por facer %{organization_name} a coñecer aos outros e axudando a ampliar a comunidade!
           description_another: Este usuario invitou a %{score} usuarios.
           description_own: Invitaches %{score} usuarios.
@@ -787,8 +792,8 @@ gl:
       show:
         email_on_notification: Quero recibir un correo electrónico cada vez que recibo unha notificación.
         everything_followed: Todo o que segue
-        newsletters: Boletíns informativos
         newsletter_notifications: Quero recibir boletíns
+        newsletters: Boletíns informativos
         own_activity: A miña propia actividade, como cando alguén comenta na miña proposta ou me menciona
         receive_notifications_about: Quero recibir notificacións sobre
         send_notifications_by_email: Envíe notificacións por correo electrónico
@@ -812,7 +817,7 @@ gl:
         extended:
           debates: Debates
           debates_explanation: Debate e discute, comparte as túas opinións e enriquece os temas relevantes.
-          how_to_participate: '¿Como participo nun proceso?'
+          how_to_participate: "¿Como participo nun proceso?"
           meetings: Reunións
           meetings_explanation: Descubra onde e cando pode participar en reunións públicas.
           more_info: Máis información
@@ -854,10 +859,6 @@ gl:
         subheading: Navega polas páxinas de axuda de %{name}
         title: Axuda
         topics: Temas
-      participatory_space:
-        metrics:
-          headline: Participación en números
-          link: Mostrar todas as estatísticas
       terms_and_conditions:
         accept:
           error: Produciuse un erro ao aceptar os termos e condicións.
@@ -871,7 +872,7 @@ gl:
           modal_btn_exit: Vou revisalo máis tarde
           modal_button: Rexeitar os termos
           modal_close: Pechar modal
-          modal_title: '¿Realmente rexeita os Termos e condicións actualizados?'
+          modal_title: "¿Realmente rexeita os Termos e condicións actualizados?"
         required_review:
           alert: Actualizamos as nosas Condicións de servizo, por favor revíselas.
           body: Leve un momento para revisar as actualizacións das nosas Condicións de servizo. Se non, non poderás usar a plataforma.
@@ -882,6 +883,7 @@ gl:
       deleted: Usuario eliminado
       view: Ver
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Este grupo de usuarios está verificado públicamente, o seu nome verificouse para corresponder co seu nome real
       default_officialization_text_for_users: Este participante está verificado públicamente, verificouse o seu nome ou o seu papel para corresponder co seu nome e rol real
       show:
@@ -993,8 +995,8 @@ gl:
         no_activities_warning: Este usuario aínda non tivo ningunha actividade.
     user_interests:
       show:
-        no_scopes: Esta organización aínda non ten ningún alcance.
         my_interests: Os meus intereses
+        no_scopes: Esta organización aínda non ten ningún alcance.
         select_your_interests: Selecciona os temas que che interesan para recibir eventos relacionados con eles na pestana Timeline do teu perfil.
         update_my_interests: Actualiza os meus intereses
       update:
@@ -1168,6 +1170,17 @@ gl:
       too_short: é demasiado curto (menos de 15 caracteres)
   forms:
     required: Requerido
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Se es humano, ignore este campo
     timestamp_error_message: Sentímolo, iso foi demasiado rápido. Reenvío de novo.
@@ -1249,7 +1262,7 @@ gl:
       day_of_week: "%a"
       day_of_week_long: "%a %e"
       day_of_year: "%d.%m.%y"
-      decidim_day_of_year: "123_2_0_321 %B 123_2_2_321 |"
+      decidim_day_of_year: 123_2_0_321 %B 123_2_2_321 |
       decidim_short: "%d/%m/%Y %H:%M"
       devise:
         mailer:

--- a/decidim-core/config/locales/hu.yml
+++ b/decidim-core/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ hu:
         personal_url: Személyes URL
         remove_avatar: Avatár eltávolítása
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Melléklet
       decidim/component_published_event: Aktív elem
       decidim/demoted_membership: Már nem egy csoport admin
@@ -45,8 +50,8 @@ hu:
         one: Felhasználói csoport
         other: Felhasználói csoportok
   booleans:
-    'false': 'Nem'
-    'true': 'Igen'
+    'false': Nem
+    'true': Igen
   carrierwave:
     errors:
       image_too_big: A kép mérete túl nagy
@@ -136,12 +141,12 @@ hu:
       amendable:
         amended_by: Módosította
         button: 'Módosítás: %{model_name}'
-        promote_button: Kezdeményezze a %{model_name}
         error: Hiba történt az erőforrás módosításakor.
         help_text: Javítsd ezt a %{model_name} az %{amendable_fields}módosításával
-        promote_help_text: Támogathatod ezt az emelést, és közzétehetik önálló %{model_name}-ként
         no_amenders: Nincsenek módosítások
         no_amendments: Nincsenek módosítások
+        promote_button: Kezdeményezze a %{model_name}
+        promote_help_text: Támogathatod ezt az emelést, és közzétehetik önálló %{model_name}-ként
         section_heading: Módosítások (%{count})
       created:
         error: Hiba történt a módosítás létrehozásával, próbálkozzon később
@@ -170,12 +175,12 @@ hu:
         heading: Készítse el a módosítását
         help_text: Módosítja a %{model_name}
         send: Módosító javaslat elküldése
+      promoted:
+        error: Az emelés előmozdításakor hiba történt
+        success: Az emelés sikeresen előmozdult
       rejected:
         error: Az emelés elutasításakor hiba történt, próbálkozzon később
         success: Az emelést sikeresen elutasították
-      promoted:
-        success: Az emelés sikeresen előmozdult
-        error: Az emelés előmozdításakor hiba történt
       review:
         back: Vissza
         heading: Tekintse át a módosítást
@@ -245,7 +250,7 @@ hu:
           title: Engedélyezés folyamatban
         unauthorized:
           explanation: Ez a művelet nem hajtható végre, mivel néhány engedélyezési adat nem egyezik.
-          invalid_field: "A(z) %{field} %{value} érték nem érvényes."
+          invalid_field: A(z) %{field} %{value} érték nem érvényes.
           ok: Rendben
           title: Nem engedélyezett
         unconfirmed:
@@ -383,39 +388,6 @@ hu:
         title: A keresett oldal nem található
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Új módosítás történt a %{amendable_title}. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést kaptad, mert szerzője vagy ennek %{amendable_title}.
-            email_subject: Új módosítás a %{amendable_title} tól %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">új módosítás</a> lett létrehozva <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Új módosítás történt a %{amendable_title}. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
-            email_subject: Új módosítás a %{amendable_title} tól %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">új módosítás</a> lett létrehozva <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Egy módosítást elutasítottunk %{amendable_title}. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést megkaptuk, mert Ön szerzője a %{amendable_title}.
-            email_subject: Egy módosítás elutasítva %{amendable_title} -ra %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> által létrehozott <a href="%{emendation_path}"></a> módosítást <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}elutasították.
-          follower:
-            email_intro: 'Egy módosítást elutasítottunk %{amendable_title}. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
-            email_subject: Egy módosítás elutasítva %{amendable_title} -ra %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> által létrehozott <a href="%{emendation_path}"></a> módosítást <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}elutasították.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'A %{amendable_title} elutasított módosítást önálló %{amendable_type}emelték. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést megkaptuk, mert Ön szerzője a %{amendable_title}.
-            email_subject: A %{emendation_author_nickname} ból származó módosítást támogatták
-            notification_title: A <a href="%{emendation_path}"></a> elutasított </a> módosítást a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} re vonatkozóan <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>kal támogatták.
-          follower:
-            email_intro: 'A %{amendable_title} elutasított módosítást önálló %{amendable_type}emelték. Láthatja ezt az oldalról:'
-            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
-            email_subject: A %{emendation_author_nickname} ból származó módosítást támogatták
-            notification_title: A <a href="%{emendation_path}"></a> elutasított </a> módosítást a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} re vonatkozóan <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>kal támogatták.
         amendment_accepted:
           affected_user:
             email_intro: 'Módosítást fogadtak el %{amendable_title}. Láthatja ezt az oldalról:'
@@ -427,6 +399,39 @@ hu:
             email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
             email_subject: Egy módosítás elfogadva %{amendable_title} -ra %{emendation_author_nickname}-tól
             notification_title: A <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> által létrehozott <a href="%{emendation_path}">módosítás</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} elfogadásra került.
+        amendment_created:
+          affected_user:
+            email_intro: 'Új módosítás történt a %{amendable_title}. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést kaptad, mert szerzője vagy ennek %{amendable_title}.
+            email_subject: Új módosítás a %{amendable_title} tól %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">új módosítás</a> lett létrehozva <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Új módosítás történt a %{amendable_title}. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
+            email_subject: Új módosítás a %{amendable_title} tól %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">új módosítás</a> lett létrehozva <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'A %{amendable_title} elutasított módosítást önálló %{amendable_type}emelték. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést megkaptuk, mert Ön szerzője a %{amendable_title}.
+            email_subject: A %{emendation_author_nickname} ból származó módosítást támogatták
+            notification_title: A <a href="%{emendation_path}"></a> elutasított </a> módosítást a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} re vonatkozóan <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>kal támogatták.
+          follower:
+            email_intro: 'A %{amendable_title} elutasított módosítást önálló %{amendable_type}emelték. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
+            email_subject: A %{emendation_author_nickname} ból származó módosítást támogatták
+            notification_title: A <a href="%{emendation_path}"></a> elutasított </a> módosítást a <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} re vonatkozóan <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>kal támogatták.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Egy módosítást elutasítottunk %{amendable_title}. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést megkaptuk, mert Ön szerzője a %{amendable_title}.
+            email_subject: Egy módosítás elutasítva %{amendable_title} -ra %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> által létrehozott <a href="%{emendation_path}"></a> módosítást <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}elutasították.
+          follower:
+            email_intro: 'Egy módosítást elutasítottunk %{amendable_title}. Láthatja ezt az oldalról:'
+            email_outro: Ezt az értesítést megkapta, mert %{amendable_title}követ. Leállíthatja az értesítések fogadását az előző link után.
+            email_subject: Egy módosítás elutasítva %{amendable_title} -ra %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> által létrehozott <a href="%{emendation_path}"></a> módosítást <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}elutasították.
       attachments:
         attachment_created:
           email_intro: 'Új dokumentumot adtak hozzá a következőhöz: %{resource_title}. Innen érheted el:'
@@ -546,7 +551,7 @@ hu:
       badges:
         continuity:
           conditions:
-            - Gyere ide gyakran
+          - Gyere ide gyakran
           description: Ez a jelvény akkor érhető el, ha rendszeresen meglátogatja a platformot. Szeretünk itt lenni!
           description_another: Ez a felhasználó egy adott napon %{score} egymást követő napon keresztül kapcsolódott.
           description_own: Ön egy bizonyos időpontban %{score} egymást követő napra kapcsolódott.
@@ -556,7 +561,7 @@ hu:
           unearned_own: Nem kapcsolódott több mint egymást követő napon.
         followers:
           conditions:
-            - Az aktív és más emberek követése biztosan másokat követni fog.
+          - Az aktív és más emberek követése biztosan másokat követni fog.
           description: Ez a jelvény akkor érhető el, ha bizonyos számú követőt ér el. %{organization_name} egy társadalmi és politikai hálózat, szövik a webet, hogy kommunikáljon más emberekkel a platformon.
           description_another: Ennek a felhasználónak %{score} követője van.
           description_own: "%{score} felhasználó követi Önt."
@@ -571,9 +576,9 @@ hu:
           title: Kitűzők
         invitations:
           conditions:
-            - Használja a "meghívni barátok" linket a felhasználói oldalon, hogy meghívja barátait
-            - Testreszabása, ha szeretné, az elküldött üzenetet
-            - A hívások meghívása és regisztrálása érdekében szintre emelkedik.
+          - Használja a "meghívni barátok" linket a felhasználói oldalon, hogy meghívja barátait
+          - Testreszabása, ha szeretné, az elküldött üzenetet
+          - A hívások meghívása és regisztrálása érdekében szintre emelkedik.
           description: Ezt a jelvényt akkor kapja meg, ha meghívott valakit, és kis időbe telik, hogy regisztráljon %{organization_name} és részt vegyen. Köszönjük, hogy %{organization_name} ismertek mások, és segít bővíteni a közösség!
           description_another: Felhasználó meghívott %{score} felhasználókat.
           description_own: Meghívtál %{score} felhasználótkat.
@@ -582,7 +587,7 @@ hu:
           unearned_another: Ez a felhasználó még nem hívott meg senkit.
           unearned_own: Még nem hívtál meg felhasználókat.
       description: A jelvények a résztvevők tevékenységét és előmenetelét hívatottak jelezni. Amint elkezded felfedezni a platformot és kapcsolatba kerülsz másokkal, különböző jelvényeket kapsz.
-      level: '%{level} szint'
+      level: "%{level} szint"
       reached_top: Elérted a jelvény legmagasabb szintjét.
     group_admins:
       actions:
@@ -777,14 +782,17 @@ hu:
         greetings: Üdvözöljük <br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Helló!
         subject: 'Szeretnél továbbra is fontos információkat kapni róluk: a %{organization_name}?'
+    notification_mailer:
+      shared:
+        note: You received this message because you're subscribed to notification by email on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
     notifications:
       no_notifications: Még nincs értesítés.
     notifications_settings:
       show:
         email_on_notification: Mindig, amikor értesítést kapok, egy emailt is küldünk róla.
         everything_followed: Minden, amit követek
-        newsletters: Hírlevelek
         newsletter_notifications: Szeretnék hírleveleket kapni
+        newsletters: Hírlevelek
         own_activity: Saját tevékenységem, mint amikor valaki megjegyzi a javaslatomat, vagy megemlíti nekem
         receive_notifications_about: Értesítést szeretnék kapni
         send_notifications_by_email: Értesítések küldése e-mailben
@@ -850,10 +858,6 @@ hu:
         subheading: Navigáljon a %{name} súgó oldalán
         title: Segítség
         topics: Témakörök
-      participatory_space:
-        metrics:
-          headline: Részvétel számokban
-          link: Az összes statisztika megjelenítése
       terms_and_conditions:
         accept:
           error: Hiba történt az általános szerződési feltételek elfogadása során.
@@ -878,6 +882,7 @@ hu:
       deleted: Törölt felhasználó
       view: Nézet
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Ez a felhasználói csoport nyilvánosan ellenőrzött, annak neve igazoltan megfelel a valódi nevének
       default_officialization_text_for_users: Ez a résztvevő nyilvánosan ellenőrzött, nevét vagy szerepét igazolták, így az megfelel valódi nevének és szerepének
       show:
@@ -925,7 +930,7 @@ hu:
       picker:
         cancel: Mégse
         choose: Kijelölés
-        title: '%{field} kijelölése'
+        title: "%{field} kijelölése"
       prompt: Válassz hatáskört
       scopes: Hatáskörök
     search:
@@ -989,8 +994,8 @@ hu:
         no_activities_warning: Ennek a felhasználónak még nem volt aktívja.
     user_interests:
       show:
-        no_scopes: Ennek a szervezetnek még nincs hatókörük!
         my_interests: Érdekeim
+        no_scopes: Ennek a szervezetnek még nincs hatókörük!
         select_your_interests: Válassza ki azokat a témákat, amelyekre érdekel, hogy hozzájusson hozzájuk kapcsolódó eseményekhez a profil Timeline (Idővonal) lapján.
         update_my_interests: Érdeklődésem frissítése
       update:
@@ -1164,6 +1169,17 @@ hu:
       too_short: túl rövid (15 karakterig)
   forms:
     required: Kötelező
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Hagyd figyelmen kívül ezt a mezőt
     timestamp_error_message: Sajnos ez túl gyors volt! Kérlek, küldd el újra.
@@ -1185,7 +1201,7 @@ hu:
         sign_up: Regisztráció
       impersonation_warning:
         close_session: Munkamenet bezárása
-        description_html: <b>%{user_name}</b> megszemélyesítése.
+        description_html: "<b>%{user_name}</b> megszemélyesítése."
         expire_time_html: A munkamenet <b><span class="minutes">%{minutes}</span> perc múlva lejár</b>.
       notifications_dashboard:
         mark_all_as_read: Összes megjelölése olvasottként

--- a/decidim-core/config/locales/id-ID.yml
+++ b/decidim-core/config/locales/id-ID.yml
@@ -1,52 +1,60 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       account:
-        delete_reason: Alasan untuk menghapus akun Anda
+        delete_reason: Reason to delete your account
       report:
-        details: Komentar tambahan
+        details: Additional comments
       user:
-        about: Tentang
-        email: Email mu
-        name: Namamu
-        nickname: Nama panggilan
-        password: Kata sandi
-        password_confirmation: Konfirmasi password Anda
-        personal_url: URL pribadi
-        remove_avatar: Hapus avatar
+        about: About
+        email: Your email
+        name: Your name
+        nickname: Nickname
+        password: Password
+        password_confirmation: Confirm your password
+        personal_url: Personal URL
+        remove_avatar: Remove avatar
     models:
-      decidim/attachment_created_event: Lampiran
-      decidim/component_published_event: Komponen aktif
-      decidim/demoted_membership: Bukan lagi admin grup
-      decidim/gamification/badge_earned_event: Lencana diperoleh
-      decidim/gamification/level_up_event: Anda sudah naik level
-      decidim/join_request_accepted_event: Permintaan bergabung diterima
-      decidim/join_request_rejected_event: Permintaan bergabung ditolak
-      decidim/profile_updated_event: Profil diperbarui
-      decidim/promote_to_admin: Dipromosikan ke admin grup
-      decidim/removed_from_group: Dihapus dari grup
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
+      decidim/attachment_created_event: Attachment
+      decidim/component_published_event: Active component
+      decidim/demoted_membership: No longer a group admin
+      decidim/gamification/badge_earned_event: Badge earned
+      decidim/gamification/level_up_event: You've leveled up
+      decidim/join_request_accepted_event: Join request accepted
+      decidim/join_request_rejected_event: Join request rejected
+      decidim/profile_updated_event: Profile updated
+      decidim/promote_to_admin: Promoted to group admin
+      decidim/removed_from_group: Removed from group
   activerecord:
     attributes:
       decidim/user:
-        current_password: Kata sandi saat ini
-        email: E-mail
-        name: Nama pengguna
-        password: Kata sandi
-        password_confirmation: konfirmasi kata kunci
-        remember_me: Ingat saya
+        current_password: Current password
+        email: Email
+        name: Username
+        password: Password
+        password_confirmation: Password confirmation
+        remember_me: Remember me
     models:
       decidim/amendment:
-        other: Amandemen
+        one: Amendment
+        other: Amendments
       decidim/user:
-        other: Pengguna
+        one: No users
+        other: Users
       decidim/user_group:
-        other: Grup Pengguna
+        one: User group
+        other: User groups
   booleans:
-    'false': 'Tidak'
-    'true': 'iya nih'
+    'false': 'No'
+    'true': 'Yes'
   carrierwave:
     errors:
-      image_too_big: Gambarnya terlalu besar
+      image_too_big: The image is too big
   date:
     formats:
       decidim_short: "%d/%m/%Y"
@@ -57,1182 +65,1194 @@ id:
   decidim:
     account:
       data_portability_export:
-        file_no_exists: File tidak ada
-        invalid_token: Token yang diberikan tidak valid.
-        no_token: Tidak ada token yang disediakan
-        notice: Data Anda sedang dalam proses. Anda akan menerima email setelah selesai.
+        file_no_exists: File does not exist
+        invalid_token: The provided token is invalid.
+        no_token: No token provided
+        notice: Your data is currently in progress. You'll receive an email when it's complete.
       delete:
-        alert: Tindakan ini tidak bisa dibatalkan. Jika Anda menghapus akun Anda, Anda tidak akan dapat masuk.
+        alert: This action cannot be undone. If you delete your account you won't be able to log in.
         confirm:
-          close: Tutup jendela
-          ok: Ya, saya ingin menghapus akun saya
-          question: Anda yakin ingin menghapus akun Anda?
-          title: Hapus akun Saya
-        explanation: Silakan, isi alasan Anda ingin menghapus akun Anda (opsional).
+          close: Close window
+          ok: Yes, I want to delete my account
+          question: Are you sure you want to delete your account?
+          title: Delete my account
+        explanation: Please, fill in the reason you want to delete your account (optional).
       destroy:
-        error: Terjadi kesalahan saat menghapus akun Anda.
-        success: Akun Anda berhasil dihapus.
+        error: There's been an error deleting your account.
+        success: Your account was deleted successfully.
       show:
-        change_password: Ganti kata sandi
-        update_account: Perbaharui akun
+        change_password: Change password
+        update_account: Update account
       update:
-        error: Terjadi kesalahan saat memperbarui akun Anda.
-        success: Akun Anda telah berhasil diperbarui.
-        success_with_email_confirmation: Akun Anda telah berhasil diperbarui. Anda akan menerima email untuk mengonfirmasi alamat email baru Anda.
+        error: There's been an error updating your account.
+        success: Your account was updated successfully.
+        success_with_email_confirmation: Your account was updated successfully. You'll receive an email to confirm your new email address.
     admin_log:
       area:
-        create: "%{user_name} menciptakan %{resource_name} area"
-        delete: "%{user_name} menghapus %{resource_name} area"
-        update: "%{user_name} memperbarui %{resource_name} area"
+        create: "%{user_name} created the %{resource_name} area"
+        delete: "%{user_name} deleted the %{resource_name} area"
+        update: "%{user_name} updated the %{resource_name} area"
       component:
-        create: "%{user_name} menambahkan %{resource_name} komponen ke %{space_name} ruang"
-        delete: "%{user_name} menghapus %{resource_name} komponen dari %{space_name} ruang"
-        publish: "%{user_name} menerbitkan %{resource_name} komponen dalam %{space_name} ruang"
-        unpublish: "%{user_name} tidak mempublikasikan %{resource_name} komponen dari %{space_name} ruang"
+        create: "%{user_name} added the %{resource_name} component to the %{space_name} space"
+        delete: "%{user_name} removed the %{resource_name} component from the %{space_name} space"
+        publish: "%{user_name} published the %{resource_name} component in the %{space_name} space"
+        unpublish: "%{user_name} unpublished the %{resource_name} component from the %{space_name} space"
       moderation:
-        hide: "%{user_name} menyembunyikan sumber daya tipe %{resource_type} di %{space_name} ruang"
-        unreport: "%{user_name} tidak dilaporkan sumber daya tipe %{resource_type} di %{space_name} ruang"
+        hide: "%{user_name} hid a resource of type %{resource_type} in the %{space_name} space"
+        unreport: "%{user_name} unreported a resource of type %{resource_type} in the %{space_name} space"
       newsletter:
-        create: "%{user_name} membuat %{resource_name} buletin"
-        delete: "%{user_name} menghapus %{resource_name} buletin"
-        deliver: "%{user_name} mengirimkan %{resource_name} buletin"
-        update: "%{user_name} memperbarui %{resource_name} buletin"
+        create: "%{user_name} created the %{resource_name} newsletter"
+        delete: "%{user_name} deleted the %{resource_name} newsletter"
+        deliver: "%{user_name} delivered the %{resource_name} newsletter"
+        update: "%{user_name} updated the %{resource_name} newsletter"
       oauth_application:
-        create: "%{user_name} membuat aplikasi %{resource_name} OAuth"
-        delete: "%{user_name} menghapus aplikasi %{resource_name} OAuth"
-        update: "%{user_name} memperbarui aplikasi %{resource_name} OAuth"
+        create: "%{user_name} created the %{resource_name} OAuth application"
+        delete: "%{user_name} deleted the %{resource_name} OAuth application"
+        update: "%{user_name} updated the %{resource_name} OAuth application"
       organization:
-        update: "%{user_name} memperbarui pengaturan organisasi"
+        update: "%{user_name} updated the organization settings"
       participatory_space_private_user:
-        create: "%{user_name} diundang %{resource_name} untuk menjadi pengguna pribadi"
-        delete: "%{user_name} menghapus pengguna %{resource_name} sebagai pengguna pribadi"
+        create: "%{user_name} invited %{resource_name} to be a private user"
+        delete: "%{user_name} removed the user %{resource_name} as a private user"
       scope:
-        create: "%{user_name} menciptakan %{resource_name} ruang lingkup"
-        create_with_parent: "%{user_name} menciptakan %{resource_name} ruang lingkup di dalam %{parent_scope} ruang lingkup"
-        delete: "%{user_name} menghapus %{resource_name} ruang lingkup"
-        delete_with_parent: "%{user_name} menghapus %{resource_name} ruang lingkup di dalam %{parent_scope} ruang lingkup"
-        update: "%{user_name} memperbarui %{resource_name} ruang lingkup"
-        update_with_parent: "%{user_name} memperbarui %{resource_name} ruang lingkup di dalam %{parent_scope} ruang lingkup"
+        create: "%{user_name} created the %{resource_name} scope"
+        create_with_parent: "%{user_name} created the %{resource_name} scope inside the %{parent_scope} scope"
+        delete: "%{user_name} deleted the %{resource_name} scope"
+        delete_with_parent: "%{user_name} deleted the %{resource_name} scope inside the %{parent_scope} scope"
+        update: "%{user_name} updated the %{resource_name} scope"
+        update_with_parent: "%{user_name} updated the %{resource_name} scope inside the %{parent_scope} scope"
       static_page:
-        create: "%{user_name} menciptakan halaman %{resource_name} statis"
-        delete: "%{user_name} menghapus halaman %{resource_name} statis"
-        update: "%{user_name} memperbarui %{resource_name} halaman statis"
+        create: "%{user_name} created the %{resource_name} static page"
+        delete: "%{user_name} deleted the %{resource_name} static page"
+        update: "%{user_name} updated the %{resource_name} static page"
       user:
-        invite: "%{user_name} mengundang pengguna %{resource_name} dengan peran: %{role}"
-        officialize: "%{user_name} resmi pengguna %{resource_name}"
-        remove_from_admin: "%{user_name} menghapus pengguna %{resource_name} dengan peran: %{role}"
-        unofficialize: "%{user_name} tidak resmi pengguna %{resource_name}"
+        invite: "%{user_name} invited the user %{resource_name} with role: %{role}"
+        officialize: "%{user_name} officialized the user %{resource_name}"
+        remove_from_admin: "%{user_name} removed the user %{resource_name} with role: %{role}"
+        unofficialize: "%{user_name} unofficialized the user %{resource_name}"
       user_group:
-        reject: "%{user_name} menolak %{resource_name} verifikasi grup pengguna"
-        verify: "%{user_name} memverifikasi %{resource_name} grup pengguna"
-        verify_via_csv: "%{user_name} memverifikasi %{resource_name} grup pengguna melalui file CSV"
+        reject: "%{user_name} rejected the %{resource_name} user group verification"
+        verify: "%{user_name} verified the %{resource_name} user group"
+        verify_via_csv: "%{user_name} verified the %{resource_name} user group via a CSV file"
     amendments:
       accepted:
-        error: Terjadi kesalahan saat menerima emendasi, coba lagi nanti.
-        success: Perubahan ini telah berhasil diterima.
+        error: An error ocurred accepting the emendation, please try again later.
+        success: This emendation has been accepted successfully.
       amendable:
-        amended_by: Diubah oleh
-        button: Ubah %{model_name}
-        promote_button: Promosikan ke %{model_name}
-        error: Terjadi kesalahan saat mengubah sumber daya ini.
-        help_text: Tingkatkan %{model_name} ini dengan memodifikasi %{amendable_fields}
-        promote_help_text: Anda dapat mempromosikan emendasi ini dan mempublikasikannya sebagai %{model_name}independen
-        no_amenders: Tidak ada amandemen
-        no_amendments: Tidak ada amandemen
-        section_heading: Amandemen (%{count})
+        amended_by: Amended by
+        button: Amend %{model_name}
+        error: There has been an error amending this resource.
+        help_text: Improve this %{model_name} by modifying its %{amendable_fields}
+        no_amenders: There are no amenders
+        no_amendments: There are no amendments
+        promote_button: Promote to %{model_name}
+        promote_help_text: You can promote this emendation and publish it as an independent %{model_name}
+        section_heading: Amendments (%{count})
       created:
-        error: Terjadi kesalahan saat membuat amendemen ini, coba lagi nanti
-        success: Amandemen telah berhasil dibuat
+        error: An error ocurred creating this amendment, try again later
+        success: The amendment has been created successfully
       emendation:
         actions:
-          button_accept: Menerima
-          button_reject: Menolak
-          help_text: Tinjau perubahan dan terima atau tolak amandemen ini. Pemberitahuan akan dikirim ke penulisnya.
+          button_accept: Accept
+          button_reject: Reject
+          help_text: Review the changes and accept or reject this amendment. A notification will be sent to its author(s).
         announcement:
           accepted: |-
-            Amandemen untuk %{amendable_type} %{amendable_link} ini telah
-            diterima pada <strong>%{announcement_date}</strong>.
+            This amendment for the %{amendable_type} %{amendable_link} has been
+            accepted on <strong>%{announcement_date}</strong>.
           evaluating: |-
-            Perubahan ini untuk %{amendable_type} %{amendable_link}
-            sedang dievaluasi.
+            This amendment for the %{amendable_type} %{amendable_link}
+            is being evaluated.
           rejected: |-
-            Perubahan ini untuk %{amendable_type} %{amendable_link}
-            ditolak pada <strong>%{announcement_date}</strong>.
+            This emendation for the %{amendable_type} %{amendable_link}
+            was rejected on <strong>%{announcement_date}</strong>.
           withdrawn: |-
-            Perubahan ini untuk %{amendable_type} %{amendable_link}
-            telah ditarik oleh penulis.
+            This amendment for the %{amendable_type} %{amendable_link}
+            has been withdrawn by the author.
       new:
-        amendment_author: Pengarang perubahan
-        back: Kembali
-        heading: Buat amandemen Anda
-        help_text: Anda memodifikasi %{model_name}
-        send: Kirim amandemen
-      rejected:
-        error: Terjadi kesalahan saat menolak perubahan ini, silakan coba lagi nanti
-        success: Amendemen tersebut telah ditolak dengan sukses
+        amendment_author: Amendment author
+        back: Back
+        heading: Create your amendment
+        help_text: You are modifying the %{model_name}
+        send: Send amendment
       promoted:
-        success: Emendasi berhasil dipromosikan
-        error: Sudah ada kesalahan saat mempromosikan emendasi
+        error: There's been errors when promoting the emendation
+        success: Emendation promoted successfully
+      rejected:
+        error: An error ocurred when rejecting this emendation, please try again later
+        success: The emendation has been rejected successfully
       review:
-        back: Kembali
-        heading: Tinjau amandemennya
-        help_text: Anda mengubah %{model_name}
-        send: Terima amandemen
-    anonymous_user: Anonim
+        back: Back
+        heading: Review the amendment
+        help_text: You are amending the %{model_name}
+        send: Accept amendment
+    anonymous_user: Anonymous
     application:
       collection:
         documents:
-          other: Dokumen
+          one: Document
+          other: Documents
       documents:
-        related_documents: Dokumen yang berkaitan
+        related_documents: Related documents
       photos:
-        related_photos: Foto-foto terkait
+        related_photos: Related photos
     author:
       comments:
-        other: komentar
+        one: comment
+        other: comments
     authorization_handlers:
       another_dummy_authorization_handler:
-        explanation: Dapatkan verifikasi dengan memperkenalkan nomor paspor dimulai dengan "A"
+        explanation: Get verified by introducing a passport number starting with "A"
         fields:
-          passport_number: Nomor paspor
-        name: Contoh otorisasi lain
+          passport_number: Passport number
+        name: Another example authorization
       dummy_authorization_handler:
-        explanation: Dapatkan verifikasi dengan memperkenalkan nomor dokumen yang diakhiri dengan "X"
+        explanation: Get verified by introducing a document number ending with "X"
         fields:
-          document_number: Nomor dokumen
-          postal_code: Kode Pos
-        name: Contoh otorisasi
+          document_number: Document number
+          postal_code: Postal code
+        name: Example authorization
       dummy_authorization_workflow:
-        name: Alur kerja otorisasi dummy
+        name: Dummy authorization workflow
       errors:
-        duplicate_authorization: Pengguna sudah diotorisasi dengan data yang sama.
-      expired_at: Kedaluwarsa pada %{timestamp}
-      expires_at: Kedaluwarsa pada %{timestamp}
+        duplicate_authorization: A user is already authorized with the same data.
+      expired_at: Expired at %{timestamp}
+      expires_at: Expires at %{timestamp}
       foo_authorization:
         fields:
           bar: Bar
           foo: Foo
-        name: Otorisasi Foo
-      granted_at: Diberikan pada %{timestamp}
+        name: Foo authorization
+      granted_at: Granted at %{timestamp}
       sms:
-        explanation: Kirim nomor ponsel Anda sehingga kami dapat memeriksa identitas Anda.
-        name: Kode melalui SMS
-      started_at: Dimulai pada %{timestamp}
+        explanation: Submit your mobile phone number so we can check your identity.
+        name: Code by SMS
+      started_at: Started at %{timestamp}
     authorization_modals:
       show:
         expired:
-          authorize: Otorisasi ulang dengan "%{authorization}"
-          explanation: Otorisasi Anda telah kedaluwarsa. Untuk melakukan tindakan ini, Anda harus diberi otorisasi ulang dengan "%{authorization}".
-          title: Otorisasi telah kedaluwarsa
+          authorize: Reauthorize with "%{authorization}"
+          explanation: Your authorization has expired. In order to perform this action, you need to be reauthorized with "%{authorization}".
+          title: Authorization has expired
         incomplete:
-          cancel: Membatalkan
-          explanation: 'Meskipun saat ini Anda diotorisasi dengan "%{authorization}", kami meminta Anda untuk mengotorisasi ulang karena kami tidak memiliki data berikut:'
+          cancel: Cancel
+          explanation: 'Even though you''re currently authorized with "%{authorization}", we need you to reauthorize because we lack the following data:'
           invalid_field: "%{field}"
-          reauthorize: Otorisasi ulang
-          title: Harap beri otorisasi ulang
+          reauthorize: Reauthorize
+          title: Please reauthorize
         missing:
-          authorize: Otorisasi dengan "%{authorization}"
-          explanation: Untuk melakukan tindakan ini, Anda harus diotorisasi dengan "%{authorization}".
-          title: Dibutuhkan otorisasi
+          authorize: Authorize with "%{authorization}"
+          explanation: In order to perform this action, you need to be authorized with "%{authorization}".
+          title: Authorization required
         pending:
-          explanation: Untuk melakukan tindakan ini, Anda harus diotorisasi dengan "%{authorization}", tetapi otorisasi Anda masih dalam proses
-          resume: Periksa kemajuan otorisasi "%{authorization}" Anda
-          title: Otorisasi masih berlangsung
+          explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
+          resume: Check your "%{authorization}" authorization progress
+          title: Authorization is still in progress
         unauthorized:
-          explanation: Maaf, Anda tidak dapat melakukan tindakan ini karena sebagian data otorisasi Anda tidak cocok.
-          invalid_field: "%{field} nilai %{value} tidak valid."
-          ok: Baik
-          title: Tidak diizinkan
+          explanation: Sorry, you can't perform this action as some of your authorization data doesn't match.
+          invalid_field: "%{field} value %{value} isn't valid."
+          ok: Ok
+          title: Not authorized
         unconfirmed:
-          confirmation_instructions: 'Jika Anda belum menerima instruksi konfirmasi, Anda dapat meminta mereka lagi:'
-          explanation_html: Untuk melakukan tindakan ini Anda harus diotorisasi, sebelum melakukan itu Anda perlu mengkonfirmasi email Anda <strong>%{email}</strong>.
-          request_confirmation_instructions: Meminta instruksi konfirmasi
-          title: Konfirmasikan email Anda
+          confirmation_instructions: 'If you haven''t received the confirmation instructions you can request them again:'
+          explanation_html: In order to perform this action you need to be authorized, before doing that you need to confirm your email <strong>%{email}</strong>.
+          request_confirmation_instructions: Request confirmation instructions
+          title: Confirm your email
     collapsible_list:
       hidden_elements_count:
-        other: dan %{count} lagi
-      see_less: "(lihat lebih sedikit)"
-      see_more: "(lihat lebih lanjut)"
+        one: and %{count} more
+        other: and %{count} more
+      see_less: "(see less)"
+      see_more: "(see more)"
     components:
       dummy:
         actions:
           bar: Bar
           foo: Foo
-        name: Komponen Dummy
+        name: Dummy Component
         settings:
           global:
-            amendments_enabled: Amandemen diaktifkan
-            comments_enabled: Komentar diaktifkan
-            dummy_global_attribute_1: Atribut Dummy 1
-            dummy_global_attribute_2: Atribut Dummy 2
-            enable_pads_creation: Aktifkan pembuatan bantalan
-            resources_permissions_enabled: Izin sumber daya diaktifkan
+            amendments_enabled: Amendments enabled
+            comments_enabled: Comments enabled
+            dummy_global_attribute_1: Dummy Attribute 1
+            dummy_global_attribute_2: Dummy Attribute 2
+            enable_pads_creation: Enable pads creation
+            resources_permissions_enabled: Resources permissions enabled
           step:
-            comments_blocked: Komentar diblokir
-            dummy_step_attribute_1: Atribut Langkah Dummy 1
-            dummy_step_attribute_2: Atribut Langkah Dummy 2
-    contact: Kontak
+            comments_blocked: Comments blocked
+            dummy_step_attribute_1: Dummy Step Attribute 1
+            dummy_step_attribute_2: Dummy Step Attribute 2
+    contact: Contact
     content_blocks:
       footer_sub_hero:
         name: Footer sub hero banner
       hero:
-        name: Citra pahlawan
+        name: Hero image
       highlighted_content_banner:
-        name: Spanduk konten yang disorot
+        name: Highlighted content banner
       how_to_participate:
-        name: Bagaimana cara berpartisipasi
+        name: How to participate
       html:
-        html_content: Konten HTML
-        name: Blok HTML
+        html_content: HTML content
+        name: HTML block
       last_activity:
-        name: Aktivitas terakhir
-        title: Aktivitas terakhir
-        view_all: Lihat semua
+        name: Last activity
+        title: Last activity
+        view_all: View all
       metrics:
-        name: Metrik organisasi
+        name: Organization metrics
       stats:
-        name: Statistik organisasi
+        name: Organization stats
       sub_hero:
-        name: Spanduk sub hero
+        name: Sub hero banner
     core:
       actions:
-        unauthorized: Anda tidak berwenang untuk melakukan tindakan ini
+        unauthorized: You are not authorized to perform this action
     data_portability:
       export:
-        ready: Siap
+        ready: Ready
       show:
-        download_data: Unduh datanya
-        download_data_description: File dengan semua informasi yang terkait dengan akun akan dikirim ke <strong>%{user_email}</strong>
-        request_data: Meminta data
+        download_data: Download the data
+        download_data_description: A file with all the information associated with the account will be sent to <strong>%{user_email}</strong>
+        request_data: Request data
     datepicker:
-      help_text: 'Format yang diharapkan: %{datepicker_format}'
+      help_text: 'Expected format: %{datepicker_format}'
     devise:
       omniauth_registrations:
         create:
-          email_already_exists: Akun lain menggunakan alamat email yang sama
+          email_already_exists: Another account is using the same email address
         new:
-          complete_profile: Profil lengkap
-          nickname_help: Pengidentifikasi singkat dan unik Anda di %{organization}
-          sign_up: Silakan lengkapi profil Anda
-          subtitle: Silakan isi formulir berikut untuk menyelesaikan pendaftaran
-          username_help: Nama publik yang muncul di pos Anda. Dengan tujuan menjamin anonimitas, dapat berupa nama apa pun.
+          complete_profile: Complete profile
+          nickname_help: Your short, unique identifier in %{organization}
+          sign_up: Please complete your profile
+          subtitle: Please fill in the following form in order to complete the sign up
+          username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
-          already_have_an_account?: Sudah memiliki akun?
-          newsletter: Terima sesekali newsletter dengan informasi yang relevan
-          newsletter_title: Izin kontak
-          nickname_help: Pengidentifikasi singkat dan unik Anda di %{organization}
-          sign_in: Masuk
-          sign_up: Daftar
+          already_have_an_account?: Already have an account?
+          newsletter: Receive an occasional newsletter with relevant information
+          newsletter_title: Contact permission
+          nickname_help: Your short, unique identifier in %{organization}
+          sign_in: Log in
+          sign_up: Sign up
           sign_up_as:
-            legend: Mendaftar sebagai
-          subtitle: Mendaftarlah untuk berpartisipasi dalam diskusi dan dukung proposal.
-          terms: syarat dan ketentuan penggunaan
-          tos_agreement: Dengan mendaftar Anda menyetujui %{link}.
-          tos_title: Ketentuan Layanan
-          username_help: Nama publik yang muncul di pos Anda. Dengan tujuan menjamin anonimitas, dapat berupa nama apa pun.
+            legend: Sign up as
+          subtitle: Sign up to participate in discussions and support proposals.
+          terms: the terms and conditions of use
+          tos_agreement: By signing up you agree to %{link}.
+          tos_title: Terms of Service
+          username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       sessions:
         new:
-          are_you_new?: Baru ke platform?
-          register: Buat sebuah akun
-          sign_in_disabled: Anda dapat mengakses dengan akun eksternal
-          sign_up_disabled: Daftar dinonaktifkan, Anda dapat menggunakan pengguna yang ada untuk mengakses
+          are_you_new?: New to the platform?
+          register: Create an account
+          sign_in_disabled: You can access with an external account
+          sign_up_disabled: Sign up is disabled, you can use an existing user to access
       shared:
         newsletter_modal:
           buttons:
-            check: Periksa dan lanjutkan
-            close_modal: Tutup modal
-            uncheck: Terus hapus centang
+            check: Check and continue
+            close_modal: Close modal
+            uncheck: Keep uncheck
           notice: |-
-            <p>Hai, apakah Anda yakin tidak ingin menerima buletin?<br>
-            Harap pertimbangkan lagi mencentang kotak nawala di bawah ini.<br>
-            Sangat penting bagi kami bahwa Anda dapat menerima email sesekali
-            untuk membuat pengumuman penting, Anda selalu dapat mengubah ini di
-            halaman pengaturan pemberitahuan Anda.</p>
-            <p>Jika Anda tidak mencentang kotak Anda mungkin kehilangan informasi yang relevan
-            tentang peluang partisipatif baru dalam platform.<br>
-            Jika Anda masih ingin menghindari menerima buletin, kami dengan sempurna
-            memahami keputusan Anda.</p>
-            <p>Terima kasih telah membaca ini!</p>
-          title: Notifikasi buletin
+            <p>Hey, are you sure you don't want to receive a newsletter?<br>
+            Please consider again ticking the newsletter checkbox below.<br>
+            It is very important for us that you can receive occasional emails
+            to make important announcements, you can always change this on your
+            notifications settings page.</p>
+            <p>If you don't tick the box you might be missing relevant information
+            about new participatory opportunities within the platform.<br>
+            If you still want to avoid receiving newsletters, we perfectly
+            understand your decision.</p>
+            <p>Thanks for reading this!</p>
+          title: Newsletter notifications
         omniauth_buttons:
-          or: Atau
+          or: Or
     doorkeeper:
       authorizations:
         new:
-          authorize: Otorisasi aplikasi
-          by_organization_link_html: <small class="heading-small">per %{link}</small>
-          cancel: Membatalkan
-          connect_your_account_html: Hubungkan akun Anda dengan masuk ke <strong>%{organization}</strong>
-          publish_content: Publikasikan konten untuk Anda
-          see_email: Lihat email Anda
-          see_name: Lihat namamu
-          see_username: Lihat nama pengguna Anda
-          this_application_will_be_able_to: 'Aplikasi ini akan dapat:'
-          this_application_will_not_be_able_to: 'Aplikasi ini tidak akan dapat:'
-          update_profile: Perbarui profil Anda
-          wants_to_use_your_account_html: "<strong>%{application_name}</strong> ingin menggunakan akun Anda"
+          authorize: Authorize application
+          by_organization_link_html: <small class="heading-small">by %{link}</small>
+          cancel: Cancel
+          connect_your_account_html: Connect your account by signing in to <strong>%{organization}</strong>
+          publish_content: Publish content for you
+          see_email: See your email
+          see_name: See your name
+          see_username: See your username
+          this_application_will_be_able_to: 'This application will be able to:'
+          this_application_will_not_be_able_to: 'This application will not be able to:'
+          update_profile: Update your profile
+          wants_to_use_your_account_html: "<strong>%{application_name}</strong> wants to use your account"
     errors:
       internal_server_error:
-        title: Ada masalah dengan server kami
-        try_later: Silakan coba lagi nanti.
+        title: There was a problem with our server
+        try_later: Please try again later.
       not_found:
-        back_home: Kembali ke rumah
-        content_doesnt_exist: Alamat ini salah atau telah dihapus.
-        title: Halaman yang Anda cari tidak dapat ditemukan
+        back_home: Back home
+        content_doesnt_exist: This address is incorrect or has been removed.
+        title: The page you're looking for can't be found
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Sebuah perubahan baru telah dibuat untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah seorang pengarang %{amendable_title}.
-            email_subject: Amandemen baru untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendasi baru</a> telah dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Sebuah perubahan baru telah dibuat untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{amendable_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-            email_subject: Amandemen baru untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emendasi baru</a> telah dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Amendemen telah ditolak untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah seorang pengarang %{amendable_title}.
-            email_subject: Amandemen ditolak untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendasi</a> dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> telah ditolak untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Amendemen telah ditolak untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{amendable_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-            email_subject: Amandemen ditolak untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendasi</a> dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> telah ditolak untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Suatu emendasi yang ditolak untuk %{amendable_title} telah dipromosikan menjadi independen %{amendable_type}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah seorang pengarang %{amendable_title}.
-            email_subject: Sebuah perbaikan dari %{emendation_author_nickname} telah dipromosikan
-            notification_title: A <a href="%{emendation_path}">emendasi</a> ditolak untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} telah dipromosikan oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Suatu emendasi yang ditolak untuk %{amendable_title} telah dipromosikan menjadi independen %{amendable_type}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{amendable_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-            email_subject: Sebuah perbaikan dari %{emendation_author_nickname} telah dipromosikan
-            notification_title: A <a href="%{emendation_path}">emendasi</a> ditolak untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} telah dipromosikan oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
-            email_intro: 'Amendemen telah diterima untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah seorang pengarang %{amendable_title}.
-            email_subject: Amandemen diterima untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendasi</a> dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> telah diterima untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+            email_intro: 'An emendation has been accepted for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An amendment accepted for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been accepted for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
           follower:
-            email_intro: 'Amendemen telah diterima untuk %{amendable_title}. Anda dapat melihatnya dari halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{amendable_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-            email_subject: Amandemen diterima untuk %{amendable_title} dari %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendasi</a> dibuat oleh <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> telah diterima untuk <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+            email_intro: 'An emendation has been accepted for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An amendment accepted for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been accepted for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'A new emendation has been created for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: A new amendment for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">new emendation</a> has been created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'A new emendation has been created for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: A new amendment for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">new emendation</a> has been created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'An emendation rejected for %{amendable_title} has been promoted to an independent %{amendable_type}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An emendation from %{emendation_author_nickname} has been promoted
+            notification_title: A <a href="%{emendation_path}">rejected emendation</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} has been promoted by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'An emendation rejected for %{amendable_title} has been promoted to an independent %{amendable_type}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An emendation from %{emendation_author_nickname} has been promoted
+            notification_title: A <a href="%{emendation_path}">rejected emendation</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} has been promoted by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'An emendation has been rejected for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An amendment rejected for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been rejected for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'An emendation has been rejected for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An amendment rejected for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been rejected for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
-          email_intro: 'Dokumen baru telah ditambahkan ke %{resource_title}. Anda dapat melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{resource_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Pembaruan ke %{resource_title}
-          notification_title: A <a href="%{resource_path}">dokumen baru</a> telah ditambahkan ke <a href="%{attached_to_url}">%{resource_title}</a>
+          email_intro: 'A new document has been added to %{resource_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title}
+          notification_title: A <a href="%{resource_path}">new document</a> has been added to <a href="%{attached_to_url}">%{resource_title}</a>
       components:
         component_published:
-          email_intro: 'Komponen %{resource_title} sekarang aktif untuk %{participatory_space_title}. Anda dapat melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Pembaruan ke %{participatory_space_title}
-          notification_title: Komponen %{resource_title} sekarang aktif untuk <a href="%{resource_path}">%{participatory_space_title}</a>
+          email_intro: 'The %{resource_title} component is now active for %{participatory_space_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The %{resource_title} component is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       email_event:
-        email_greeting: Halo %{user_name},
-        email_intro: 'Telah ada pembaruan ke "%{resource_title}". Anda dapat melihatnya dari halaman ini:'
-        email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-        email_subject: Pembaruan ke %{resource_title}
+        email_greeting: Hello %{user_name},
+        email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
+        email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+        email_subject: An update to %{resource_title}
       gamification:
         badge_earned:
-          email_intro: Kerja bagus! Anda memperoleh lencana <a href="%{resource_url}">%{badge_name}</a> (tingkat %{current_level}).
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda melakukan aktivitas di situs web kami.
-          email_subject: 'Anda telah memperoleh lencana baru: %{badge_name}!'
-          notification_title: Kerja bagus! Anda memperoleh lencana <a href="%{resource_path}">%{badge_name}</a> (tingkat %{current_level}).
+          email_intro: Great job! You've earned the <a href="%{resource_url}">%{badge_name} badge</a> (level %{current_level}).
+          email_outro: You have received this notification because you made activity on our website.
+          email_subject: 'You''ve earned a new badge: %{badge_name}!'
+          notification_title: Great job! You've earned the <a href="%{resource_path}">%{badge_name} badge</a> (level %{current_level}).
         level_up:
-          email_intro: Kerja bagus! Anda telah mencapai level %{current_level} pada lencana <a href="%{resource_url}">%{badge_name}</a>!
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda melakukan aktivitas di situs web kami.
-          email_subject: Anda telah mencapai level %{current_level} pada %{badge_name} lencana!
-          notification_title: Kerja bagus! Anda telah mencapai level %{current_level} pada lencana <a href="%{resource_path}">%{badge_name}</a>!
+          email_intro: Great job! You've reached level %{current_level} on the <a href="%{resource_url}">%{badge_name} badge</a>!
+          email_outro: You have received this notification because you made activity on our website.
+          email_subject: You've reached level %{current_level} on the %{badge_name} badge!
+          notification_title: Great job! You've reached level %{current_level} on the <a href="%{resource_path}">%{badge_name} badge</a>!
       groups:
         demoted_membership:
-          email_intro: Admin grup <a href="%{resource_url}">%{user_group_name}</a> telah menghapus hak admin Anda ke grup itu.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah anggota grup itu.
-          email_subject: Anda bukan lagi admin dari grup %{user_group_name}!
-          notification_title: Anda bukan lagi admin grup <a href="%{resource_path}">%{user_group_name}</a>.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed your admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are no longer an admin of the %{user_group_name} group!
+          notification_title: You are no longer an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         invited_to_group:
-          email_intro: Admin grup <a href="%{resource_url}">%{user_group_name}</a> telah mengundang Anda untuk bergabung.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda telah diundang ke grup. Silakan periksa tab Grup di profil Anda untuk menyetujuinya.
-          email_subject: Anda diundang untuk bergabung dengan grup %{user_group_name}!
-          notification_title: Anda diundang untuk bergabung dengan grup <a href="%{resource_path}">%{user_group_name}</a> . Periksa <a href="%{groups_profile_tab_path}">Grup halaman</a> di profil Anda untuk menyetujuinya!
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has invited you to join it.
+          email_outro: You have received this notification because you have been invited to an group. Please check the Groups tab in your profile to approve it.
+          email_subject: You have been invited to join the %{user_group_name} group!
+          notification_title: You have been invited to join the <a href="%{resource_path}">%{user_group_name}</a> group. Check the <a href="%{groups_profile_tab_path}">Groups page</a> in your profile to approve it!
         join_request_accepted:
-          email_intro: Selamat! Admin grup <a href="%{resource_url}">%{user_group_name}</a> telah menerima permintaan Anda untuk bergabung.
-          email_outro: Anda telah menerima pemberitahuan ini karena permintaan bergabung Anda telah diperbarui.
-          email_subject: Anda telah diterima di grup %{user_group_name}!
-          notification_title: Anda telah diterima ke grup <a href="%{resource_path}">%{user_group_name}</a>.
+          email_intro: Congratulations! An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has accepted your request to join it.
+          email_outro: You have received this notification because your join request has been updated.
+          email_subject: You have been accepted to the %{user_group_name} group!
+          notification_title: You have been accepted to the <a href="%{resource_path}">%{user_group_name}</a> group.
         join_request_created:
-          email_intro: Seseorang diminta untuk bergabung dengan grup %{user_group_name} . Anda dapat menerima atau menolaknya dari <a href="%{resource_url}">halaman anggota grup</a>.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda dapat mengelola grup %{user_group_name}.
-          email_subject: Seseorang diminta untuk bergabung dengan grup %{user_group_name}!
-          notification_title: Seseorang diminta untuk bergabung dengan grup %{user_group_name} . Anda dapat menerima atau menolaknya dari <a href="%{resource_path}">halaman anggota grup</a>.
+          email_intro: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_url}">the group members page</a>.
+          email_outro: You have received this notification because you can manage the %{user_group_name} group.
+          email_subject: Someone requested to join the %{user_group_name} group!
+          notification_title: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_path}">the group members page</a>.
         join_request_rejected:
-          email_intro: Admin grup <a href="%{resource_url}">%{user_group_name}</a> menolak permintaan Anda untuk bergabung.
-          email_outro: Anda telah menerima pemberitahuan ini karena permintaan bergabung Anda telah diperbarui.
-          email_subject: Permintaan Anda untuk bergabung dengan grup %{user_group_name} telah ditolak!
-          notification_title: Permintaan Anda untuk bergabung dengan grup <a href="%{resource_path}">%{user_group_name}</a> telah ditolak.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group rejected your request to join it.
+          email_outro: You have received this notification because your join request has been updated.
+          email_subject: Your request to join the %{user_group_name} group has been rejected!
+          notification_title: Your request to join the <a href="%{resource_path}">%{user_group_name}</a> group has been rejected.
         promoted_to_admin:
-          email_intro: Admin grup <a href="%{resource_url}">%{user_group_name}</a> telah memberi Anda hak admin ke grup itu.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah anggota grup itu.
-          email_subject: Anda sekarang menjadi admin dari grup %{user_group_name}!
-          notification_title: Anda sekarang menjadi admin dari grup <a href="%{resource_path}">%{user_group_name}</a>.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has given you admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are now an admin of the %{user_group_name} group!
+          notification_title: You are now an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         removed_from_group:
-          email_intro: Admin grup <a href="%{resource_url}">%{user_group_name}</a> telah menghapus Anda darinya.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah anggota grup itu.
-          email_subject: Anda telah dikeluarkan dari grup %{user_group_name}!
-          notification_title: Anda telah dikeluarkan dari grup <a href="%{resource_path}">%{user_group_name}</a>.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed you from it.
+          email_outro: You have received this notification because you were a member of that group.
+          email_subject: You have been removed from the %{user_group_name} group!
+          notification_title: You have been removed from the <a href="%{resource_path}">%{user_group_name}</a> group.
       notification_event:
-        notification_title: Peristiwa terjadi pada <a href="%{resource_path}">%{resource_title}</a>.
+        notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       users:
         profile_updated:
-          email_intro: Halaman <a href="%{resource_url}">profil</a> dari %{name} (%{nickname}), yang Anda ikuti, telah diperbarui.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{nickname}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: "%{nickname} memperbarui profil mereka"
-          notification_title: Halaman <a href="%{resource_path}">profil</a> dari %{name} (%{nickname}), yang Anda ikuti, telah diperbarui.
+          email_intro: The <a href="%{resource_url}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
+          email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.
+          email_subject: "%{nickname} updated their profile"
+          notification_title: The <a href="%{resource_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
     export_mailer:
       data_portability_export:
-        click_button: Klik tombol berikutnya untuk mengunduh data Anda. <br/> Anda akan memiliki file yang tersedia hingga %{date}.
-        download: Unduh
+        click_button: Click the next button to download your data. <br/> You will have the file available until %{date}.
+        download: Download
       export:
-        ready: Silakan temukan terlampir versi zip dari ekspor Anda.
-      subject: Ekspor Anda "%{name}" sudah siap
+        ready: Please find attached a zipped version of your export.
+      subject: Your export "%{name}" is ready
     filters:
       linked_classes:
-        all: Semua
-        collaborative_draft: Draf kolaboratif
-        dummy_resource: Sumber daya boneka
-        meeting: Rapat
-        project: Proyek
-        proposal: Proposal
-        result: Hasil
+        all: All
+        collaborative_draft: Collaborative draft
+        dummy_resource: Dummy resources
+        meeting: Meetings
+        project: Projects
+        proposal: Proposals
+        result: Results
     fingerprint:
-      check: Periksa sidik jari
-      explanation: Bagian teks di bawah ini adalah representasi singkat, berciri dari konten ini. Ini berguna untuk memastikan konten belum dirusak, karena satu modifikasi akan menghasilkan nilai yang sangat berbeda.
-      online_calculator_name: Kalkulator MD5 online
-      replicate_help: Sidik jari ini dihitung menggunakan algoritma hashing SHA256. Untuk mereplikasi sendiri, Anda dapat menggunakan %{online_calculator_link} dan copy-paste data sumber.
-      source: Sumber
-      title: Sidik jari
-      value: Nilai
+      check: Check fingerprint
+      explanation: The piece of text below is a shortened, hashed representation of this content. It's useful to ensure the content hasn't been tampered with, as a single modification would result in a totally different value.
+      online_calculator_name: MD5 calculator online
+      replicate_help: This fingerprint is calculated using a SHA256 hashing algorithm. In order to replicate it yourself, you can use an %{online_calculator_link} and copy-paste the source data.
+      source: Source
+      title: Fingerprint
+      value: Value
     followers:
-      no_followers: Belum ada pengikut.
+      no_followers: No followers yet.
     following:
-      no_followings: Tidak mengikuti siapa pun atau apa pun.
+      no_followings: Doesn't follow anyone or anything yet.
     follows:
       create:
-        button: Mengikuti
-        error: Ada kesalahan mengikuti sumber ini.
+        button: Follow
+        error: There has been an error following this resource.
       destroy:
-        button: Berhenti mengikuti
-        error: Terjadi kesalahan saat berhenti mengikuti sumber daya ini.
+        button: Stop following
+        error: There has been an error unfollowing this resource.
     forms:
-      current_file: File saat ini
-      current_image: Gambar saat ini
-      default_image: Gambar default
+      current_file: Current file
+      current_image: Current image
+      default_image: Default image
       errors:
-        error: Ada kesalahan di bidang ini.
-      remove_this_file: Hapus file ini
+        error: There's an error in this field.
+      remove_this_file: Remove this file
     gamification:
-      all_badges_link: Lihat semua lencana yang tersedia.
+      all_badges_link: See all available badges.
       badges:
         continuity:
-          conditions:
-            - Sering ke sini
-          description: Lencana ini diberikan saat Anda mengunjungi platform dengan cara biasa. Kami suka ada Anda di sini!
-          description_another: Pengguna ini telah terhubung selama %{score} hari berturut-turut di beberapa titik.
-          description_own: Anda telah terhubung selama %{score} hari berturut-turut di beberapa titik.
-          name: Kontinuitas
-          next_level_in: Terhubung selama %{score} hari berturut-turut untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum masuk selama lebih dari satu hari berturut-turut.
-          unearned_own: Anda belum terhubung selama lebih dari satu hari berturut-turut.
+          conditions: '["Come here often"]'
+          description: This badge is granted when you visit the platform in a regular way. We like having you around here!
+          description_another: This user has connected for %{score} consecutive days at some point.
+          description_own: You have connected for %{score} consecutive days at some point.
+          name: Continuity
+          next_level_in: Connect for %{score} consecutive days to get to the next level!
+          unearned_another: This user hasn't signed in for more than one consecutive day.
+          unearned_own: You haven't connected for more than one consecutive day.
         followers:
-          conditions:
-            - Menjadi aktif dan mengikuti orang lain pasti akan membuat orang lain mengikuti Anda.
-          description: Lencana ini diberikan ketika Anda mencapai sejumlah pengikut tertentu. %{organization_name} adalah jaringan sosial dan politik, menjalin web Anda untuk berkomunikasi dengan orang lain di platform.
-          description_another: Pengguna ini memiliki %{score} pengikut.
-          description_own: "%{score} pengguna mengikuti Anda."
-          name: Pengikut
-          next_level_in: Dapatkan %{score} lebih banyak pengguna untuk mengikuti Anda untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum memiliki pengikut.
-          unearned_own: Anda belum punya pengikut.
+          conditions: '["Being active and following other people will surely make other people follow you."]'
+          description: This badge is granted when you reach a certain number of followers. %{organization_name} is a social and political network, weave your web to communicate with other people in the platform.
+          description_another: This user has %{score} followers.
+          description_own: "%{score} users are following you."
+          name: Followers
+          next_level_in: Get %{score} more users to follow you to reach the next level!
+          unearned_another: This user doesn't have any followers yet.
+          unearned_own: You've got no followers yet.
         index:
-          badge_title: "%{name} lencana"
-          how: Bagaimana Anda bisa mendapatkannya
-          page_description: Lencana adalah pengakuan untuk tindakan dan kemajuan peserta dalam platform. Ketika Anda mulai menemukan, berpartisipasi, dan berinteraksi di platform, Anda akan mendapatkan lencana yang berbeda. Di sini adalah daftar lencana dan beberapa cara Anda dapat memperolehnya.
-          title: Lencana
+          badge_title: "%{name} badge"
+          how: How can you earn it
+          page_description: Badges are recognitions to participant actions and progress in the platform. As you start discovering, participating and interacting in the platform, you will earn different badges. Here is the list of badges and some ways you can earn them.
+          title: Badges
         invitations:
-          conditions:
-            - Gunakan tautan "undang teman" di halaman pengguna Anda untuk mengundang teman-teman Anda
-            - Sesuaikan, jika Anda mau, pesan yang Anda kirim
-            - Anda akan naik level dengan mengirim undangan dan meminta mereka terdaftar.
-          description: Lencana ini diberikan ketika Anda mengundang beberapa orang dan mereka telah menghabiskan sedikit waktu untuk mendaftar di %{organization_name} dan menjadi peserta. Terima kasih telah membuat %{organization_name} diketahui orang lain dan membantu memperluas komunitas!
-          description_another: Pengguna ini telah mengundang %{score} pengguna.
-          description_own: Anda telah mengundang %{score} pengguna.
-          name: Undangan
-          next_level_in: Undang %{score} lebih banyak pengguna untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum mengundang pengguna apa pun.
-          unearned_own: Anda belum mengundang pengguna.
-      description: Lencana adalah pengakuan untuk tindakan dan kemajuan peserta dalam platform. Ketika Anda mulai menemukan, berpartisipasi, dan berinteraksi di platform, Anda akan mendapatkan lencana yang berbeda.
+          conditions: '["Use the “invite friends” link on your user page to invite your friends", "Customize, if you want, the message you are sending", "You’ll level up by sending invitations and getting them registered."]'
+          description: This badge is granted when you’ve invited some people and they have spend a little time to register in %{organization_name} and become participants. Thank you for making %{organization_name} known to others and helping to expand the community!
+          description_another: This user has invited %{score} users.
+          description_own: You have invited %{score} users.
+          name: Invitations
+          next_level_in: Invite %{score} more users to reach the next level!
+          unearned_another: This user hasn't invited any user yet.
+          unearned_own: You have invited no users yet.
+      description: Badges are recognitions to participant actions and progress in the platform. As you start discovering, participating and interacting in the platform, you will earn different badges.
       level: Level %{level}
-      reached_top: Anda telah mencapai level teratas untuk lencana ini.
+      reached_top: You've reached the top level for this badge.
     group_admins:
       actions:
-        are_you_sure: Apakah kamu yakin? Ini tidak akan menghapus pengguna dari grup.
-        demote_admin: Hapus admin
+        are_you_sure: Are you sure? This won't remove the user from the group.
+        demote_admin: Remove admin
       demote:
-        error: Terjadi kesalahan saat menghapus pengguna ini dari daftar admin
-        success: Pengguna dihapus dari admin dengan sukses
+        error: There was an error removing this user from the admins list
+        success: User removed from admin successfully
       index:
-        current_admins: 'Admin saat ini:'
-        manage_admins: Kelola admin
+        current_admins: 'Current admins:'
+        manage_admins: Manage admins
     group_invites:
       accept:
-        error: Terjadi kesalahan saat menerima undangan ini
-        success: Undangan diterima dengan sukses
-      accept_invitation: Menerima
-      accept_or_reject_group_invitations: 'Grup berikut telah mengundang Anda untuk bergabung dengan mereka. Terima atau tolak permintaan mereka:'
+        error: There was an error accepting this invitation
+        success: Invitation accepted successfully
+      accept_invitation: Accept
+      accept_or_reject_group_invitations: 'The following groups have invited you to join them. Accept or reject their requests:'
       index:
-        invite: Undang
-        invite_user: Undang pengguna
+        invite: Invite
+        invite_user: Invite a user
       invite:
-        error: Terjadi kesalahan saat mengundang pengguna ini
-        success: Pengguna berhasil diundang
+        error: There was an error inviting this user
+        success: User invited successfully
       reject:
-        error: Terjadi kesalahan saat menolak undangan ini
-        success: Undangan ditolak dengan sukses
-      reject_invitation: Menolak
+        error: There was an error rejecting this invitation
+        success: Invitation rejected successfully
+      reject_invitation: Reject
     group_members:
       accept:
-        error: Terjadi kesalahan saat menerima permintaan bergabung ini
-        success: Permintaan bergabung diterima dengan sukses
+        error: There was an error accepting this join request
+        success: Join request accepted successfully
       actions:
-        are_you_sure: Apakah kamu yakin?
-        promote_to_admin: Membuat admin
-        remove_from_group: Hapus pengguna
+        are_you_sure: Are you sure?
+        promote_to_admin: Make admin
+        remove_from_group: Remove user
       index:
-        current_members_without_admins: 'Anggota saat ini (tanpa admin):'
-        manage_members: Kelola anggota
+        current_members_without_admins: 'Current members (without admins):'
+        manage_members: Manage members
       promote:
-        error: Terjadi kesalahan saat mempromosikan pengguna ini
-        success: Pengguna berhasil dipromosikan
+        error: There was an error promoting this user
+        success: User promoted successfully
       reject:
-        error: Terjadi kesalahan saat menolak permintaan bergabung ini
-        success: Gabung permintaan ditolak dengan sukses
+        error: There was an error rejecting this join request
+        success: Join request rejected successfully
       remove:
-        error: Terjadi kesalahan saat menghapus pengguna ini dari grup
-        success: Pengguna dihapus dari grup dengan sukses
+        error: There was an error removing this user from the group
+        success: User removed from the group successfully
     groups:
       actions:
-        are_you_sure: Apakah kamu yakin?
+        are_you_sure: Are you sure?
       create:
-        error: Ada masalah saat membuat grup
-        success: Grup berhasil dibuat
+        error: There has been a problem creating the group
+        success: Group created successfully
       edit:
-        edit_user_group: Edit grup
-        update_user_group: Perbarui grup
+        edit_user_group: Edit group
+        update_user_group: Update group
       form:
-        document_number_help: Jangan gunakan tanda hubung atau spasi
-        email_help: Email dari organisasi Anda, asosiasi, kolektif, grup, dll.
-        fill_in_for_verification: 'Isi bidang-bidang ini jika Anda ingin grup Anda diverifikasi:'
-        name_help: Nama organisasi Anda, asosiasi, kolektif, grup, dll.
-        nickname_help: Nama pengguna organisasi Anda, asosiasi, kolektif, grup, dll. Jangan menggunakan spasi atau aksen.
-        phone_help: Jangan gunakan tanda hubung atau spasi
+        document_number_help: Do not use dashes nor spaces
+        email_help: Email of your organization, association, collective, group, etc.
+        fill_in_for_verification: 'Fill in these fields if you want your group to be verified:'
+        name_help: Name of your organization, association, collective, group, etc.
+        nickname_help: Username of your organization, association, collective, group, etc. Do not use spaces nor accents.
+        phone_help: Do not use dashes nor spaces
       join:
-        error: Ada masalah saat bergabung dengan grup
-        success: Gabung permintaan berhasil dibuat. Admin akan meninjau permintaan Anda sebelum menerima Anda ke grup.
+        error: There has been a problem joining the group
+        success: Join request created successfully. An admin will review your request before accepting you to the group.
       leave:
-        error: Ada masalah saat keluar dari grup
-        success: Grup berhasil dibiarkan.
+        error: There has been a problem leaving the group
+        success: Group left successfully.
       members:
-        accept_or_reject_join_requests: 'Pengguna berikut telah mendaftar untuk bergabung dengan grup ini. Terima atau tolak permintaan mereka:'
-        accept_request: Menerima
-        reject_request: Menolak
+        accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'
+        accept_request: Accept
+        reject_request: Reject
       new:
-        create_user_group: Membuat grup
-        new_user_group: Grup baru
-        subtitle: Buat grup dan undang pengguna lain untuk bergabung untuk berpartisipasi dalam tingkat kolektif.
-      no_user_groups: Belum menjadi anggota grup apa pun.
+        create_user_group: Create group
+        new_user_group: New group
+        subtitle: Create a group and invite other users to join to participate in a collective level.
+      no_user_groups: Doesn't belong to any group yet.
       roles:
         admin: Administrator
-        creator: Pencipta
-        member: Anggota
+        creator: Creator
+        member: Member
       update:
-        error: Terjadi masalah saat memperbarui grup
-        success: Grup berhasil diperbarui
+        error: There has been a problem updating the group
+        success: Group updated successfully
     help:
       main_topic:
         default_page:
-          content: "<p>Dalam %{organization} Anda dapat berpartisipasi dan memutuskan topik yang berbeda, melalui ruang yang Anda lihat di menu atas: Proses, Rakitan, Inisiatif, Konsultasi.</p> <p>Di dalam masing-masing Anda akan menemukan berbagai opsi untuk berpartisipasi: membuat proposal - secara individu atau dengan orang lain-, ambil bagian dalam perdebatan, memprioritaskan proyek untuk dilaksanakan, menghadiri pertemuan tatap muka dan tindakan lainnya.</p>\n"
-          title: Apa yang bisa saya lakukan di %{organization}?
-        description: Baca lebih lanjut tentang %{organization}
-        title: Bantuan umum
+          content: "<p>In %{organization} you can participate and decide on different topics, through the spaces you see in the top menu: Processes, Assemblies, Initiatives, Consultations.</p> <p>Within each one you will find different options to participate: make proposals - individually or with other people-, take part in debates, prioritize projects to implement, attend face-to-face meetings and other actions.</p>\n"
+          title: What can I do in %{organization}?
+        description: Read more about %{organization}
+        title: General Help
     last_activities:
       activities:
-        no_activities_warning: Tidak ada kegiatan
-      all: Semua jenis aktivitas
+        no_activities_warning: No activity
+      all: All activity types
       index:
-        last_activity: Aktivitas terakhir
-        resource_type: Mengetik
+        last_activity: Last activity
+        resource_type: Type
     log:
       base_presenter:
-        create: "%{user_name} dibuat %{resource_name}"
-        create_with_space: "%{user_name} dibuat %{resource_name} dalam %{space_name}"
-        delete: "%{user_name} dihapus %{resource_name}"
-        delete_with_space: "%{user_name} dihapus %{resource_name} dalam %{space_name}"
-        unknown_action: "%{user_name} melakukan beberapa tindakan pada %{resource_name}"
-        unknown_action_with_space: "%{user_name} melakukan beberapa tindakan pada %{resource_name} di %{space_name}"
-        update: "%{user_name} diperbarui %{resource_name}"
-        update_with_space: "%{user_name} diperbarui %{resource_name} dalam %{space_name}"
+        create: "%{user_name} created %{resource_name}"
+        create_with_space: "%{user_name} created %{resource_name} in %{space_name}"
+        delete: "%{user_name} deleted %{resource_name}"
+        delete_with_space: "%{user_name} deleted %{resource_name} in %{space_name}"
+        unknown_action: "%{user_name} performed some action on %{resource_name}"
+        unknown_action_with_space: "%{user_name} performed some action on %{resource_name} in %{space_name}"
+        update: "%{user_name} updated %{resource_name}"
+        update_with_space: "%{user_name} updated %{resource_name} in %{space_name}"
       value_types:
         area_presenter:
-          not_found: 'Daerah itu tidak ditemukan di database (ID: %{id})'
+          not_found: 'The area was not found on the database (ID: %{id})'
         area_type_presenter:
-          not_found: 'Tipe area tidak ditemukan di database (ID: %{id})'
+          not_found: 'The area type was not found on the database (ID: %{id})'
         scope_presenter:
-          not_found: 'Ruang lingkup tidak ditemukan di database (ID: %{id})'
+          not_found: 'The scope was not found on the database (ID: %{id})'
         scope_type_presenter:
-          not_found: 'Jenis ruang lingkup tidak ditemukan di database (ID: %{id})'
+          not_found: 'The scope type was not found on the database (ID: %{id})'
     managed_users:
-      expired_session: Sesi peniruan saat ini telah kedaluwarsa.
+      expired_session: The current impersonation session has expired.
     members:
-      no_members: Kelompok pengguna ini belum memiliki anggota.
+      no_members: This user groups doesn't have any member yet.
     menu:
-      help: Membantu
-      home: Rumah
+      help: Help
+      home: Home
     messaging:
       conversation_mailer:
         new_conversation:
-          greeting: Hai, %{recipient}!
-          intro: "%{sender} telah memulai percakapan baru dengan Anda. Klik di sini untuk melihatnya:"
-          outro: Selamat menikmati decidim!
-          subject: "%{sender} telah memulai percakapan dengan Anda"
+          greeting: Hi, %{recipient}!
+          intro: "%{sender} has started a new conversation with you. Click here to see it:"
+          outro: Enjoy decidim!
+          subject: "%{sender} has started a conversation with you"
         new_message:
-          greeting: Hai, %{recipient}!
-          intro: "%{sender} telah memposting pesan baru di percakapan Anda. Klik di sini untuk melihatnya:"
-          outro: Selamat menikmati decidim!
-          subject: Anda memiliki pesan baru dari %{sender}
+          greeting: Hi, %{recipient}!
+          intro: "%{sender} has posted new messages in your conversation. Click here to see them:"
+          outro: Enjoy decidim!
+          subject: You have new messages from %{sender}
       conversations:
         create:
-          error: Percakapan tidak dimulai. Coba lagi nanti
+          error: Conversation not started. Try again later
         index:
-          no_conversations: Anda belum memiliki percakapan
-          title: Percakapan
+          no_conversations: You have no conversations yet
+          title: Conversations
         reply:
-          send: Kirim
-          title: Balasan
+          send: Send
+          title: Reply
         show:
-          title: Percakapan dengan %{usernames}
+          title: Conversation with %{usernames}
         start:
-          send: Kirim
-          title: Mulai percakapan
+          send: Send
+          title: Start a conversation
         update:
-          error: Pesan tidak terkirim. Coba lagi nanti
+          error: Message not sent. Try again later
     metrics:
       download:
-        csv: Unduh data (csv)
+        csv: Download data (csv)
       followers:
-        description: Jumlah pengguna yang mengikuti dalam organisasi
-        object: pengikut
-        title: Pengikut
+        description: Number of users that follow this participation space
+        object: followers
+        title: Followers
       participants:
-        description: Jumlah pengguna aktif dalam organisasi
-        object: peserta
-        title: Peserta
+        description: Number of active user in organization
+        object: participants
+        title: Participants
       users:
-        description: Jumlah pengguna dalam organisasi
-        object: pengguna
-        title: Pengguna
+        description: Number of user in organization
+        object: users
+        title: Users
     newsletter_mailer:
       newsletter:
-        note: Anda menerima email ini karena Anda berlangganan nawala pada %{organization_name}. Anda dapat mengubah pengaturan Anda pada <a href="%{link}">halaman pemberitahuan</a>.
-        see_on_website: Tidak bisa melihat email ini dengan benar? Lihat di situs web <a href="%{link}" target="_blank"></a>.
-        unsubscribe: Untuk memilih tidak menerima jenis email ini, <a href="%{link}" target="_blank" class="unsubscribe">Berhenti Berlangganan</a>.
+        note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
+        see_on_website: Can’t see this email correctly? View it on the <a href="%{link}" target="_blank">website</a>.
+        unsubscribe: To opt out of receiving this type of email, <a href="%{link}" target="_blank" class="unsubscribe">Unsubscribe</a>.
     newsletters:
       unsubscribe:
-        check_subscription: Jika Anda ingin mengubah preferensi Anda, Anda dapat melakukannya di <a href="%{link}" target="_blank">halaman konfigurasi</a>
-        error: Terjadi kesalahan saat berhenti berlangganan
-        success: Anda berhasil berhenti berlangganan.
-        token_error: Tautan telah kedaluwarsa.
-        unsubscribe: Berhenti berlangganan
+        check_subscription: If you want to change your preferences, you can do so in the <a href="%{link}" target="_blank">configuration page</a>
+        error: There's been an error unsubscribing
+        success: You are unsubscribed successfully.
+        token_error: The link has expired.
+        unsubscribe: Unsubscribe
     newsletters_opt_in:
-      unathorized: Maaf, tautan ini tidak lagi tersedia
+      unathorized: Sorry, this link is no longer available
       update:
-        error: Terjadi kesalahan
-        success: Pengaturan buletin berhasil diperbarui
+        error: Something wrong happened
+        success: Newsletter settings updated successfully
     newsletters_opt_in_mailer:
       notify:
-        body_1: Pengolahan data pribadi dan perlindungannya menjadi semakin penting bagi kita semua. Dengan Peraturan Perlindungan Data Umum yang baru (GDPR) 25 Mei 2018, individu memiliki kontrol yang lebih baik atas data pribadi mereka. Untuk alasan ini kami memerlukan "OK" Anda untuk terus mengirim informasi yang relevan tentang kegiatan %{organization_name}.
-        body_2: 'Bagaimana Anda bisa memberi kami persetujuan Anda? Cukup klik tombol berikut:'
-        body_3: Dengan persetujuan ini Anda akan dapat terus menerima informasi tentang layanan platform. Jika, sebaliknya, kami tidak menerima konfirmasi positif dari pihak Anda, kami akan berhenti mengirimi Anda pesan kami. Jika Anda mengonfirmasi bahwa Anda ingin terus mendapat informasi, Anda akan selalu memiliki opsi untuk membatalkan kapan saja.
-        button: Ya, saya ingin terus menerima informasi yang relevan
-        greetings: Salam,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
-        hello: Halo,
-        subject: Apakah Anda ingin tetap menerima informasi yang relevan tentang %{organization_name}?
+        body_1: The processing of personal data and its protection is becoming increasingly important for all of us. With the new General Data Protection Regulation (GDPR) of May 25, 2018, individuals have better control over their personal data. For this reason we need your "OK" to continue sending relevant information about the activities of the %{organization_name}.
+        body_2: 'How can you give us your consent? Just click the following button:'
+        body_3: With this consent you will be able to continue receiving information about the services of the platform. If, on the contrary, we do not receive a positive confirmation on your part we will stop sending you our messages. If you confirm that you want to keep being informed, you will always have the option to cancel at any time.
+        button: Yes, I want to continue receiving relevant information
+        greetings: Greetings,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+        hello: Hello,
+        subject: Do you want to keep receiving relevant information about %{organization_name}?
+    notification_mailer:
+      shared:
+        note: You received this message because you're subscribed to notification by email on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
     notifications:
-      no_notifications: Belum ada pemberitahuan.
+      no_notifications: No notifications yet.
     notifications_settings:
       show:
-        email_on_notification: Saya ingin menerima email setiap kali saya menerima pemberitahuan.
-        everything_followed: Semua yang saya ikuti
-        newsletters: Nawala
-        newsletter_notifications: Saya ingin menerima buletin
-        own_activity: Aktivitas saya sendiri, seperti ketika seseorang berkomentar di proposal saya atau menyebut saya
-        receive_notifications_about: Saya ingin mendapatkan pemberitahuan tentang
-        send_notifications_by_email: Kirim pemberitahuan melalui email
-        update_notifications_settings: Simpan perubahan
+        email_on_notification: I want to receive an email every time I receive a notification.
+        everything_followed: Everything I follow
+        newsletter_notifications: I want to receive newsletters
+        newsletters: Newsletters
+        own_activity: My own activity, like when someone comments in my proposal or mentions me
+        receive_notifications_about: I want to get notifications about
+        send_notifications_by_email: Send notifications by email
+        update_notifications_settings: Save changes
       update:
-        error: Terjadi kesalahan saat memperbarui pengaturan notifikasi Anda.
-        success: Pengaturan pemberitahuan Anda telah berhasil diperbarui.
+        error: There's been an error updating your notifications settings.
+        success: Your notifications settings were updated successfully.
     open_data:
-      not_available_yet: File Open Data belum tersedia, silakan coba lagi dalam beberapa menit.
+      not_available_yet: The Open Data files are not yet available, please try again in a few minutes.
     own_user_groups:
       index:
-        pending: Menunggu keputusan
-        rejected: Ditolak
-        verified: Diverifikasi
+        pending: Pending
+        rejected: Rejected
+        verified: Verified
     pad_iframe:
-      disclaimer: Isi pad ini ditulis oleh pengguna terdaftar dan menyatakan pendapat mereka. %{organization} tidak dapat bertanggung jawab atas isinya.
-      explanation: Gunakan pad ini untuk bersama-sama membuat catatan selama pertemuan sehingga lebih mudah untuk menulis menit kemudian.
-      pad: Bantalan
+      disclaimer: The contents of this pad are written by registered users and express their opinions. %{organization} cannot be held responsible for its contents.
+      explanation: Use this pad to collaboratively take notes during the meeting so it's easier to write down the minute afterwards.
+      pad: Pad
     pages:
       home:
         extended:
-          debates: Perdebatan
-          debates_explanation: Perdebatkan dan diskusikan, bagikan pandangan Anda, dan perkaya topik yang relevan.
-          how_to_participate: Bagaimana saya ikut serta dalam suatu proses?
-          meetings: Rapat
-          meetings_explanation: Cari tahu di mana dan kapan Anda dapat berpartisipasi dalam pertemuan publik.
-          more_info: Info lebih lanjut
-          proposals: Proposal
-          proposals_explanation: Buat proposal, dukung yang sudah ada dan promosikan perubahan yang ingin Anda lihat.
+          debates: Debates
+          debates_explanation: Debate and discuss, share your views and enrich the relevant topics.
+          how_to_participate: How do I take part in a process?
+          meetings: Meetings
+          meetings_explanation: Find out where and when you can participate in public meetings.
+          more_info: More info
+          proposals: Proposals
+          proposals_explanation: Make proposals, support existing ones and promote the changes you want to see.
         footer_sub_hero:
-          footer_sub_hero_body: Mari membangun masyarakat yang lebih terbuka, transparan, dan kolaboratif.<br /> Gabung, berpartisipasi, dan putuskan.
-          footer_sub_hero_headline: Selamat datang di %{organization} platform partisipatif.
-          register: Daftar
+          footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.
+          footer_sub_hero_headline: Welcome to %{organization} participatory platform.
+          register: Register
         hero:
-          participate: Ikut
-          welcome: Selamat datang di %{organization}!
+          participate: Participate
+          welcome: Welcome to %{organization}!
         metrics:
-          headline: Partisipasi dalam angka
+          headline: Participation in figures
         statistics:
-          answers_count: Survei yang Selesai
+          answers_count: Completed Surveys
           assemblies_count: Assemblies
-          comments_count: Komentar
-          conferences_count: Konferensi
-          debates_count: Perdebatan
-          endorsements_count: Endorsemen
-          headline: Keadaan saat ini %{organization}
-          meetings_count: Rapat
-          orders_count: Suara
-          pages_count: Halaman
-          processes_count: Proses
-          projects_count: Proyek
-          proposals_accepted: Proposal yang Diterima
-          proposals_count: Proposal
-          results_count: Hasil
-          surveys_count: Survei
-          users_count: Peserta
-          votes_count: Suara
+          comments_count: Comments
+          conferences_count: Conferences
+          debates_count: Debates
+          endorsements_count: Endorsements
+          headline: Current state of %{organization}
+          meetings_count: Meetings
+          orders_count: Votes
+          pages_count: Pages
+          processes_count: Processes
+          projects_count: Projects
+          proposals_accepted: Accepted Proposals
+          proposals_count: Proposals
+          results_count: Results
+          surveys_count: Surveys
+          users_count: Participants
+          votes_count: Votes
         sub_hero:
-          register: Daftar
+          register: Register
       index:
-        read_more: Baca lebih lajut
-        standalone_pages: Halaman
-        subheading: Menavigasi melalui halaman bantuan %{name}
-        title: Membantu
-        topics: Topik
-      participatory_space:
-        metrics:
-          headline: Partisipasi dalam angka
-          link: Tampilkan semua statistik
+        read_more: Read more
+        standalone_pages: Pages
+        subheading: Navigate through the help pages of %{name}
+        title: Help
+        topics: Topics
       terms_and_conditions:
         accept:
-          error: Terjadi kesalahan saat menerima persyaratan dan ketentuan.
-          success: Besar! Anda telah menyetujui persyaratan dan ketentuan.
+          error: There's been an error while accepting the terms and conditions.
+          success: Great! You have accepted the terms and conditions.
         form:
-          agreement: Saya setuju dengan ketentuan ini
-          legend: Setujui persyaratan dan ketentuan penggunaan
+          agreement: I agree this terms
+          legend: Agree to the terms and conditions of use
         refuse:
-          modal_body: Jika Anda menolak, Anda tidak akan dapat menggunakan platform, Anda dapat <a href="%{data_portability_path}">mengunduh data Anda</a> dan / atau <a href="%{delete_path}">menghapus akun Anda</a>.
-          modal_btn_continue: Terima persyaratan dan lanjutkan
-          modal_btn_exit: Saya akan memeriksanya nanti
-          modal_button: Menolak persyaratan
-          modal_close: Tutup modal
-          modal_title: Apakah Anda benar-benar menolak Syarat dan Ketentuan yang diperbarui?
+          modal_body: If you refuse, you won't be able to use the platform, you can <a href="%{data_portability_path}">download your data</a> and/or <a href="%{delete_path}">delete your account</a>.
+          modal_btn_continue: Accept terms and continue
+          modal_btn_exit: I'll review it later
+          modal_button: Refuse the terms
+          modal_close: Close modal
+          modal_title: Do you really refuse the updated Terms and Conditions?
         required_review:
-          alert: Kami telah memperbarui Persyaratan Layanan, harap tinjau.
-          body: Harap luangkan waktu untuk meninjau pembaruan pada Ketentuan Layanan kami. Jika tidak, Anda tidak akan dapat menggunakan platform.
-          title: 'Diperlukan: Tinjau pembaruan untuk persyaratan layanan kami'
+          alert: We've updated our Terms of Service, please review them.
+          body: Please take a moment to review updates to our Terms of Services. Otherwise you won't be able to use the platform.
+          title: 'Required: Review updates to our terms of service'
     participatory_space_private_users:
-      not_allowed: Anda tidak diizinkan untuk melihat konten ini
+      not_allowed: You are not allowed to view this content
     profile:
-      deleted: Pengguna yang dihapus
-      view: Melihat
+      deleted: Deleted user
+      view: View
     profiles:
-      default_officialization_text_for_user_groups: Kelompok pengguna ini diverifikasi secara publik, namanya telah diverifikasi untuk sesuai dengan nama aslinya
-      default_officialization_text_for_users: Peserta ini diverifikasi secara publik, nama atau perannya telah diverifikasi untuk sesuai dengan nama dan peran aslinya
+      default_officialization_text: Justification
+      default_officialization_text_for_user_groups: This user group is publicly verified, its name has been verified to correspond with its real name
+      default_officialization_text_for_users: This participant is publicly verified, his/her name or role has been verified to correspond with his/her real name and role
       show:
-        activity: Aktivitas
-        badges: Lencana
-        followers: Pengikut
-        following: Mengikuti
-        groups: Grup
-        members: Anggota
-        timeline: Garis waktu
-        view_full_profile: Lihat profil lengkap
+        activity: Activity
+        badges: Badges
+        followers: Followers
+        following: Follows
+        groups: Groups
+        members: Members
+        timeline: Timeline
+        view_full_profile: View full profile
       sidebar:
         badges:
-          info: Lencana diperoleh dengan melakukan aktivitas tertentu di platform.
-          title: Lencana
+          info: Badges are earned by performing specific activity in the platform.
+          title: Badges
       user:
-        confirmation_instructions_sent: Instruksi konfirmasi email terkirim
-        create_user_group: Membuat grup
-        edit_profile: Edit profil
-        edit_user_group: Edit profil grup
-        fill_in_email_to_confirm_it: Silakan isi email grup Anda untuk mengonfirmasi
-        invite_user: Undang pengguna
-        join_user_group: Permintaan untuk bergabung dengan grup
-        leave_user_group: Meninggalkan grup
-        manage_user_group_admins: Kelola admin
-        manage_user_group_users: Kelola anggota
-        resend_email_confirmation_instructions: Kirim ulang instruksi konfirmasi email
+        confirmation_instructions_sent: Email confirmation instructions sent
+        create_user_group: Create group
+        edit_profile: Edit profile
+        edit_user_group: Edit group profile
+        fill_in_email_to_confirm_it: Please, fill in your group's email to confirm it
+        invite_user: Invite user
+        join_user_group: Request to join group
+        leave_user_group: Leave group
+        manage_user_group_admins: Manage admins
+        manage_user_group_users: Manage members
+        resend_email_confirmation_instructions: Resend email confirmation instructions
     reported_mailer:
       hide:
-        hello: Halo %{name},
-        manage_moderations: Kelola moderasi
-        report_html: <p>berikut <a href="%{url}">konten</a> telah disembunyikan secara otomatis.</p>
-        subject: Sumber daya telah disembunyikan secara otomatis
+        hello: Hello %{name},
+        manage_moderations: Manage moderations
+        report_html: <p>The following <a href="%{url}">content</a> has been hidden automatically.</p>
+        subject: A resource has been hidden automatically
       report:
-        hello: Halo %{name},
-        manage_moderations: Kelola moderasi
-        report_html: <p> <a href="%{url}">konten</a> berikut telah dilaporkan.</p>
-        subject: Sumber daya telah dilaporkan
+        hello: Hello %{name},
+        manage_moderations: Manage moderations
+        report_html: <p>The following <a href="%{url}">content</a> has been reported.</p>
+        subject: A resource has been reported
     reports:
       create:
-        error: Terjadi kesalahan saat membuat laporan. Tolong, coba lagi.
-        success: Laporan telah berhasil dibuat dan akan ditinjau oleh admin.
+        error: An error ocurred while creating the report. Please, try it again.
+        success: The report has been created successfully and it will be reviewed by an admin.
     scopes:
-      global: Ruang lingkup global
+      global: Global scope
       picker:
-        cancel: Membatalkan
-        choose: Memilih
-        title: Pilih %{field}
-      prompt: Pilih cakupan
+        cancel: Cancel
+        choose: Select
+        title: Select %{field}
+      prompt: Select a scope
       scopes: Scopes
     search:
-      results_found_for_term: '%{count} Hasil untuk pencarian: "%{term}"'
-      term_input_placeholder: Pencarian
+      results_found_for_term: '%{count} Results for the search: "%{term}"'
+      term_input_placeholder: Search
     searches:
       filters:
-        back: Kembali ke hasil
-        jump_to: 'Lompat ke:'
+        back: Back to results
+        jump_to: 'Jump to:'
         state:
-          active: Aktif
-          all: Semua
-          future: Masa depan
-          past: Lalu
+          active: Active
+          all: All
+          future: Future
+          past: Past
       filters_small_view:
-        close_modal: Tutup modal
+        close_modal: Close modal
         filter: Filter
-        filter_by: Filter berdasarkan
-        unfold: Membuka
+        filter_by: Filter by
+        unfold: Unfold
       results:
         results:
-          other: "%{count} hasil"
-        view_all: Lihat semua (%{count})
+          one: "%{count} result"
+          other: "%{count} results"
+        view_all: View all (%{count})
     shared:
       embed_modal:
-        close_window: Tutup jendela
-        embed: Silakan tempel kode ini di halaman Anda
-        embed_link: Menanamkan
+        close_window: Close window
+        embed: Please paste this code in your page
+        embed_link: Embed
       extended_navigation_bar:
-        more: Lebih
-        unfold: Membuka
+        more: More
+        unfold: Unfold
       flag_modal:
-        already_reported: Konten ini sudah dilaporkan dan akan ditinjau oleh admin.
-        close: Dekat
-        description: Apakah konten ini tidak pantas?
-        does_not_belong: Berisi aktivitas ilegal, ancaman bunuh diri, informasi pribadi, atau hal lain yang menurut Anda bukan milik %{organization_name}.
-        offensive: Berisi rasisme, seksisme, penghinaan, serangan pribadi, ancaman pembunuhan, permintaan bunuh diri atau segala bentuk pidato kebencian.
-        report: Melaporkan
-        spam: Berisi clickbait, iklan, penipuan, atau bot skrip.
-        title: Laporkan masalah
+        already_reported: This content is already reported and it will be reviewed by an admin.
+        close: Close
+        description: Is this content inappropriate?
+        does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+        offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+        report: Report
+        spam: Contains clickbait, advertising, scams or script bots.
+        title: Report a problem
       floating_help:
-        help: Membantu
+        help: Help
       follow_button:
-        sign_in_before_follow: Harap masuk sebelum melakukan tindakan ini
+        sign_in_before_follow: Please sign in before performing this action
       login_modal:
-        please_sign_in: Silakan masuk
-        sign_up: Daftar
+        please_sign_in: Please sign in
+        sign_up: Sign up
       reference:
-        reference: 'Referensi: %{reference}'
+        reference: 'Reference: %{reference}'
       results_per_page:
-        label: 'Hasil per halaman:'
+        label: 'Results per page:'
       share_modal:
-        close_window: Tutup jendela
-        share: Bagikan
-        share_link: Membagikan tautan
+        close_window: Close window
+        share: Share
+        share_link: Share link
       version_author:
-        deleted: Pengguna yang dihapus
+        deleted: Deleted user
     user_activity:
       index:
-        no_activities_warning: Pengguna ini belum memiliki aktivitas apa pun.
+        no_activities_warning: This user hasn't had any activity yet.
     user_interests:
       show:
-        no_scopes: Organisasi ini belum memiliki ruang lingkup!
-        my_interests: Minat saya
-        select_your_interests: Pilih topik yang Anda minati untuk menerima acara yang terkait dengan mereka di tab Kronologi profil Anda.
-        update_my_interests: Perbarui minat saya
+        my_interests: My interests
+        no_scopes: This organization doesn't have any scope yet!
+        select_your_interests: Select the topics you're interested in to receive events related to them in your profile Timeline tab.
+        update_my_interests: Update my interests
       update:
-        error: Terjadi kesalahan saat memperbarui minat Anda.
-        success: Minat Anda telah berhasil diperbarui.
+        error: There was an error while updating your interests.
+        success: Your interests have been successfully updated.
     welcome_notification:
-      default_body: <p>Hai {{name}}, terima kasih sudah bergabung dengan {{organization}} dan selamat datang!</p><ul><li>Jika Anda ingin mendapatkan ide cepat tentang apa yang dapat Anda lakukan di sini, lihat bagian <a href="{{help_url}}">Bantuan</a> .</li><li>Setelah Anda membacanya, Anda akan mendapatkan lencana pertama Anda. Berikut adalah <a href="{{badges_url}}">daftar dari semua lencana</a> yang dapat Anda peroleh ketika Anda berpartisipasi dalam {{organization}}</li><li>Terakhir tetapi tidak sedikit, bergabunglah dengan orang lain, bagikan kepada mereka pengalaman terlibat dan berpartisipasi dalam {{organization}}. Buatlah proposal, komentar, debat, pikirkan tentang bagaimana berkontribusi terhadap kebaikan bersama, memberikan argumen untuk meyakinkan, mendengarkan dan membaca untuk diyakinkan, mengekspresikan ide Anda dengan cara yang konkrit dan langsung, merespons dengan kesabaran dan keputusan, membela ide-ide Anda dan tetap pikiran terbuka untuk berkolaborasi dan bergabung dengan ide orang lain.</li></ul>
-      default_subject: Terima kasih telah bergabung dengan {{organization}}!
+      default_body: <p>Hi {{name}}, thanks for joining {{organization}} and welcome!</p><ul><li>If you want to get a quick idea of what you can do here, have a look at the <a href="{{help_url}}">Help</a> section.</li><li>Once you have read it you will get your first badge. Here's a <a href="{{badges_url}}">list of all the badges</a> you can get as you participate in {{organization}}</li><li>Last but not least, join other people, share with them the experience of being engaged and participating in {{organization}}. Make proposals, comments, debate, think about how to contribute to the common good, provide arguments to convince, listen and read to be convinced, express your ideas in a concrete and direct way, respond with patience and decision, defend your ideas and keep an open mind to collaborate and join other people's ideas.</li></ul>
+      default_subject: Thanks for joining {{organization}}!
   devise:
     confirmations:
-      confirmed: Alamat email Anda telah berhasil dikonfirmasi.
+      confirmed: Your email address has been successfully confirmed.
       new:
-        resend_confirmation_instructions: Kirim ulang instruksi konfirmasi
-      send_instructions: Anda akan menerima email berisi instruksi untuk cara mengonfirmasi alamat email Anda dalam beberapa menit.
-      send_paranoid_instructions: Jika alamat email Anda ada di basis data kami, Anda akan menerima email berisi petunjuk cara mengonfirmasi alamat email Anda dalam beberapa menit.
+        resend_confirmation_instructions: Resend confirmation instructions
+      send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
-      already_authenticated: Anda sudah masuk.
-      inactive: Akun Anda belum diaktifkan.
-      invalid: Kata sandi atau %{authentication_keys} tidak valid.
-      invited: Anda memiliki undangan yang tertunda, setujui untuk menyelesaikan pembuatan akun Anda.
-      last_attempt: Anda memiliki satu upaya lagi sebelum akun Anda dikunci.
-      locked: Akun Anda terkunci.
-      not_found_in_database: Kata sandi atau %{authentication_keys} tidak valid.
-      timeout: Sesi Anda berakhir. Harap masuk lagi untuk melanjutkan.
-      unauthenticated: Anda harus masuk atau mendaftar sebelum melanjutkan.
+      already_authenticated: You are already signed in.
+      inactive: Your account is not activated yet.
+      invalid: Invalid %{authentication_keys} or password.
+      invited: You have a pending invitation, accept it to finish creating your account.
+      last_attempt: You have one more attempt before your account is locked.
+      locked: Your account is locked.
+      not_found_in_database: Invalid %{authentication_keys} or password.
+      timeout: Your session expired. Please sign in again to continue.
+      unauthenticated: You need to sign in or sign up before continuing.
     invitations:
       edit:
-        header: Selesaikan membuat akun Anda
-        nickname_help: Pengenal unik Anda dalam %{organization}.
-        submit_button: Menyimpan
-        subtitle: Jika Anda menerima undangan, atur nama panggilan dan kata sandi Anda.
-      invitation_removed: Undangan Anda telah dihapus.
-      invitation_token_invalid: Token undangan yang diberikan tidak valid!
+        header: Finish creating your account
+        nickname_help: Your unique identifier in %{organization}.
+        submit_button: Save
+        subtitle: If you accept the invitation please set your nickname and password.
+      invitation_removed: Your invitation was removed.
+      invitation_token_invalid: The invitation token provided is not valid!
       new:
-        header: Kirim undangan
-        submit_button: Kirim undangan
-      no_invitations_remaining: Tidak ada undangan yang tersisa
-      send_instructions: Email undangan telah dikirim ke %{email}.
-      updated: Kata sandi Anda berhasil ditetapkan. Anda sekarang masuk.
-      updated_not_active: Kata sandi Anda berhasil ditetapkan.
+        header: Send invitation
+        submit_button: Send an invitation
+      no_invitations_remaining: No invitations remaining
+      send_instructions: An invitation email has been sent to %{email}.
+      updated: Your password was set successfully. You are now signed in.
+      updated_not_active: Your password was set successfully.
     mailer:
       confirmation_instructions:
-        action: Konfirmasikan akun saya
-        greeting: Selamat datang %{recipient}!
-        instruction: 'Anda dapat mengkonfirmasi email akun Anda melalui tautan di bawah ini:'
-        subject: Instruksi konfirmasi
+        action: Confirm my account
+        greeting: Welcome %{recipient}!
+        instruction: 'You can confirm your account email through the link below:'
+        subject: Confirmation instructions
       email_changed:
-        greeting: Halo %{recipient}!
-        message: Kami menghubungi Anda untuk memberi tahu Anda bahwa email Anda diubah menjadi %{email}.
-        subject: Email Diubah
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your email is being changed to %{email}.
+        subject: Email Changed
       invitation_instructions:
-        accept: Menerima undangan
-        accept_until: Undangan ini akan jatuh tempo dalam %{due_date}.
-        decline: Tolak undangan
-        hello: Halo %{email},
+        accept: Accept invitation
+        accept_until: This invitation will be due in %{due_date}.
+        decline: Decline invitation
+        hello: Hello %{email},
         ignore: |-
-          Jika Anda tidak ingin menerima undangan, silakan abaikan email ini.<br />
-          Akun Anda tidak akan dibuat sampai Anda mengakses tautan di atas dan mengatur nama panggilan dan kata sandi Anda.
-        invited_you_as_admin: "%{invited_by} telah mengundang Anda sebagai admin %{application}. Anda dapat menerimanya melalui tautan di bawah ini."
-        invited_you_as_private_user: "%{invited_by} telah mengundang Anda sebagai pengguna pribadi dari %{application}. Anda dapat menerimanya melalui tautan di bawah ini."
-        someone_invited_you: Seseorang telah mengundang Anda ke %{application}. Anda dapat menerimanya melalui tautan di bawah ini.
-        someone_invited_you_as_admin: Seseorang telah mengundang Anda sebagai admin %{application}, Anda dapat menerimanya melalui tautan di bawah.
-        someone_invited_you_as_private_user: Seseorang telah mengundang Anda sebagai pengguna pribadi %{application}, Anda dapat menerimanya melalui tautan di bawah ini.
-        subject: Instruksi undangan
+          If you don't want to accept the invitation, please ignore this email.<br />
+          Your account won't be created until you access the link above and set your nickname and password.
+        invited_you_as_admin: "%{invited_by} has invited you as an admin of %{application}. You can accept it through the link below."
+        invited_you_as_private_user: "%{invited_by} has invited you as a private user of %{application}. You can accept it through the link below."
+        someone_invited_you: Someone has invited you to %{application}. You can accept it through the link below.
+        someone_invited_you_as_admin: Someone has invited you as an admin of %{application}, you can accept it through the link below.
+        someone_invited_you_as_private_user: Someone has invited you as private_user of %{application}, you can accept it through the link below.
+        subject: Invitation instructions
       invite_admin:
-        subject: Anda telah diundang untuk mengelola %{organization}
+        subject: You've been invited to manage %{organization}
       invite_collaborator:
-        subject: Anda telah diundang untuk berkolaborasi pada %{organization}
+        subject: You've been invited to collaborate on %{organization}
       invite_private_user:
-        subject: Anda telah diundang ke proses partisipasi pribadi di %{organization}
+        subject: You've been invited to a private participatory process on %{organization}
       organization_admin_invitation_instructions:
-        subject: Anda telah diundang untuk mengelola %{organization}
+        subject: You've been invited to manage %{organization}
       password_change:
-        greeting: Halo %{recipient}!
-        message: Kami menghubungi Anda untuk memberi tahu Anda bahwa kata sandi Anda telah diubah.
-        subject: Kata sandi diubah
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your password has been changed.
+        subject: Password changed
       reset_password_instructions:
-        action: Ubah kata sandi saya
-        greeting: Halo %{recipient}!
-        instruction: Seseorang telah meminta tautan untuk mengubah kata sandi Anda, dan Anda dapat melakukannya melalui tautan di bawah ini.
-        instruction_2: Jika Anda tidak meminta ini, silakan abaikan email ini.
-        instruction_3: Kata sandi Anda tidak akan berubah sampai Anda mengakses tautan di atas dan membuat yang baru.
-        subject: Setel ulang instruksi kata sandi
+        action: Change my password
+        greeting: Hello %{recipient}!
+        instruction: Someone has requested a link to change your password, and you can do this through the link below.
+        instruction_2: If you didn't request this, please ignore this email.
+        instruction_3: Your password won't change until you access the link above and create a new one.
+        subject: Reset password instructions
       unlock_instructions:
-        action: Buka kunci akun saya
-        greeting: Halo %{recipient}!
-        instruction: 'Klik tautan di bawah ini untuk membuka kunci akun Anda:'
-        message: Akun Anda telah dikunci karena jumlah upaya gagal masuk yang berlebihan.
-        subject: Buka instruksi
+        action: Unlock my account
+        greeting: Hello %{recipient}!
+        instruction: 'Click the link below to unlock your account:'
+        message: Your account has been locked due to an excessive amount of unsuccessful sign in attempts.
+        subject: Unlock instructions
     omniauth_callbacks:
-      failure: Tidak dapat mengautentikasi Anda dari %{kind} karena "%{reason}".
-      success: Berhasil diautentikasi dari %{kind} akun.
+      failure: Could not authenticate you from %{kind} because "%{reason}".
+      success: Successfully authenticated from %{kind} account.
     passwords:
       edit:
-        change_my_password: Ubah kata sandi saya
-        change_your_password: Ubah kata sandi Anda
-        confirm_new_password: Konfirmasi password baru
-        new_password: Kata sandi baru
+        change_my_password: Change my password
+        change_your_password: Change your password
+        confirm_new_password: Confirm new password
+        new_password: New password
       new:
-        forgot_your_password: lupa kata sandi Anda?
-        send_me_reset_password_instructions: Kirimi saya ulang instruksi kata sandi
-      no_token: Anda tidak dapat mengakses halaman ini tanpa datang dari email pengaturan ulang kata sandi. Jika Anda datang dari email pengaturan ulang kata sandi, pastikan Anda menggunakan URL lengkap yang disediakan.
-      send_instructions: Anda akan menerima email berisi instruksi tentang cara mereset kata sandi Anda dalam beberapa menit.
-      send_paranoid_instructions: Jika alamat email Anda ada di basis data kami, Anda akan menerima tautan pemulihan kata sandi di alamat email Anda dalam beberapa menit.
-      updated: Kata sandi Anda telah berhasil diubah. Anda sekarang masuk.
-      updated_not_active: Kata sandi Anda telah berhasil diubah.
+        forgot_your_password: Forgot your password?
+        send_me_reset_password_instructions: Send me reset password instructions
+      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+      updated: Your password has been changed successfully. You are now signed in.
+      updated_not_active: Your password has been changed successfully.
     registrations:
-      destroyed: Bye! Akun Anda telah berhasil dibatalkan. Kami berharap dapat melihat Anda lagi segera.
+      destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
       edit:
-        are_you_sure: Apakah kamu yakin?
-        cancel_my_account: Batalkan akun saya
-        currently_waiting_confirmation_for_email: 'Sedang menunggu konfirmasi untuk: %{email}'
-        leave_blank_if_you_don_t_want_to_change_it: biarkan kosong jika Anda tidak ingin mengubahnya
+        are_you_sure: Are you sure?
+        cancel_my_account: Cancel my account
+        currently_waiting_confirmation_for_email: 'Currently waiting confirmation for: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
         title: Edit %{resource}
-        unhappy: Tidak bahagia?
-        update: Memperbarui
-        we_need_your_current_password_to_confirm_your_changes: kami memerlukan kata sandi Anda saat ini untuk mengonfirmasi perubahan Anda
+        unhappy: Unhappy?
+        update: Update
+        we_need_your_current_password_to_confirm_your_changes: we need your current password to confirm your changes
       new:
-        sign_up: Daftar
-      signed_up: Selamat datang! Anda telah berhasil mendaftar.
-      signed_up_but_inactive: Anda telah berhasil mendaftar. Namun, kami tidak dapat masuk karena akun Anda belum diaktifkan.
-      signed_up_but_locked: Anda telah berhasil mendaftar. Namun, kami tidak dapat masuk karena akun Anda terkunci.
-      signed_up_but_unconfirmed: Sebuah pesan dengan tautan konfirmasi telah dikirim ke alamat email Anda. Silakan ikuti tautan untuk mengaktifkan akun Anda.
-      update_needs_confirmation: Anda telah memperbarui akun Anda, tetapi kami perlu memverifikasi alamat email baru Anda. Silakan periksa email Anda dan ikuti tautan konfirmasi untuk mengonfirmasi alamat email baru Anda.
-      updated: Akun Anda telah berhasil diperbarui.
+        sign_up: Sign up
+      signed_up: Welcome! You have signed up successfully.
+      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
+      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
+      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
+      update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.
+      updated: Your account has been updated successfully.
     sessions:
-      already_signed_out: Berhasil keluar.
+      already_signed_out: Signed out successfully.
       new:
-        sign_in: Masuk
-      signed_in: Berhasil masuk.
-      signed_out: Berhasil keluar.
+        sign_in: Log in
+      signed_in: Signed in successfully.
+      signed_out: Signed out successfully.
     shared:
       links:
-        back: Kembali
-        didn_t_receive_confirmation_instructions: Tidak menerima instruksi konfirmasi?
-        didn_t_receive_unlock_instructions: Tidak menerima instruksi buka kunci?
-        forgot_your_password: lupa kata sandi Anda?
-        sign_in: Masuk
-        sign_in_with_provider: Masuk dengan %{provider}
-        sign_up: Daftar
+        back: Back
+        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+        forgot_your_password: Forgot your password?
+        sign_in: Log in
+        sign_in_with_provider: Sign in with %{provider}
+        sign_up: Sign up
       minimum_password_length:
-        other: "(Minimal%{count} karakter)"
+        one: "(%{count} character minimum)"
+        other: "(%{count} characters minimum)"
     unlocks:
       new:
-        resend_unlock_instructions: Kirim ulang instruksi buka kunci
-      send_instructions: Anda akan menerima email berisi petunjuk cara membuka kunci akun Anda dalam beberapa menit.
-      send_paranoid_instructions: Jika akun Anda ada, Anda akan menerima email berisi petunjuk cara membuka kuncinya dalam beberapa menit.
-      unlocked: Akun Anda telah berhasil dibuka kuncinya. Tolong masuk untuk melanjutkan.
+        resend_unlock_instructions: Resend unlock instructions
+      send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
+      send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
+      unlocked: Your account has been unlocked successfully. Please sign in to continue.
   doorkeeper:
     scopes:
-      public: Informasi publik Anda.
+      public: Your public information.
   errors:
     messages:
-      already_confirmed: sudah dikonfirmasi, silakan coba masuk
-      confirmation_period_expired: perlu dikonfirmasi dalam %{period}, silakan minta yang baru
-      content_type_whitelist_error: jenis file tidak valid
-      cycle_detected: orang tua ruang lingkup tidak bisa menjadi salah satu keturunannya
-      expired: telah kedaluwarsa, silakan minta yang baru
-      file_size_is_less_than_or_equal_to: ukuran file harus kurang dari atau sama dengan %{count}
-      long_words: mengandung kata-kata yang terlalu panjang (lebih dari 35 karakter)
-      must_start_with_caps: harus dimulai dengan huruf kapital
-      nesting_too_deep: tidak dapat berada di dalam suatu subkategori
-      not_found: tidak ditemukan
-      not_locked: tidak terkunci
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
+      content_type_whitelist_error: the file type is not valid
+      cycle_detected: a scope's parent can't be one of its descendants
+      expired: has expired, please request a new one
+      file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
+      long_words: contains words that are too long (over 35 characters)
+      must_start_with_caps: must start with a capital letter
+      nesting_too_deep: can't be inside of a subcategory
+      not_found: not found
+      not_locked: was not locked
       not_saved:
-        other: "%{count} kesalahan melarang %{resource} ini disimpan:"
-      too_many_marks: menggunakan terlalu banyak tanda baca (misalnya! dan?)
-      too_much_caps: menggunakan terlalu banyak huruf besar (lebih dari 25% dari teks)
-      too_short: terlalu pendek (kurang dari 15 karakter)
+        one: '1 error prohibited this %{resource} from being saved:'
+        other: "%{count} errors prohibited this %{resource} from being saved:"
+      too_many_marks: is using too many consecutive punctuation marks (e.g. ! and ?)
+      too_much_caps: is using too many capital letters (over 25% of the text)
+      too_short: is too short (under 15 characters)
   forms:
-    required: Wajib
+    required: Required
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
-    sentence_for_humans: Jika Anda manusia, abaikan bidang ini
-    timestamp_error_message: Maaf, itu terlalu cepat! Silakan kirim ulang.
+    sentence_for_humans: If you are human, ignore this field
+    timestamp_error_message: Sorry, that was too quick! Please resubmit.
   layouts:
     decidim:
       cookie_warning:
-        description_html: Situs ini menggunakan cookie. Dengan melanjutkan menelusuri situs, Anda menyetujui penggunaan cookie kami. Cari tahu lebih banyak tentang itu %{link}.
-        link_label: sini
-        ok: saya setuju
+        description_html: This site uses cookies. By continuing to browse the site, you agree to our use of cookies. Find out more about it %{link}.
+        link_label: here
+        ok: I agree
       edit_link:
         edit: Edit
       footer:
-        download_open_data: Unduh file Open Data
-        made_with_open_source: Situs web dibuat dengan <a target="_blank" href="https://github.com/decidim/decidim">perangkat lunak gratis</a>.
+        download_open_data: Download Open Data files
+        made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
       header:
-        close_menu: Tutup menu
-        navigation: Navigasi
-        sign_in: Masuk
-        sign_up: Daftar
+        close_menu: Close menu
+        navigation: Navigation
+        sign_in: Sign In
+        sign_up: Sign Up
       impersonation_warning:
-        close_session: Tutup sesi
-        description_html: Anda meniru identitas pengguna <b>%{user_name}</b>.
-        expire_time_html: Sesi Anda akan berakhir dalam <b><span class="minutes">%{minutes}</span> menit</b>.
+        close_session: Close session
+        description_html: You are impersonating the user <b>%{user_name}</b>.
+        expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       notifications_dashboard:
-        mark_all_as_read: tandai semua telah dibaca
+        mark_all_as_read: Mark all as read
       user_menu:
-        admin_dashboard: Dasbor admin
-        conversations: Percakapan
-        notifications: Notifikasi
-        profile: Akun saya
-        public_profile: Profil publik saya
-        sign_out: Keluar
+        admin_dashboard: Admin dashboard
+        conversations: Conversations
+        notifications: Notifications
+        profile: My account
+        public_profile: My public profile
+        sign_out: Sign out
       user_profile:
-        account: Rekening
-        authorizations: Otorisasi
-        delete_my_account: Hapus akun Saya
-        my_data: Data saya
-        my_interests: Minat saya
-        notifications_settings: Pengaturan Notifikasi
-        title: Pengaturan pengguna
-        user_groups: Grup
+        account: Account
+        authorizations: Authorizations
+        delete_my_account: Delete my account
+        my_data: My data
+        my_interests: My interests
+        notifications_settings: Notifications settings
+        title: User settings
+        user_groups: Groups
       widget:
-        see_more: Lihat lebih banyak
+        see_more: See more
   locale:
-    name: Inggris
+    name: English
   password_validator:
-    domain_included_in_password: terlalu mirip dengan nama domain ini
-    email_included_in_password: terlalu mirip dengan email Anda
-    fallback: tidak valid
-    name_included_in_password: terlalu mirip dengan nama Anda
-    not_enough_unique_characters: tidak memiliki karakter unik yang cukup
-    password_not_allowed: tidak diizinkan
-    password_too_common: terlalu umum
-    password_too_long: terlalu panjang
-    password_too_short: terlalu pendek
+    domain_included_in_password: is too similar to this domain name
+    email_included_in_password: is too similar to your email
+    fallback: is not valid
+    name_included_in_password: is too similar to your name
+    not_enough_unique_characters: does not have enough unique characters
+    password_not_allowed: is not allowed
+    password_too_common: is too common
+    password_too_long: is too long
+    password_too_short: is too short
   social_share_button:
-    delicious: Lezat
+    delicious: Delicious
     douban: Douban
-    email: E-mail
+    email: Email
     facebook: Facebook
     google_bookmark: Google Bookmark
     google_plus: Google+
-    hacker_news: Berita Hacker
+    hacker_news: Hacker News
     linkedin: Linkedin
     pinterest: Pinterest
     qq: Qzone
     reddit: Reddit
-    share_to: Bagikan ke %{name}
+    share_to: Share to %{name}
     tumblr: Tumblr
-    twitter: Kericau
+    twitter: Twitter
     vkontakte: Vkontakte
-    wechat: Wechat
-    wechat_footer: Buka WeChat Anda, klik tombol "Temukan" lalu klik menu "Pindai Kode QR".
+    wechat: WeChat
+    wechat_footer: Open your WeChat, click "Discover" button then click the "Scan QR Code" menu.
     weibo: Sina Weibo
     xing: Xing
   time:
@@ -1250,8 +1270,8 @@ id:
       time_of_day: "%H:%M"
   views:
     pagination:
-      first: "&laquo; Pertama"
-      last: '&raquo;Terakhir'
-      next: Berikutnya &rsaquo;
-      previous: "&lsaquo; Sebelumnya"
+      first: "&laquo; First"
+      last: Last &raquo;
+      next: Next &rsaquo;
+      previous: "&lsaquo; Prev"
       truncate: "&hellip;"

--- a/decidim-core/config/locales/it.yml
+++ b/decidim-core/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ it:
         personal_url: URL personale
         remove_avatar: Rimuovi avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Allegato
       decidim/component_published_event: Componente attivo
       decidim/demoted_membership: Non è più un amministratore di gruppo
@@ -46,7 +51,7 @@ it:
         other: Gruppi di utenti
   booleans:
     'false': 'No'
-    'true': 'Si'
+    'true': Si
   carrierwave:
     errors:
       image_too_big: L'immagine è troppo grande
@@ -136,12 +141,12 @@ it:
       amendable:
         amended_by: Modificato da
         button: Modificare %{model_name}
-        promote_button: Promuovi a %{model_name}
         error: Si è verificato un errore durante la modifica di questa risorsa.
         help_text: Migliora questo %{model_name} modificando il suo %{amendable_fields}
-        promote_help_text: Puoi promuovere questa emendazione e pubblicarla come %{model_name}indipendente
         no_amenders: Non ci sono emendatori
         no_amendments: Non ci sono modifiche
+        promote_button: Promuovi a %{model_name}
+        promote_help_text: Puoi promuovere questa emendazione e pubblicarla come %{model_name}indipendente
         section_heading: Modifiche (%{count})
       created:
         error: Si è verificato un errore durante la creazione di questo emendamento, riprovare più tardi
@@ -170,12 +175,12 @@ it:
         heading: Crea il tuo emendamento
         help_text: Stai modificando lo %{model_name}
         send: Invia un emendamento
+      promoted:
+        error: Ci sono stati errori nel promuovere l'emendamento
+        success: Emendation promossa con successo
       rejected:
         error: Si è verificato un errore durante il rifiuto di questa modifica, riprova più tardi
         success: L'emendamento è stato respinto con successo
-      promoted:
-        success: Emendation promossa con successo
-        error: Ci sono stati errori nel promuovere l'emendamento
       review:
         back: Indietro
         heading: Rivedi l'emendamento
@@ -384,39 +389,6 @@ it:
         title: La pagina che stai cercando non è stata trovata
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Una nuova emendazione è stata creata per %{amendable_title}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
-            email_subject: Un nuovo emendamento per %{amendable_title} da %{emendation_author_nickname}
-            notification_title: Un <a href="%{emendation_path}">nuovo emendation</a> è stato creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Una nuova emendazione è stata creata per %{amendable_title}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
-            email_subject: Un nuovo emendamento per %{amendable_title} da %{emendation_author_nickname}
-            notification_title: Un <a href="%{emendation_path}">nuovo emendation</a> è stato creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Un''emissione è stata rifiutata per %{amendable_title}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
-            email_subject: Un emendamento respinto per %{amendable_title} %{emendation_author_nickname}
-            notification_title: Il <a href="%{emendation_path}">emendation</a> creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> è stata rifiutata per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Un''emissione è stata rifiutata per %{amendable_title}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
-            email_subject: Un emendamento respinto per %{amendable_title} %{emendation_author_nickname}
-            notification_title: Il <a href="%{emendation_path}">emendation</a> creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> è stata rifiutata per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Un emendamento respinto per %{amendable_title} è stato promosso a un indipendente %{amendable_type}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
-            email_subject: È stata promossa un'emendamento da %{emendation_author_nickname}
-            notification_title: Un'emendamento rifiutato <a href="%{emendation_path}"></a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} è stato promosso da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Un emendamento respinto per %{amendable_title} è stato promosso a un indipendente %{amendable_type}. Puoi vederlo da questa pagina:'
-            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
-            email_subject: È stata promossa un'emendamento da %{emendation_author_nickname}
-            notification_title: Un'emendamento rifiutato <a href="%{emendation_path}"></a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} è stato promosso da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Un''emendamento è stato accettato per %{amendable_title}. Puoi vederlo da questa pagina:'
@@ -428,6 +400,39 @@ it:
             email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
             email_subject: Un emendamento accettato per %{amendable_title} %{emendation_author_nickname}
             notification_title: Il <a href="%{emendation_path}">emendation</a> creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> è stato accettato per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Una nuova emendazione è stata creata per %{amendable_title}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
+            email_subject: Un nuovo emendamento per %{amendable_title} da %{emendation_author_nickname}
+            notification_title: Un <a href="%{emendation_path}">nuovo emendation</a> è stato creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Una nuova emendazione è stata creata per %{amendable_title}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
+            email_subject: Un nuovo emendamento per %{amendable_title} da %{emendation_author_nickname}
+            notification_title: Un <a href="%{emendation_path}">nuovo emendation</a> è stato creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Un emendamento respinto per %{amendable_title} è stato promosso a un indipendente %{amendable_type}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
+            email_subject: È stata promossa un'emendamento da %{emendation_author_nickname}
+            notification_title: Un'emendamento rifiutato <a href="%{emendation_path}"></a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} è stato promosso da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Un emendamento respinto per %{amendable_title} è stato promosso a un indipendente %{amendable_type}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
+            email_subject: È stata promossa un'emendamento da %{emendation_author_nickname}
+            notification_title: Un'emendamento rifiutato <a href="%{emendation_path}"></a> per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} è stato promosso da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Un''emissione è stata rifiutata per %{amendable_title}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché sei un autore di %{amendable_title}.
+            email_subject: Un emendamento respinto per %{amendable_title} %{emendation_author_nickname}
+            notification_title: Il <a href="%{emendation_path}">emendation</a> creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> è stata rifiutata per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Un''emissione è stata rifiutata per %{amendable_title}. Puoi vederlo da questa pagina:'
+            email_outro: Hai ricevuto questa notifica perché stai seguendo %{amendable_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
+            email_subject: Un emendamento respinto per %{amendable_title} %{emendation_author_nickname}
+            notification_title: Il <a href="%{emendation_path}">emendation</a> creato da <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> è stata rifiutata per <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Un nuovo documento è stato aggiunto a %{resource_title}. Puoi vederlo da questa pagina:'
@@ -547,7 +552,7 @@ it:
       badges:
         continuity:
           conditions:
-            - Vieni qui spesso
+          - Vieni qui spesso
           description: Questo badge è concesso quando visiti la piattaforma in modo regolare. Ci piace averti qui intorno!
           description_another: Questo utente si è connesso per %{score} giorni consecutivi ad un certo punto.
           description_own: Hai collegato per %{score} giorni consecutivi ad un certo punto.
@@ -557,7 +562,7 @@ it:
           unearned_own: Non ti sei connesso per più di un giorno consecutivo.
         followers:
           conditions:
-            - Essere attivi e seguire altre persone sicuramente farà sì che altre persone ti seguano.
+          - Essere attivi e seguire altre persone sicuramente farà sì che altre persone ti seguano.
           description: Questo badge è concesso quando raggiungi un certo numero di follower. %{organization_name} è una rete sociale e politica, intreccia la tua rete per comunicare con altre persone nella piattaforma.
           description_another: Questo utente ha %{score} follower.
           description_own: "%{score} utenti ti stanno seguendo."
@@ -572,9 +577,9 @@ it:
           title: badge
         invitations:
           conditions:
-            - Usa il link "invita amici" nella tua pagina utente per invitare i tuoi amici
-            - Personalizza, se vuoi, il messaggio che stai inviando
-            - Aumenterai di livello inviando inviti e registrandoli.
+          - Usa il link "invita amici" nella tua pagina utente per invitare i tuoi amici
+          - Personalizza, se vuoi, il messaggio che stai inviando
+          - Aumenterai di livello inviando inviti e registrandoli.
           description: Questo badge è concesso quando hai invitato alcune persone e hanno trascorso un po 'di tempo per registrarsi in %{organization_name} e diventare partecipanti. Grazie per aver reso %{organization_name} conoscere agli altri e contribuendo ad ampliare la comunità!
           description_another: Questo utente ha invitato %{score} utenti.
           description_own: Hai invitato %{score} utenti.
@@ -787,8 +792,8 @@ it:
       show:
         email_on_notification: Voglio ricevere un'e-mail ogni volta che ricevo una notifica.
         everything_followed: Tutto ciò che seguo
-        newsletters: Newsletters
         newsletter_notifications: Voglio ricevere le newsletter
+        newsletters: Newsletters
         own_activity: La mia attività personale, come quando qualcuno commenta la mia proposta o mi menziona
         receive_notifications_about: Voglio ricevere le notifiche
         send_notifications_by_email: Invia notifiche via email
@@ -854,10 +859,6 @@ it:
         subheading: Navigare attraverso le pagine di aiuto di %{name}
         title: Aiuto
         topics: Temi
-      participatory_space:
-        metrics:
-          headline: Partecipazione in cifre
-          link: Mostra tutte le statistiche
       terms_and_conditions:
         accept:
           error: Si è verificato un errore durante l'accettazione dei termini e delle condizioni.
@@ -882,6 +883,7 @@ it:
       deleted: Utente eliminato
       view: vista
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Questo gruppo di utenti è verificato pubblicamente, il suo nome è stato verificato per corrispondere con il suo vero nome
       default_officialization_text_for_users: Questo partecipante è verificato pubblicamente, il suo nome o ruolo è stato verificato per corrispondere con il suo vero nome e ruolo
       show:
@@ -993,8 +995,8 @@ it:
         no_activities_warning: Questo utente non ha ancora avuto alcuna attività.
     user_interests:
       show:
-        no_scopes: Questa organizzazione non ha ancora alcun scopo!
         my_interests: I miei interessi
+        no_scopes: Questa organizzazione non ha ancora alcun scopo!
         select_your_interests: Seleziona gli argomenti a cui sei interessato per ricevere eventi correlati a loro nella scheda Cronologia del profilo.
         update_my_interests: Aggiorna i miei interessi
       update:
@@ -1013,11 +1015,11 @@ it:
     failure:
       already_authenticated: Sei già iscritto.
       inactive: Il tuo account non è ancora attivato.
-      invalid: '%{authentication_keys} o password non validi.'
+      invalid: "%{authentication_keys} o password non validi."
       invited: Hai un invito in sospeso, accettalo per completare la creazione del tuo account.
       last_attempt: Hai ancora un tentativo prima che il tuo account sia bloccato.
       locked: Il tuo account è bloccato.
-      not_found_in_database: '%{authentication_keys} o password non validi.'
+      not_found_in_database: "%{authentication_keys} o password non validi."
       timeout: La tua sessione è scaduta. Per favore accedi di nuovo per continuare.
       unauthenticated: È necessario accedere o registrarsi prima di continuare.
     invitations:
@@ -1168,6 +1170,17 @@ it:
       too_short: è troppo corto (meno di 15 caratteri)
   forms:
     required: Richiesto
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Se sei una persona e non un computer, ignora questo campo
     timestamp_error_message: Mi dispiace, troppo veloce! Per favore, invia di nuovo.

--- a/decidim-core/config/locales/nl.yml
+++ b/decidim-core/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ nl:
         personal_url: Persoonlijke URL
         remove_avatar: Verwijder avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: gehechtheid
       decidim/component_published_event: Actieve component
       decidim/demoted_membership: Niet langer een groepsbeheerder
@@ -45,8 +50,8 @@ nl:
         one: Gebruikersgroep
         other: Gebruikersgroepen
   booleans:
-    'false': 'Nee'
-    'true': 'Ja'
+    'false': Nee
+    'true': Ja
   carrierwave:
     errors:
       image_too_big: De afbeelding is te groot
@@ -136,12 +141,12 @@ nl:
       amendable:
         amended_by: Gewijzigd door
         button: Wijzigen %{model_name}
-        promote_button: Promoot tot %{model_name}
         error: Er is een fout opgetreden bij het wijzigen van deze bron.
         help_text: Verbeter deze %{model_name} door zijn %{amendable_fields}
-        promote_help_text: U kunt deze emendatie promoten en publiceren als een onafhankelijke %{model_name}
         no_amenders: Er zijn geen amendementen
         no_amendments: Er zijn geen amendementen
+        promote_button: Promoot tot %{model_name}
+        promote_help_text: U kunt deze emendatie promoten en publiceren als een onafhankelijke %{model_name}
         section_heading: Wijzigingen (%{count})
       created:
         error: Er is een fout opgetreden bij het maken van dit amendement, probeer het later opnieuw
@@ -170,12 +175,12 @@ nl:
         heading: Maak uw amendement
         help_text: U wijzigt de %{model_name}
         send: Verzend amendement
+      promoted:
+        error: Er zijn fouten opgetreden bij het promoten van de emendation
+        success: Emendation met succes gepromoot
       rejected:
         error: Er is een fout opgetreden bij het afwijzen van deze emendatie. Probeer het later opnieuw
         success: De emendation is met succes afgewezen
-      promoted:
-        success: Emendation met succes gepromoot
-        error: Er zijn fouten opgetreden bij het promoten van de emendation
       review:
         back: Terug
         heading: Bekijk het amendement
@@ -384,39 +389,6 @@ nl:
         title: De opgevraagde pagina kan niet gevonden worden
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Er is een nieuwe emendation gemaakt voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
-            email_subject: Een nieuw amendement voor %{amendable_title} van %{emendation_author_nickname}
-            notification_title: Een <a href="%{emendation_path}">nieuwe emendatie</a> is gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Er is een nieuwe emendation gemaakt voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
-            email_subject: Een nieuw amendement voor %{amendable_title} van %{emendation_author_nickname}
-            notification_title: Een <a href="%{emendation_path}">nieuwe emendatie</a> is gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Een emendation is afgewezen voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
-            email_subject: Een amendement afgewezen voor %{amendable_title} van %{emendation_author_nickname}
-            notification_title: De <a href="%{emendation_path}">emendation</a> gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> is afgewezen voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Een emendation is afgewezen voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
-            email_subject: Een amendement afgewezen voor %{amendable_title} van %{emendation_author_nickname}
-            notification_title: De <a href="%{emendation_path}">emendation</a> gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> is afgewezen voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Een emendatie afgewezen voor %{amendable_title} is gepromoveerd tot een onafhankelijke %{amendable_type}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
-            email_subject: Een emendation van %{emendation_author_nickname} is gepromoot
-            notification_title: Een <a href="%{emendation_path}">afgewezen emendation</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} is gepromoot met <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Een emendatie afgewezen voor %{amendable_title} is gepromoveerd tot een onafhankelijke %{amendable_type}. Je kunt het vanaf deze pagina bekijken:'
-            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
-            email_subject: Een emendation van %{emendation_author_nickname} is gepromoot
-            notification_title: Een <a href="%{emendation_path}">afgewezen emendation</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} is gepromoot met <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Een emendation is geaccepteerd voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
@@ -428,6 +400,39 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
             email_subject: Een amendement geaccepteerd voor %{amendable_title} van %{emendation_author_nickname}
             notification_title: De <a href="%{emendation_path}">emendation</a> gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> is geaccepteerd voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Er is een nieuwe emendation gemaakt voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
+            email_subject: Een nieuw amendement voor %{amendable_title} van %{emendation_author_nickname}
+            notification_title: Een <a href="%{emendation_path}">nieuwe emendatie</a> is gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Er is een nieuwe emendation gemaakt voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
+            email_subject: Een nieuw amendement voor %{amendable_title} van %{emendation_author_nickname}
+            notification_title: Een <a href="%{emendation_path}">nieuwe emendatie</a> is gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Een emendatie afgewezen voor %{amendable_title} is gepromoveerd tot een onafhankelijke %{amendable_type}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
+            email_subject: Een emendation van %{emendation_author_nickname} is gepromoot
+            notification_title: Een <a href="%{emendation_path}">afgewezen emendation</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} is gepromoot met <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Een emendatie afgewezen voor %{amendable_title} is gepromoveerd tot een onafhankelijke %{amendable_type}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
+            email_subject: Een emendation van %{emendation_author_nickname} is gepromoot
+            notification_title: Een <a href="%{emendation_path}">afgewezen emendation</a> voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} is gepromoot met <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Een emendation is afgewezen voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u een auteur bent van %{amendable_title}.
+            email_subject: Een amendement afgewezen voor %{amendable_title} van %{emendation_author_nickname}
+            notification_title: De <a href="%{emendation_path}">emendation</a> gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> is afgewezen voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Een emendation is afgewezen voor %{amendable_title}. Je kunt het vanaf deze pagina bekijken:'
+            email_outro: U hebt deze melding ontvangen omdat u %{amendable_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
+            email_subject: Een amendement afgewezen voor %{amendable_title} van %{emendation_author_nickname}
+            notification_title: De <a href="%{emendation_path}">emendation</a> gemaakt door <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> is afgewezen voor <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Een nieuw document we’d toegevoegd aan %{resource_title}. Je kan het via deze link bekijken:'
@@ -547,7 +552,7 @@ nl:
       badges:
         continuity:
           conditions:
-            - Kom hier vaker
+          - Kom hier vaker
           description: Deze badge wordt toegekend wanneer u het platform op een reguliere manier bezoekt. We vinden het leuk om je hier in de buurt te hebben!
           description_another: Deze gebruiker heeft op een gegeven moment %{score} opeenvolgende dagen verbonden.
           description_own: Je hebt op een gegeven moment %{score} opeenvolgende dagen verbonden.
@@ -557,7 +562,7 @@ nl:
           unearned_own: Je hebt niet langer dan één opeenvolgende dag verbonden.
         followers:
           conditions:
-            - Actief zijn en andere mensen volgen, zal ervoor zorgen dat andere mensen je volgen.
+          - Actief zijn en andere mensen volgen, zal ervoor zorgen dat andere mensen je volgen.
           description: Deze badge wordt toegekend wanneer u een bepaald aantal volgers bereikt. %{organization_name} is een sociaal en politiek netwerk, weven uw web om te communiceren met andere mensen op het platform.
           description_another: Deze gebruiker heeft %{score} volgers.
           description_own: "%{score} gebruikers volgen u."
@@ -572,9 +577,9 @@ nl:
           title: badges
         invitations:
           conditions:
-            - Gebruik de link "Vrienden uitnodigen" op uw gebruikerspagina om uw vrienden uit te nodigen
-            - Pas, als u wilt, het bericht aan dat u verzendt
-            - Je komt op een niveau door uitnodigingen te versturen en ze te laten registreren.
+          - Gebruik de link "Vrienden uitnodigen" op uw gebruikerspagina om uw vrienden uit te nodigen
+          - Pas, als u wilt, het bericht aan dat u verzendt
+          - Je komt op een niveau door uitnodigingen te versturen en ze te laten registreren.
           description: Deze badge wordt toegekend als je enkele mensen hebt uitgenodigd en ze hebben een beetje tijd besteed om je in %{organization_name} te registreren en deelnemers te worden. Dank u voor u %{organization_name} bekend bij anderen en het helpen om de community uit te breiden!
           description_another: Deze gebruiker heeft %{score} gebruikers uitgenodigd.
           description_own: Je hebt %{score} gebruikers uitgenodigd.
@@ -787,8 +792,8 @@ nl:
       show:
         email_on_notification: Ik wil een e-mail ontvangen telkens als ik een melding krijg.
         everything_followed: Alles wat ik volg
-        newsletters: nieuwsbrieven
         newsletter_notifications: Ik wil de nieuwsbrief ontvangen
+        newsletters: nieuwsbrieven
         own_activity: Mijn eigen activiteit, zoals wanneer iemand opmerkingen maakt in mijn voorstel of mij vermeldt
         receive_notifications_about: Ik wil meldingen ontvangen over
         send_notifications_by_email: Verstuur meldingen per e-mail
@@ -854,10 +859,6 @@ nl:
         subheading: Navigeer door de helppagina's van %{name}
         title: Helpen
         topics: Onderwerpen
-      participatory_space:
-        metrics:
-          headline: Deelname aan cijfers
-          link: Toon alle statistieken
       terms_and_conditions:
         accept:
           error: Er is een fout opgetreden bij het accepteren van de algemene voorwaarden.
@@ -882,6 +883,7 @@ nl:
       deleted: Verwijderde gebruiker
       view: Uitzicht
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Deze gebruikersgroep is openbaar geverifieerd, de naam is geverifieerd om overeen te komen met de echte naam
       default_officialization_text_for_users: Deze deelnemer wordt publiekelijk geverifieerd, zijn/haar naam of rol is geverifieerd om overeen te komen met zijn/haar echte naam en rol
       show:
@@ -993,8 +995,8 @@ nl:
         no_activities_warning: Deze gebruiker heeft nog geen activiteit gehad.
     user_interests:
       show:
-        no_scopes: Deze organisatie heeft nog geen bereik!
         my_interests: Mijn interesses
+        no_scopes: Deze organisatie heeft nog geen bereik!
         select_your_interests: Selecteer de onderwerpen waarin u geïnteresseerd bent om aan hen gerelateerde evenementen te ontvangen op het tabblad Tijdlijn van uw profiel.
         update_my_interests: Update mijn interesses
       update:
@@ -1168,6 +1170,17 @@ nl:
       too_short: is te kort (minder dan 15 tekens)
   forms:
     required: Vereist
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Als u een mens bent negeert u dit veld
     timestamp_error_message: Sorry, dat was te snel! Gelieve opnieuw in te dienen.

--- a/decidim-core/config/locales/pl.yml
+++ b/decidim-core/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ pl:
         personal_url: Osobisty URL
         remove_avatar: Usuń awatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Załącznik
       decidim/component_published_event: Aktywny składnik
       decidim/demoted_membership: Nie jest już administratorem grupy
@@ -36,23 +41,23 @@ pl:
         remember_me: Zapamiętaj mnie
     models:
       decidim/amendment:
-        one: Poprawka
         few: Poprawki
         many: Poprawki
+        one: Poprawka
         other: Poprawki
       decidim/user:
-        one: Brak użytkowników
         few: Użytkownicy
         many: Użytkownicy
+        one: Brak użytkowników
         other: Użytkownicy
       decidim/user_group:
-        one: Grupa użytkowników
         few: Grupy użytkowników
         many: Grupy użytkowników
+        one: Grupa użytkowników
         other: Grupy użytkowników
   booleans:
-    'false': 'Nie'
-    'true': 'Tak'
+    'false': Nie
+    'true': Tak
   carrierwave:
     errors:
       image_too_big: Obraz jest zbyt duży
@@ -142,12 +147,12 @@ pl:
       amendable:
         amended_by: Zmienione przez
         button: Zmień %{model_name}
-        promote_button: Promuj do %{model_name}
         error: Wystąpił błąd podczas zmiany tego zasobu.
         help_text: Popraw to %{model_name} , modyfikując %{amendable_fields}
-        promote_help_text: Możesz promować to wyróżnienie i opublikować je jako niezależne %{model_name}
         no_amenders: Nie ma żadnych fałszerstw
         no_amendments: Brak zmian
+        promote_button: Promuj do %{model_name}
+        promote_help_text: Możesz promować to wyróżnienie i opublikować je jako niezależne %{model_name}
         section_heading: Poprawki (%{count})
       created:
         error: Wystąpił błąd podczas tworzenia tej poprawki, spróbuj ponownie później
@@ -176,12 +181,12 @@ pl:
         heading: Utwórz poprawkę
         help_text: Modyfikujesz %{model_name}
         send: Wyślij poprawkę
+      promoted:
+        error: Podczas promowania wyemitowania wystąpiły błędy
+        success: Emedycja została pomyślnie awansowana
       rejected:
         error: Wystąpił błąd podczas odrzucania tej poprawki, spróbuj ponownie później
         success: Emendacja została odrzucona pomyślnie
-      promoted:
-        success: Emedycja została pomyślnie awansowana
-        error: Podczas promowania wyemitowania wystąpiły błędy
       review:
         back: Z powrotem
         heading: Przejrzyj poprawkę
@@ -191,9 +196,9 @@ pl:
     application:
       collection:
         documents:
-          one: Dokument
           few: Dokumenty
           many: Dokumenty
+          one: Dokument
           other: Dokumenty
       documents:
         related_documents: Powiązane dokumenty
@@ -201,9 +206,9 @@ pl:
         related_photos: Powiązane zdjęcia
     author:
       comments:
-        one: komentarz
         few: komentarze
         many: komentarze
+        one: komentarz
         other: komentarze
     authorization_handlers:
       another_dummy_authorization_handler:
@@ -265,9 +270,9 @@ pl:
           title: Potwierdź swój email
     collapsible_list:
       hidden_elements_count:
-        one: i %{count} więcej
         few: i %{count} więcej
         many: i %{count} więcej
+        one: i %{count} więcej
         other: i %{count} więcej
       see_less: "(patrz mniej)"
       see_more: "(Zobacz więcej)"
@@ -396,39 +401,6 @@ pl:
         title: Szukana strona nie została znaleziona
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Nowa emisja została utworzona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
-            email_subject: Nowa poprawka dla %{amendable_title} z %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">nowy poprawka</a> został utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Nowa emisja została utworzona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
-            email_subject: Nowa poprawka dla %{amendable_title} z %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">nowy poprawka</a> został utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Emendacja została odrzucona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
-            email_subject: Poprawka odrzucona dla %{amendable_title} z %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">poprawka</a> utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> została odrzucona <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Emendacja została odrzucona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
-            email_subject: Poprawka odrzucona dla %{amendable_title} z %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">poprawka</a> utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> została odrzucona <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Emendacja odrzucona dla %{amendable_title} została awansowana na niezależną %{amendable_type}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
-            email_subject: Promowane od %{emendation_author_nickname} zostało promowane
-            notification_title: Odrzucona <a href="%{emendation_path}">emisja</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} została zwiększona o <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Emendacja odrzucona dla %{amendable_title} została awansowana na niezależną %{amendable_type}. Możesz go zobaczyć na tej stronie:'
-            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
-            email_subject: Promowane od %{emendation_author_nickname} zostało promowane
-            notification_title: Odrzucona <a href="%{emendation_path}">emisja</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} została zwiększona o <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Emendacja została zaakceptowana dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
@@ -440,6 +412,39 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
             email_subject: Poprawka przyjęta dla %{amendable_title} z %{emendation_author_nickname}
             notification_title: <a href="%{emendation_path}">poprawka</a> utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> został przyjęty do <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Nowa emisja została utworzona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
+            email_subject: Nowa poprawka dla %{amendable_title} z %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">nowy poprawka</a> został utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Nowa emisja została utworzona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
+            email_subject: Nowa poprawka dla %{amendable_title} z %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">nowy poprawka</a> został utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Emendacja odrzucona dla %{amendable_title} została awansowana na niezależną %{amendable_type}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
+            email_subject: Promowane od %{emendation_author_nickname} zostało promowane
+            notification_title: Odrzucona <a href="%{emendation_path}">emisja</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} została zwiększona o <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Emendacja odrzucona dla %{amendable_title} została awansowana na niezależną %{amendable_type}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
+            email_subject: Promowane od %{emendation_author_nickname} zostało promowane
+            notification_title: Odrzucona <a href="%{emendation_path}">emisja</a> dla <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} została zwiększona o <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Emendacja została odrzucona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem %{amendable_title}.
+            email_subject: Poprawka odrzucona dla %{amendable_title} z %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">poprawka</a> utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> została odrzucona <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Emendacja została odrzucona dla %{amendable_title}. Możesz go zobaczyć na tej stronie:'
+            email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{amendable_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
+            email_subject: Poprawka odrzucona dla %{amendable_title} z %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">poprawka</a> utworzony przez <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> została odrzucona <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Nowy dokument został dodany do %{resource_title}. Możesz go zobaczyć na tej stronie:'
@@ -559,7 +564,7 @@ pl:
       badges:
         continuity:
           conditions:
-            - Chodź tu często
+          - Chodź tu często
           description: Ta odznaka jest przyznawana podczas regularnego odwiedzania platformy. Lubimy mieć cię tutaj!
           description_another: Ten użytkownik nawiązał połączenie przez %{score} kolejnych dni w pewnym momencie.
           description_own: W pewnym momencie łączyłeś się przez %{score} kolejnych dni.
@@ -569,7 +574,7 @@ pl:
           unearned_own: Nie łączyłeś się przez więcej niż jeden kolejny dzień.
         followers:
           conditions:
-            - Bycie aktywnym i podążanie za innymi ludźmi z pewnością sprawi, że inne osoby będą za Tobą podążać.
+          - Bycie aktywnym i podążanie za innymi ludźmi z pewnością sprawi, że inne osoby będą za Tobą podążać.
           description: Ta odznaka jest przyznawana, gdy dotrzesz do określonej liczby obserwujących. %{organization_name} to sieć społeczna i polityczna, tkanie sieci w celu komunikowania się z innymi osobami na platformie.
           description_another: Ten użytkownik ma %{score} obserwujących.
           description_own: "%{score} użytkowników obserwuje Ciebie."
@@ -584,9 +589,9 @@ pl:
           title: Odznaki
         invitations:
           conditions:
-            - Użyj linku "zaproś znajomych" na swojej stronie użytkownika, aby zaprosić znajomych
-            - Dostosuj, jeśli chcesz, wiadomość, którą wysyłasz
-            - Możesz awansować na wyższy poziom, wysyłając zaproszenia i rejestrując je.
+          - Użyj linku "zaproś znajomych" na swojej stronie użytkownika, aby zaprosić znajomych
+          - Dostosuj, jeśli chcesz, wiadomość, którą wysyłasz
+          - Możesz awansować na wyższy poziom, wysyłając zaproszenia i rejestrując je.
           description: Ta odznaka jest przyznawana, gdy zaprosiłeś niektórych ludzi i spędzili trochę czasu, aby zarejestrować się w %{organization_name} i zostać uczestnikami. Dziękujemy za udostępnienie %{organization_name} innym osobom i pomoc w rozszerzeniu społeczności!
           description_another: Ten użytkownik właśnie zaprosił %{score} użytkowników.
           description_own: Zaprosiłeś %{score} użytkowników.
@@ -799,8 +804,8 @@ pl:
       show:
         email_on_notification: Chcę otrzymywać wiadomości e-mail za każdym razem otrzymuję powiadomienie.
         everything_followed: Wszystko, co obserwuję
-        newsletters: Biuletyny
         newsletter_notifications: Chcę otrzymywać newslettery
+        newsletters: Biuletyny
         own_activity: Moja własna działalność, np. Kiedy ktoś komentuje moją propozycję lub wspomina mnie
         receive_notifications_about: Chcę otrzymywać powiadomienia
         send_notifications_by_email: Wysyłaj powiadomienia pocztą e-mail
@@ -866,10 +871,6 @@ pl:
         subheading: Przejdź przez strony pomocy %{name}
         title: Wsparcie
         topics: Tematy
-      participatory_space:
-        metrics:
-          headline: Udział w liczbach
-          link: Pokaż wszystkie statystyki
       terms_and_conditions:
         accept:
           error: Wystąpił błąd podczas akceptowania warunków.
@@ -894,6 +895,7 @@ pl:
       deleted: Usunięty użytkownik
       view: Widok
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Ta grupa użytkowników jest publicznie weryfikowana, jej nazwa została zweryfikowana, aby odpowiadała jej prawdziwej nazwie
       default_officialization_text_for_users: Ten uczestnik jest publicznie weryfikowany, jego / jego nazwisko lub rola została zweryfikowana, aby odpowiadała jego / jej prawdziwemu imieniu i roli
       show:
@@ -963,9 +965,9 @@ pl:
         unfold: Rozwijać się
       results:
         results:
-          one: "%{count} wynik"
           few: "%{count} wyników"
           many: "%{count} wyników"
+          one: "%{count} wynik"
           other: "%{count} wyników"
         view_all: Zobacz wszystko (%{count})
     shared:
@@ -1007,8 +1009,8 @@ pl:
         no_activities_warning: Ten użytkownik nie ma jeszcze żadnej aktywności.
     user_interests:
       show:
-        no_scopes: Ta organizacja nie ma jeszcze żadnego zakresu!
         my_interests: Moje zainteresowania
+        no_scopes: Ta organizacja nie ma jeszcze żadnego zakresu!
         select_your_interests: Wybierz tematy, które Cię interesują, aby otrzymywać związane z nimi wydarzenia na karcie Oś czasu w profilu.
         update_my_interests: Zaktualizuj moje zainteresowania
       update:
@@ -1150,9 +1152,9 @@ pl:
         sign_in_with_provider: Zaloguj się, używając %{provider}
         sign_up: Zapisz się
       minimum_password_length:
-        one: "(Minimum%{count} znaków)"
         few: "(Minimum%{count} znaków)"
         many: "(Minimum%{count} znaków)"
+        one: "(Minimum%{count} znaków)"
         other: "(Minimum%{count} znaków)"
     unlocks:
       new:
@@ -1177,15 +1179,26 @@ pl:
       not_found: nie znaleziono
       not_locked: nie był zablokowany
       not_saved:
-        one: '1 błąd uniemożliwił zapisanie tego %{resource}:'
         few: "%{count} błędów uniemożliwiło zapisanie tego %{resource}:"
         many: "%{count} błędów uniemożliwiło zapisanie tego %{resource}:"
+        one: '1 błąd uniemożliwił zapisanie tego %{resource}:'
         other: "%{count} błędów uniemożliwiło zapisanie tego %{resource}:"
       too_many_marks: używa zbyt wielu kolejnych znaków interpunkcyjnych (np.! i?)
       too_much_caps: używa zbyt dużej liczby wielkich liter (ponad 25% tekstu)
       too_short: jest za krótki (poniżej 15 znaków)
   forms:
     required: wymagany
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Jeśli jesteś człowiekiem, zignoruj ​​to pole
     timestamp_error_message: Przepraszam, to było za szybkie! Proszę przesłać ponownie.

--- a/decidim-core/config/locales/pt-BR.yml
+++ b/decidim-core/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ pt-BR:
         personal_url: URL pessoal
         remove_avatar: Excluir avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Anexo
       decidim/component_published_event: Componente ativo
       decidim/demoted_membership: Não é mais um administrador de grupo
@@ -45,8 +50,8 @@ pt-BR:
         one: Grupo de usuários
         other: Grupos de usuários
   booleans:
-    'false': 'Não'
-    'true': 'Sim'
+    'false': Não
+    'true': Sim
   carrierwave:
     errors:
       image_too_big: A imagem é muito grande
@@ -136,12 +141,12 @@ pt-BR:
       amendable:
         amended_by: Alterada pela
         button: Emendar %{model_name}
-        promote_button: Promover para %{model_name}
         error: Houve um erro ao alterar este recurso.
         help_text: Melhore este %{model_name} modificando seu %{amendable_fields}
-        promote_help_text: Você pode promover esta emendação e publicá-la como um %{model_name}independente
         no_amenders: Não há emendas
         no_amendments: Não há alterações
+        promote_button: Promover para %{model_name}
+        promote_help_text: Você pode promover esta emendação e publicá-la como um %{model_name}independente
         section_heading: Alterações (%{count})
       created:
         error: Ocorreu um erro ao criar esta alteração, tente novamente mais tarde
@@ -170,12 +175,12 @@ pt-BR:
         heading: Crie sua emenda
         help_text: Você está modificando o %{model_name}
         send: Enviar emenda
+      promoted:
+        error: Houve erros ao promover a emenda
+        success: Emendação promovida com sucesso
       rejected:
         error: Ocorreu um erro ao rejeitar esta emenda, por favor, tente novamente mais tarde
         success: A emendação foi rejeitada com sucesso
-      promoted:
-        success: Emendação promovida com sucesso
-        error: Houve erros ao promover a emenda
       review:
         back: De volta
         heading: Revise a emenda
@@ -384,39 +389,6 @@ pt-BR:
         title: A página que você procura não pode ser encontrada
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
-            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
-            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
-            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
-            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Uma emendação foi aceita para %{amendable_title}. Você pode ver a partir desta página:'
@@ -428,6 +400,39 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
             email_subject: Uma emenda aceita para %{amendable_title} partir de %{emendation_author_nickname}
             notification_title: O <a href="%{emendation_path}">emendation</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi aceito para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
+            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
+            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
+            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
+            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Um novo documento foi adicionado a %{resource_title}. Você pode vê-lo a partir desta página:'
@@ -547,7 +552,7 @@ pt-BR:
       badges:
         continuity:
           conditions:
-            - Vem aqui com frequência
+          - Vem aqui com frequência
           description: Esse selo é concedido quando você visita a plataforma regularmente. Nós gostamos de ter você por aqui!
           description_another: Este usuário se conectou por %{score} dias consecutivos em algum momento.
           description_own: Você se conectou por %{score} dias consecutivos em algum momento.
@@ -557,7 +562,7 @@ pt-BR:
           unearned_own: Você não se conectou por mais de um dia consecutivo.
         followers:
           conditions:
-            - Ser ativo e seguir outras pessoas certamente fará com que outras pessoas o sigam.
+          - Ser ativo e seguir outras pessoas certamente fará com que outras pessoas o sigam.
           description: Esse selo é concedido quando você alcança um certo número de seguidores. %{organization_name} é uma rede social e política, teça sua web para se comunicar com outras pessoas na plataforma.
           description_another: Esse usuário possui %{score} seguidores.
           description_own: "%{score} usuários estão seguindo você."
@@ -572,9 +577,9 @@ pt-BR:
           title: Distintivos
         invitations:
           conditions:
-            - Use o link "convidar amigos" na sua página de usuário para convidar seus amigos
-            - Personalize, se quiser, a mensagem que você está enviando
-            - Você vai subir de nível enviando convites e recebendo-os registrados.
+          - Use o link "convidar amigos" na sua página de usuário para convidar seus amigos
+          - Personalize, se quiser, a mensagem que você está enviando
+          - Você vai subir de nível enviando convites e recebendo-os registrados.
           description: Esse selo é concedido quando você convidou algumas pessoas e elas gastaram um pouco de tempo para se inscrever em %{organization_name} e se tornarem participantes. Obrigado por fazer %{organization_name} a conhecer aos outros e ajudando a expandir a comunidade!
           description_another: Este usuário convidou %{score} usuários.
           description_own: Você convidou %{score} usuários.
@@ -787,8 +792,8 @@ pt-BR:
       show:
         email_on_notification: Quero receber um email sempre que recebo uma notificação.
         everything_followed: Tudo que eu sigo
-        newsletters: boletins informativos
         newsletter_notifications: Quero receber boletins informativos
+        newsletters: boletins informativos
         own_activity: Minha atividade, como quando alguém comenta minha proposta ou me menciona
         receive_notifications_about: Quero receber notificações sobre
         send_notifications_by_email: Enviar notificações por email
@@ -854,10 +859,6 @@ pt-BR:
         subheading: Navegue pelas páginas de ajuda de %{name}
         title: Ajuda
         topics: Tópicos
-      participatory_space:
-        metrics:
-          headline: Participação em números
-          link: Mostrar todas as estatísticas
       terms_and_conditions:
         accept:
           error: Houve um erro ao aceitar os termos e condições.
@@ -882,6 +883,7 @@ pt-BR:
       deleted: Usuário excluído
       view: Vista
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Este grupo de usuários é verificado publicamente, seu nome foi verificado para corresponder com seu nome real
       default_officialization_text_for_users: Este participante é verificado publicamente, seu nome ou função foi verificada para corresponder com seu nome e função real
       show:
@@ -993,8 +995,8 @@ pt-BR:
         no_activities_warning: Este usuário ainda não possui nenhuma atividade.
     user_interests:
       show:
-        no_scopes: Esta organização ainda não possui nenhum escopo!
         my_interests: Meus interesses
+        no_scopes: Esta organização ainda não possui nenhum escopo!
         select_your_interests: Selecione os tópicos em que você está interessado para receber eventos relacionados a eles na guia Timeline de seu perfil.
         update_my_interests: Atualize meus interesses
       update:
@@ -1013,11 +1015,11 @@ pt-BR:
     failure:
       already_authenticated: Você já está inscrito.
       inactive: Sua conta Ainda não esta ativada.
-      invalid: '%{authentication_keys} inválido ou senha.'
+      invalid: "%{authentication_keys} inválido ou senha."
       invited: Você tem um convite pendente, aceite-o para concluir a criação da sua conta.
       last_attempt: Você tem mais uma tentativa antes que sua conta seja bloqueada.
       locked: Sua conta está bloqueada.
-      not_found_in_database: '%{authentication_keys} inválido ou senha.'
+      not_found_in_database: "%{authentication_keys} inválido ou senha."
       timeout: Sua sessão expirou. Por favor, entre novamente para continuar.
       unauthenticated: Você precisa fazer login ou se inscrever antes de continuar.
     invitations:
@@ -1168,6 +1170,17 @@ pt-BR:
       too_short: é muito curto (menos de 15 caracteres)
   forms:
     required: Requeridos
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Se você é humano, ignore este campo
     timestamp_error_message: Desculpe, isso foi muito rápido! Reenvie.

--- a/decidim-core/config/locales/pt.yml
+++ b/decidim-core/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ pt:
         personal_url: URL pessoal
         remove_avatar: Remover avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Anexo
       decidim/component_published_event: Componente ativo
       decidim/demoted_membership: Não é mais um administrador de grupo
@@ -45,8 +50,8 @@ pt:
         one: Grupo de usuários
         other: Grupos de usuários
   booleans:
-    'false': 'Não'
-    'true': 'Sim'
+    'false': Não
+    'true': Sim
   carrierwave:
     errors:
       image_too_big: A imagem é demasiado grande
@@ -136,12 +141,12 @@ pt:
       amendable:
         amended_by: Alterada pela
         button: Emendar %{model_name}
-        promote_button: Promover para %{model_name}
         error: Houve um erro ao alterar este recurso.
         help_text: Melhore este %{model_name} modificando seu %{amendable_fields}
-        promote_help_text: Você pode promover esta emendação e publicá-la como um %{model_name}independente
         no_amenders: Não há emendas
         no_amendments: Não há alterações
+        promote_button: Promover para %{model_name}
+        promote_help_text: Você pode promover esta emendação e publicá-la como um %{model_name}independente
         section_heading: Alterações (%{count})
       created:
         error: Ocorreu um erro ao criar esta alteração, tente novamente mais tarde
@@ -170,12 +175,12 @@ pt:
         heading: Crie sua emenda
         help_text: Você está modificando o %{model_name}
         send: Enviar emenda
+      promoted:
+        error: Houve erros ao promover a emenda
+        success: Emendação promovida com sucesso
       rejected:
         error: Ocorreu um erro ao rejeitar esta emenda, por favor, tente novamente mais tarde
         success: A emendação foi rejeitada com sucesso
-      promoted:
-        success: Emendação promovida com sucesso
-        error: Houve erros ao promover a emenda
       review:
         back: De volta
         heading: Revise a emenda
@@ -384,39 +389,6 @@ pt:
         title: A página que você procura não pode ser encontrada
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
-            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
-            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
-            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
-            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
-            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
-            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
-            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
-            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'Uma emendação foi aceita para %{amendable_title}. Você pode ver a partir desta página:'
@@ -428,6 +400,39 @@ pt:
             email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
             email_subject: Uma emenda aceita para %{amendable_title} partir de %{emendation_author_nickname}
             notification_title: O <a href="%{emendation_path}">emendation</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi aceito para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
+            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uma nova emendação foi criada para %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma nova emenda para %{amendable_title} partir de %{emendation_author_nickname}
+            notification_title: Uma <a href="%{emendation_path}">nova emenda</a> foi criada por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
+            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'Uma emenda rejeitada por %{amendable_title} foi promovida a um independente %{amendable_type}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma emenda de %{emendation_author_nickname} foi promovida
+            notification_title: A <a href="%{emendation_path}">rejeitada emendação</a> para <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} foi promovida por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque é um autor de %{amendable_title}.
+            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'Uma emenda foi rejeitada por %{amendable_title}. Você pode ver a partir desta página:'
+            email_outro: Você recebeu esta notificação porque está seguindo %{amendable_title}. Você pode parar de receber notificações após o link anterior.
+            email_subject: Uma alteração rejeitada por %{amendable_title} %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">emenda</a> criado por <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> foi rejeitado por <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Um novo documento foi adicionado a %{resource_title}. Você pode vê-lo a partir desta página:'
@@ -547,7 +552,7 @@ pt:
       badges:
         continuity:
           conditions:
-            - Vem aqui com frequência
+          - Vem aqui com frequência
           description: Esse selo é concedido quando você visita a plataforma regularmente. Nós gostamos de ter você por aqui!
           description_another: Este usuário conectou por %{score} dias consecutivos em algum momento.
           description_own: Você se conectou por %{score} dias consecutivos em algum momento.
@@ -557,7 +562,7 @@ pt:
           unearned_own: Você não se conectou por mais de um dia consecutivo.
         followers:
           conditions:
-            - Ser ativo e seguir outras pessoas certamente fará com que outras pessoas o sigam.
+          - Ser ativo e seguir outras pessoas certamente fará com que outras pessoas o sigam.
           description: Esse selo é concedido quando você alcança um certo número de seguidores. %{organization_name} é uma rede social e política, tecer sua web para se comunicar com outras pessoas na plataforma.
           description_another: Esse usuário possui %{score} seguidores.
           description_own: "%{score} usuários estão seguindo você."
@@ -572,9 +577,9 @@ pt:
           title: Distintivos
         invitations:
           conditions:
-            - Use o link "convidar amigos" na sua página de usuário para convidar seus amigos
-            - Personalize, se quiser, a mensagem que você está enviando
-            - Você vai subir de nível enviando convites e registrando-os.
+          - Use o link "convidar amigos" na sua página de usuário para convidar seus amigos
+          - Personalize, se quiser, a mensagem que você está enviando
+          - Você vai subir de nível enviando convites e registrando-os.
           description: Esse selo é concedido quando você convidou algumas pessoas e elas gastaram um pouco de tempo para se inscrever em %{organization_name} e se tornarem participantes. Obrigado por fazer %{organization_name} a conhecer aos outros e ajudando a expandir a comunidade!
           description_another: Este usuário convidou %{score} usuários.
           description_own: Você convidou %{score} usuários.
@@ -787,8 +792,8 @@ pt:
       show:
         email_on_notification: Quero receber um email sempre que recebo uma notificação.
         everything_followed: Tudo que eu sigo
-        newsletters: boletins informativos
         newsletter_notifications: Quero receber boletins informativos
+        newsletters: boletins informativos
         own_activity: Minha atividade, como quando alguém comenta minha proposta ou me menciona
         receive_notifications_about: Quero receber notificações sobre
         send_notifications_by_email: Enviar notificações por email
@@ -854,10 +859,6 @@ pt:
         subheading: Navegue pelas páginas de ajuda de %{name}
         title: Socorro
         topics: Tópicos
-      participatory_space:
-        metrics:
-          headline: Participação em números
-          link: Mostrar todas as estatísticas
       terms_and_conditions:
         accept:
           error: Houve um erro ao aceitar os termos e condições.
@@ -882,6 +883,7 @@ pt:
       deleted: Usuário deletado
       view: Visão
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Este grupo de usuários é verificado publicamente, seu nome foi confirmado para corresponder ao seu nome real
       default_officialization_text_for_users: Este participante é verificado publicamente, seu nome ou função foi verificada para corresponder com seu nome e função real
       show:
@@ -993,8 +995,8 @@ pt:
         no_activities_warning: Este usuário ainda não possui nenhuma atividade.
     user_interests:
       show:
-        no_scopes: Esta organização ainda não possui nenhum escopo!
         my_interests: Meus interesses
+        no_scopes: Esta organização ainda não possui nenhum escopo!
         select_your_interests: Selecione os tópicos em que você está interessado para receber eventos relacionados a eles na guia Timeline de seu perfil.
         update_my_interests: Atualize meus interesses
       update:
@@ -1013,11 +1015,11 @@ pt:
     failure:
       already_authenticated: Você já está inscrito.
       inactive: Sua conta Ainda não esta ativada.
-      invalid: '%{authentication_keys} inválido ou senha.'
+      invalid: "%{authentication_keys} inválido ou senha."
       invited: Você tem um convite pendente, aceite-o para concluir a criação da sua conta.
       last_attempt: Você tem mais uma tentativa antes que sua conta seja bloqueada.
       locked: Sua conta está bloqueada.
-      not_found_in_database: '%{authentication_keys} inválido ou senha.'
+      not_found_in_database: "%{authentication_keys} inválido ou senha."
       timeout: Sua sessão expirou. Por favor, entre novamente para continuar.
       unauthenticated: Você precisa fazer login ou se inscrever antes de continuar.
     invitations:
@@ -1168,6 +1170,17 @@ pt:
       too_short: é muito curto (menos de 15 caracteres)
   forms:
     required: Requeridos
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Se você é humano, ignore este campo
     timestamp_error_message: Desculpe, isso foi muito rápido! Reenvie.

--- a/decidim-core/config/locales/ru.yml
+++ b/decidim-core/config/locales/ru.yml
@@ -16,6 +16,10 @@ ru:
         personal_url: Личный веб-адрес
         remove_avatar: Удалить аватар
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Прикрепленный файл
       decidim/component_published_event: Действующая составляющая
       decidim/demoted_membership: No longer a group admin
@@ -1163,6 +1167,17 @@ ru:
       too_short: is too short (under 15 characters)
   forms:
     required: Обязательно
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Если вы человек, не заполняйте это поле
     timestamp_error_message: Извините, это было слишком быстро! Отправьте, пожалуйста, еще раз.

--- a/decidim-core/config/locales/sv.yml
+++ b/decidim-core/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -15,6 +16,10 @@ sv:
         personal_url: Personlig URL
         remove_avatar: Ta bort avatar
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Bilaga
       decidim/component_published_event: Aktiv komponent
       decidim/demoted_membership: Inte längre en gruppadministratör
@@ -45,8 +50,8 @@ sv:
         one: Användargrupp
         other: Användargrupper
   booleans:
-    'false': 'Nej'
-    'true': 'Ja'
+    'false': Nej
+    'true': Ja
   carrierwave:
     errors:
       image_too_big: Bilden är för stor
@@ -136,12 +141,12 @@ sv:
       amendable:
         amended_by: Ändrad av
         button: Ändra %{model_name}
-        promote_button: Främja till %{model_name}
         error: Det har inträffat ett fel vid ändring av denna resurs.
         help_text: Förbättra detta %{model_name} genom att ändra dess %{amendable_fields}
-        promote_help_text: Du kan marknadsföra denna utgåva och publicera den som en oberoende %{model_name}
         no_amenders: Det finns inga ändringsförslag
         no_amendments: Det finns inga ändringar
+        promote_button: Främja till %{model_name}
+        promote_help_text: Du kan marknadsföra denna utgåva och publicera den som en oberoende %{model_name}
         section_heading: Ändringar (%{count})
       created:
         error: Ett fel uppstod för att skapa detta ändringsförslag, försök igen senare
@@ -170,12 +175,12 @@ sv:
         heading: Skapa ditt ändringsförslag
         help_text: Du ändrar %{model_name}
         send: Skicka ändringsförslag
+      promoted:
+        error: Det har varit fel när man främjar emendationen
+        success: Emendation främjas framgångsrikt
       rejected:
         error: Ett fel uppstod när du avvisade den här utgåvan, var god försök igen senare
         success: Emendationen har avvisats framgångsrikt
-      promoted:
-        success: Emendation främjas framgångsrikt
-        error: Det har varit fel när man främjar emendationen
       review:
         back: Tillbaka
         heading: Granska ändringen
@@ -384,39 +389,6 @@ sv:
         title: Sidan du söker kan inte hittas
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: 'En ny emendation har skapats för %{amendable_title}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
-            email_subject: Ett nytt ändringsförslag för %{amendable_title} från %{emendation_author_nickname}
-            notification_title: En <a href="%{emendation_path}">ny emendation</a> har skapats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'En ny emendation har skapats för %{amendable_title}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
-            email_subject: Ett nytt ändringsförslag för %{amendable_title} från %{emendation_author_nickname}
-            notification_title: En <a href="%{emendation_path}">ny emendation</a> har skapats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'En emendation har avslagits för %{amendable_title}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
-            email_subject: Ett ändringsförslag avvisat för %{amendable_title} från %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendationen</a> skapad av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> har blivit avvisad för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-          follower:
-            email_intro: 'En emendation har avslagits för %{amendable_title}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
-            email_subject: Ett ändringsförslag avvisat för %{amendable_title} från %{emendation_author_nickname}
-            notification_title: <a href="%{emendation_path}">emendationen</a> skapad av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> har blivit avvisad för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
-        amendment_promoted:
-          affected_user:
-            email_intro: 'En emendation som avvisats för %{amendable_title} har blivit promoterad till en oberoende %{amendable_type}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
-            email_subject: En emendation från %{emendation_author_nickname} har blivit befordrad
-            notification_title: En <a href="%{emendation_path}">avvisad emendation</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} har främjats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
-          follower:
-            email_intro: 'En emendation som avvisats för %{amendable_title} har blivit promoterad till en oberoende %{amendable_type}. Du kan se den från den här sidan:'
-            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
-            email_subject: En emendation från %{emendation_author_nickname} har blivit befordrad
-            notification_title: En <a href="%{emendation_path}">avvisad emendation</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} har främjats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
         amendment_accepted:
           affected_user:
             email_intro: 'En emendation har godkänts för %{amendable_title}. Du kan se den från den här sidan:'
@@ -428,6 +400,39 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
             email_subject: Ett ändringsförslag accepterat för %{amendable_title} från %{emendation_author_nickname}
             notification_title: <a href="%{emendation_path}">emendationen</a> skapad av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> har godkänts för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'En ny emendation har skapats för %{amendable_title}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
+            email_subject: Ett nytt ändringsförslag för %{amendable_title} från %{emendation_author_nickname}
+            notification_title: En <a href="%{emendation_path}">ny emendation</a> har skapats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'En ny emendation har skapats för %{amendable_title}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
+            email_subject: Ett nytt ändringsförslag för %{amendable_title} från %{emendation_author_nickname}
+            notification_title: En <a href="%{emendation_path}">ny emendation</a> har skapats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'En emendation som avvisats för %{amendable_title} har blivit promoterad till en oberoende %{amendable_type}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
+            email_subject: En emendation från %{emendation_author_nickname} har blivit befordrad
+            notification_title: En <a href="%{emendation_path}">avvisad emendation</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} har främjats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'En emendation som avvisats för %{amendable_title} har blivit promoterad till en oberoende %{amendable_type}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
+            email_subject: En emendation från %{emendation_author_nickname} har blivit befordrad
+            notification_title: En <a href="%{emendation_path}">avvisad emendation</a> för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} har främjats av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'En emendation har avslagits för %{amendable_title}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du är en författare till %{amendable_title}.
+            email_subject: Ett ändringsförslag avvisat för %{amendable_title} från %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">emendationen</a> skapad av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> har blivit avvisad för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'En emendation har avslagits för %{amendable_title}. Du kan se den från den här sidan:'
+            email_outro: Du har fått den här meddelandet eftersom du följer %{amendable_title}. Du kan sluta ta emot meddelanden efter föregående länk.
+            email_subject: Ett ändringsförslag avvisat för %{amendable_title} från %{emendation_author_nickname}
+            notification_title: <a href="%{emendation_path}">emendationen</a> skapad av <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> har blivit avvisad för <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
           email_intro: 'Ett nytt dokument har lagts till %{resource_title}. Du kan se den från den här sidan:'
@@ -547,7 +552,7 @@ sv:
       badges:
         continuity:
           conditions:
-            - Kommer hit ofta
+          - Kommer hit ofta
           description: Detta märke beviljas när du besöker plattformen på ett vanligt sätt. Vi gillar att ha dig här!
           description_another: Den här användaren har anslutit sig under %{score} på varandra följande dagar vid någon tidpunkt.
           description_own: Du har anslutit dig under %{score} på varandra följande dagar vid någon tidpunkt.
@@ -557,7 +562,7 @@ sv:
           unearned_own: Du har inte anslutit dig under på varandra följande dagar.
         followers:
           conditions:
-            - Att vara aktiv och följa andra människor kommer säkert att få andra att följa dig.
+          - Att vara aktiv och följa andra människor kommer säkert att få andra att följa dig.
           description: Detta märke beviljas när du når ett visst antal följare. %{organization_name} är ett socialt och politiskt nätverk, väv ditt nät för att kommunicera med andra personer på plattformen.
           description_another: Den här användaren har %{score} följare.
           description_own: "%{score} användare följer dig."
@@ -572,9 +577,9 @@ sv:
           title: Märken
         invitations:
           conditions:
-            - Använd länken "bjud in vänner" på din användarsida för att bjuda in dina vänner
-            - Anpassa, om du vill, meddelandet du håller på att skicka
-            - Du kommer att nivåera upp genom att skicka inbjudningar och få dem registrerade.
+          - Använd länken "bjud in vänner" på din användarsida för att bjuda in dina vänner
+          - Anpassa, om du vill, meddelandet du håller på att skicka
+          - Du kommer att nivåera upp genom att skicka inbjudningar och få dem registrerade.
           description: Detta märke beviljas när du har bjudit in några personer och de har spenderat lite tid att registrera sig i %{organization_name} och bli deltagare. Tack för att göra %{organization_name} känt för andra och hjälpa till att utvidga community!
           description_another: Den här användaren har bjudit in %{score} användare.
           description_own: Du har bjudit in %{score} användare.
@@ -787,8 +792,8 @@ sv:
       show:
         email_on_notification: Jag vill få ett e-postmeddelande varje gång jag får en notis.
         everything_followed: Allt jag följer
-        newsletters: nyhetsbrev
         newsletter_notifications: Jag vill få nyhetsbrev
+        newsletters: nyhetsbrev
         own_activity: Min egen verksamhet, som när någon kommenterar i mitt förslag eller nämner mig
         receive_notifications_about: Jag vill få meddelanden om
         send_notifications_by_email: Skicka meddelanden via e-post
@@ -854,10 +859,6 @@ sv:
         subheading: Navigera genom hjälpsidorna till %{name}
         title: Hjälp
         topics: ämnen
-      participatory_space:
-        metrics:
-          headline: Deltagande i siffror
-          link: Visa all statistik
       terms_and_conditions:
         accept:
           error: Det har blivit ett fel när du accepterade villkoren.
@@ -882,6 +883,7 @@ sv:
       deleted: Ta bort användare
       view: Se
     profiles:
+      default_officialization_text: Justification
       default_officialization_text_for_user_groups: Den här användargruppen är offentligt verifierad, namnet har verifierats för att motsvara sitt riktiga namn
       default_officialization_text_for_users: Denna deltagare är offentligt verifierad, hans / hennes namn eller roll har verifierats för att motsvara hans / hennes riktiga namn och roll
       show:
@@ -993,8 +995,8 @@ sv:
         no_activities_warning: Den här användaren har inte någon aktivitet än.
     user_interests:
       show:
-        no_scopes: Den här organisationen har inget utrymme än!
         my_interests: Mina intressen
+        no_scopes: Den här organisationen har inget utrymme än!
         select_your_interests: Välj de ämnen du är intresserad av att ta emot händelser relaterade till dem i din profil Tidslinje flik.
         update_my_interests: Uppdatera mina intressen
       update:
@@ -1168,6 +1170,17 @@ sv:
       too_short: är för kort (under 15 tecken)
   forms:
     required: Krävs
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Om du är mänsklig, ignorera det här fältet
     timestamp_error_message: Tyvärr, det var för snabbt! Vänligen skicka in igen.

--- a/decidim-core/config/locales/tr-TR.yml
+++ b/decidim-core/config/locales/tr-TR.yml
@@ -1,55 +1,60 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       account:
-        delete_reason: Hesabınızı silmenin nedeni
+        delete_reason: Reason to delete your account
       report:
-        details: Ek Yorumlar
+        details: Additional comments
       user:
-        about: hakkında
-        email: E-posta adresiniz
-        name: Adınız
-        nickname: Takma ad
-        password: Parola
-        password_confirmation: Parolanızı onaylayın
-        personal_url: Kişisel URL
-        remove_avatar: Avatarı kaldır
+        about: About
+        email: Your email
+        name: Your name
+        nickname: Nickname
+        password: Password
+        password_confirmation: Confirm your password
+        personal_url: Personal URL
+        remove_avatar: Remove avatar
     models:
-      decidim/attachment_created_event: Ek dosya
-      decidim/component_published_event: Aktif bileşen
-      decidim/demoted_membership: Artık bir grup yöneticisi
-      decidim/gamification/badge_earned_event: Kazanılan rozet
-      decidim/gamification/level_up_event: Seviyeledin
-      decidim/join_request_accepted_event: Katılım isteği kabul edildi
-      decidim/join_request_rejected_event: İstek reddedildi
-      decidim/profile_updated_event: Profil güncellendi
-      decidim/promote_to_admin: Grup yöneticisine yükseltildi
-      decidim/removed_from_group: Gruptan kaldırıldı
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
+      decidim/attachment_created_event: Attachment
+      decidim/component_published_event: Active component
+      decidim/demoted_membership: No longer a group admin
+      decidim/gamification/badge_earned_event: Badge earned
+      decidim/gamification/level_up_event: You've leveled up
+      decidim/join_request_accepted_event: Join request accepted
+      decidim/join_request_rejected_event: Join request rejected
+      decidim/profile_updated_event: Profile updated
+      decidim/promote_to_admin: Promoted to group admin
+      decidim/removed_from_group: Removed from group
   activerecord:
     attributes:
       decidim/user:
-        current_password: Şimdiki Şifre
-        email: E-posta
-        name: Kullanıcı adı
-        password: Parola
-        password_confirmation: Şifre onayı
-        remember_me: Beni Hatırla
+        current_password: Current password
+        email: Email
+        name: Username
+        password: Password
+        password_confirmation: Password confirmation
+        remember_me: Remember me
     models:
       decidim/amendment:
-        one: düzeltme
-        other: Değişiklikler
+        one: Amendment
+        other: Amendments
       decidim/user:
-        one: Kullanıcı yok
-        other: Kullanıcılar
+        one: No users
+        other: Users
       decidim/user_group:
-        one: Kullanıcı grubu
-        other: Kullanıcı Grupları
+        one: User group
+        other: User groups
   booleans:
-    'false': 'Yok hayır'
-    'true': 'Evet'
+    'false': 'No'
+    'true': 'Yes'
   carrierwave:
     errors:
-      image_too_big: Görüntü çok büyük
+      image_too_big: The image is too big
   date:
     formats:
       decidim_short: "%d/%m/%Y"
@@ -60,1188 +65,1194 @@ tr:
   decidim:
     account:
       data_portability_export:
-        file_no_exists: Dosya bulunmuyor
-        invalid_token: Sağlanan simge geçersiz.
-        no_token: Sağlanan jeton yok
-        notice: Verileriniz şu anda devam ediyor. Tamamlandığında bir e-posta alacaksınız.
+        file_no_exists: File does not exist
+        invalid_token: The provided token is invalid.
+        no_token: No token provided
+        notice: Your data is currently in progress. You'll receive an email when it's complete.
       delete:
-        alert: Bu işlem geri alınamaz. Hesabınızı silerseniz, giriş yapamazsınız.
+        alert: This action cannot be undone. If you delete your account you won't be able to log in.
         confirm:
-          close: Pencereyi kapat
-          ok: Evet, hesabımı silmek istiyorum
-          question: Hesabınızı silmek istediğinizden emin misiniz?
-          title: Hesabımı sil
-        explanation: Lütfen hesabınızı silmek istediğiniz nedeni doldurun (isteğe bağlı).
+          close: Close window
+          ok: Yes, I want to delete my account
+          question: Are you sure you want to delete your account?
+          title: Delete my account
+        explanation: Please, fill in the reason you want to delete your account (optional).
       destroy:
-        error: Hesabınız silinirken bir hata oluştu.
-        success: Hesabınız başarıyla silindi.
+        error: There's been an error deleting your account.
+        success: Your account was deleted successfully.
       show:
-        change_password: Şifre değiştir
-        update_account: Hesabı güncelle
+        change_password: Change password
+        update_account: Update account
       update:
-        error: Hesabınız güncellenirken bir hata oluştu.
-        success: Hesabınız başarıyla güncellendi.
-        success_with_email_confirmation: Hesabınız başarıyla güncellendi. Yeni e-posta adresinizi onaylamak için bir e-posta alacaksınız.
+        error: There's been an error updating your account.
+        success: Your account was updated successfully.
+        success_with_email_confirmation: Your account was updated successfully. You'll receive an email to confirm your new email address.
     admin_log:
       area:
-        create: "%{user_name} %{resource_name} alanı oluşturdu"
-        delete: "%{user_name} %{resource_name} alanı sildi"
-        update: "%{user_name} updated %{resource_name} alana"
+        create: "%{user_name} created the %{resource_name} area"
+        delete: "%{user_name} deleted the %{resource_name} area"
+        update: "%{user_name} updated the %{resource_name} area"
       component:
-        create: "%{user_name} , %{resource_name} bileşeni %{space_name} boşluğa ekledi"
-        delete: "%{user_name} uzaklaştırıldı %{resource_name} bileşeni %{space_name} boşluk"
-        publish: "%{user_name} %{space_name} alanda %{resource_name} bileşeni yayınladı"
-        unpublish: "%{user_name} %{space_name} boşluğun %{resource_name} bileşenini basılmamış"
+        create: "%{user_name} added the %{resource_name} component to the %{space_name} space"
+        delete: "%{user_name} removed the %{resource_name} component from the %{space_name} space"
+        publish: "%{user_name} published the %{resource_name} component in the %{space_name} space"
+        unpublish: "%{user_name} unpublished the %{resource_name} component from the %{space_name} space"
       moderation:
-        hide: "%{user_name} %{space_name} alanda bir tip %{resource_type} kaynağını sakla"
-        unreport: "%{user_name} tür bir kaynağı bildirilmemiş %{resource_type} içinde %{space_name} boşluk"
+        hide: "%{user_name} hid a resource of type %{resource_type} in the %{space_name} space"
+        unreport: "%{user_name} unreported a resource of type %{resource_type} in the %{space_name} space"
       newsletter:
-        create: "%{user_name} %{resource_name} bülteni oluşturdu"
-        delete: "%{user_name} %{resource_name} bülteni sildi"
-        deliver: "%{user_name} %{resource_name} haber bülteni teslim etti"
-        update: "%{user_name} güncelleyen %{resource_name} haber bülteni"
+        create: "%{user_name} created the %{resource_name} newsletter"
+        delete: "%{user_name} deleted the %{resource_name} newsletter"
+        deliver: "%{user_name} delivered the %{resource_name} newsletter"
+        update: "%{user_name} updated the %{resource_name} newsletter"
       oauth_application:
-        create: "%{user_name} , %{resource_name} OAuth uygulamasını oluşturdu"
-        delete: "%{user_name} %{resource_name} OAuth uygulamasını sildi"
-        update: "%{user_name} , %{resource_name} OAuth uygulamasını güncelledi"
+        create: "%{user_name} created the %{resource_name} OAuth application"
+        delete: "%{user_name} deleted the %{resource_name} OAuth application"
+        update: "%{user_name} updated the %{resource_name} OAuth application"
       organization:
-        update: "%{user_name} kuruluş ayarlarını güncelledi"
+        update: "%{user_name} updated the organization settings"
       participatory_space_private_user:
-        create: "%{user_name} özel bir kullanıcı olmak için %{resource_name} davet edildi"
-        delete: "%{user_name} kullanıcı %{resource_name} özel bir kullanıcı olarak kaldırdı"
+        create: "%{user_name} invited %{resource_name} to be a private user"
+        delete: "%{user_name} removed the user %{resource_name} as a private user"
       scope:
-        create: "%{user_name} %{resource_name} kapsamı oluşturdu"
-        create_with_parent: "%{user_name} , %{parent_scope} kapsamdaki %{resource_name} kapsamı oluşturdu"
-        delete: "%{user_name} %{resource_name} kapsam silindi"
-        delete_with_parent: "%{user_name} , %{parent_scope} kapsamdaki %{resource_name} kapsamı sildi"
-        update: "%{user_name} güncellendi %{resource_name} kapsam"
-        update_with_parent: "%{user_name} %{parent_scope} kapsamdaki %{resource_name} kapsamı güncellendi"
+        create: "%{user_name} created the %{resource_name} scope"
+        create_with_parent: "%{user_name} created the %{resource_name} scope inside the %{parent_scope} scope"
+        delete: "%{user_name} deleted the %{resource_name} scope"
+        delete_with_parent: "%{user_name} deleted the %{resource_name} scope inside the %{parent_scope} scope"
+        update: "%{user_name} updated the %{resource_name} scope"
+        update_with_parent: "%{user_name} updated the %{resource_name} scope inside the %{parent_scope} scope"
       static_page:
-        create: "%{user_name} , %{resource_name} statik sayfayı oluşturdu"
-        delete: "%{user_name} %{resource_name} statik sayfayı sildi"
-        update: "%{user_name} , %{resource_name} statik sayfayı güncelledi"
+        create: "%{user_name} created the %{resource_name} static page"
+        delete: "%{user_name} deleted the %{resource_name} static page"
+        update: "%{user_name} updated the %{resource_name} static page"
       user:
-        invite: "%{user_name} kullanıcı %{resource_name} rolüyle davet edildi: %{role}"
-        officialize: "%{user_name} kullanıcı resmi %{resource_name}"
-        remove_from_admin: "%{user_name} kullanıcı %{resource_name} rolüyle kaldırıldı: %{role}"
-        unofficialize: "%{user_name} kullanıcı resmi olmayan %{resource_name}"
+        invite: "%{user_name} invited the user %{resource_name} with role: %{role}"
+        officialize: "%{user_name} officialized the user %{resource_name}"
+        remove_from_admin: "%{user_name} removed the user %{resource_name} with role: %{role}"
+        unofficialize: "%{user_name} unofficialized the user %{resource_name}"
       user_group:
-        reject: "%{user_name} , %{resource_name} kullanıcı grubu doğrulamasını reddetti"
-        verify: "%{user_name} , %{resource_name} kullanıcı grubunu doğruladı"
-        verify_via_csv: "%{user_name} , bir CSV dosyası aracılığıyla %{resource_name} kullanıcı grubunu doğruladı"
+        reject: "%{user_name} rejected the %{resource_name} user group verification"
+        verify: "%{user_name} verified the %{resource_name} user group"
+        verify_via_csv: "%{user_name} verified the %{resource_name} user group via a CSV file"
     amendments:
       accepted:
-        error: Ödenmeyi kabul eden bir hata oluştu, lütfen daha sonra tekrar deneyin.
-        success: Bu ödeme başarıyla kabul edildi.
+        error: An error ocurred accepting the emendation, please try again later.
+        success: This emendation has been accepted successfully.
       amendable:
-        amended_by: Tarafından değiştirildi
-        button: '%{model_name}'
-        promote_button: '%{model_name}yükselt'
-        error: Bu kaynağı değiştiren bir hata oluştu.
-        help_text: Onun değiştirerek bu %{model_name} geliştirin %{amendable_fields}
-        promote_help_text: Bu ödemenizi tanıtabilir ve bağımsız olarak yayınlayabilirsiniz %{model_name}
-        no_amenders: Herhangi bir değişiklik yok
-        no_amendments: Hiçbir değişiklik yok
-        section_heading: Değişiklikler (%{count})
+        amended_by: Amended by
+        button: Amend %{model_name}
+        error: There has been an error amending this resource.
+        help_text: Improve this %{model_name} by modifying its %{amendable_fields}
+        no_amenders: There are no amenders
+        no_amendments: There are no amendments
+        promote_button: Promote to %{model_name}
+        promote_help_text: You can promote this emendation and publish it as an independent %{model_name}
+        section_heading: Amendments (%{count})
       created:
-        error: Bu değişikliği oluştururken bir hata oluştu, daha sonra tekrar deneyin
-        success: Değişiklik başarıyla oluşturuldu
+        error: An error ocurred creating this amendment, try again later
+        success: The amendment has been created successfully
       emendation:
         actions:
-          button_accept: Kabul etmek
-          button_reject: reddetmek
-          help_text: Değişiklikleri gözden geçirin ve bu değişikliği kabul edin veya reddedin. Yazar (lar) a bir bildirim gönderilecektir.
+          button_accept: Accept
+          button_reject: Reject
+          help_text: Review the changes and accept or reject this amendment. A notification will be sent to its author(s).
         announcement:
           accepted: |-
-            Bu değişiklik, %{amendable_type} %{amendable_link} olmuştur
-            kabul <strong>%{announcement_date}</strong>.
+            This amendment for the %{amendable_type} %{amendable_link} has been
+            accepted on <strong>%{announcement_date}</strong>.
           evaluating: |-
-            %{amendable_type} %{amendable_link}
-            için yapılan bu değişiklik değerlendiriliyor.
+            This amendment for the %{amendable_type} %{amendable_link}
+            is being evaluated.
           rejected: |-
-            %{amendable_type} %{amendable_link}
-            için bu emenisyon <strong>%{announcement_date}</strong>reddedildi.
+            This emendation for the %{amendable_type} %{amendable_link}
+            was rejected on <strong>%{announcement_date}</strong>.
           withdrawn: |-
-            %{amendable_type} %{amendable_link}
-            için bu değişiklik yazar tarafından geri çekilmiştir.
+            This amendment for the %{amendable_type} %{amendable_link}
+            has been withdrawn by the author.
       new:
-        amendment_author: Değişiklik yazarı
-        back: Geri
-        heading: Değişikliğinizi oluşturun
-        help_text: '%{model_name}değiştiriyorsunuz'
-        send: Değişiklik gönder
-      rejected:
-        error: Bu ödeme reddedilirken bir hata oluştu, lütfen daha sonra tekrar deneyin.
-        success: Emendation başarıyla reddedildi
+        amendment_author: Amendment author
+        back: Back
+        heading: Create your amendment
+        help_text: You are modifying the %{model_name}
+        send: Send amendment
       promoted:
-        success: Emendation başarıyla tanıtıldı
-        error: Düzeltmeyi teşvik ederken hatalar oluştu
+        error: There's been errors when promoting the emendation
+        success: Emendation promoted successfully
+      rejected:
+        error: An error ocurred when rejecting this emendation, please try again later
+        success: The emendation has been rejected successfully
       review:
-        back: Geri
-        heading: Değişikliği gözden geçirin
-        help_text: '%{model_name}değiştiriyorsun'
-        send: Değişikliği kabul et
-    anonymous_user: Anonim
+        back: Back
+        heading: Review the amendment
+        help_text: You are amending the %{model_name}
+        send: Accept amendment
+    anonymous_user: Anonymous
     application:
       collection:
         documents:
-          one: belge
-          other: evraklar
+          one: Document
+          other: Documents
       documents:
-        related_documents: Alakalı dökümanlar
+        related_documents: Related documents
       photos:
-        related_photos: İlgili fotoğraflar
+        related_photos: Related photos
     author:
       comments:
-        one: yorum Yap
-        other: yorumlar
+        one: comment
+        other: comments
     authorization_handlers:
       another_dummy_authorization_handler:
-        explanation: '"A" ile başlayan bir pasaport numarası girerek doğrulanın.'
+        explanation: Get verified by introducing a passport number starting with "A"
         fields:
-          passport_number: Pasaport numarası
-        name: Başka bir örnek yetkilendirme
+          passport_number: Passport number
+        name: Another example authorization
       dummy_authorization_handler:
-        explanation: '"X" ile biten bir belge numarası girerek doğrulanmış olsun'
+        explanation: Get verified by introducing a document number ending with "X"
         fields:
-          document_number: Belge Numarası
-          postal_code: Posta kodu
-        name: Örnek yetkilendirme
+          document_number: Document number
+          postal_code: Postal code
+        name: Example authorization
       dummy_authorization_workflow:
-        name: Kukla yetkilendirme iş akışı
+        name: Dummy authorization workflow
       errors:
-        duplicate_authorization: Bir kullanıcı zaten aynı verilerle yetkilendirilmiştir.
-      expired_at: '%{timestamp}bitti'
-      expires_at: '%{timestamp}sona eriyor'
+        duplicate_authorization: A user is already authorized with the same data.
+      expired_at: Expired at %{timestamp}
+      expires_at: Expires at %{timestamp}
       foo_authorization:
         fields:
           bar: Bar
-          foo: foo
-        name: Foo yetkilendirmesi
-      granted_at: '%{timestamp}'
+          foo: Foo
+        name: Foo authorization
+      granted_at: Granted at %{timestamp}
       sms:
-        explanation: Cep telefon numaranızı gönderin, böylece kimliğinizi kontrol edebiliriz.
-        name: SMS ile kod
-      started_at: '%{timestamp}başlıyor'
+        explanation: Submit your mobile phone number so we can check your identity.
+        name: Code by SMS
+      started_at: Started at %{timestamp}
     authorization_modals:
       show:
         expired:
-          authorize: '"%{authorization}" ile yeniden yetkilendirin'
-          explanation: Yetkilendirme süreniz doldu. Bu eylemi gerçekleştirmek için "%{authorization}" ile yetkilendirilmeniz gerekir.
-          title: Yetkilendirme süresi doldu
+          authorize: Reauthorize with "%{authorization}"
+          explanation: Your authorization has expired. In order to perform this action, you need to be reauthorized with "%{authorization}".
+          title: Authorization has expired
         incomplete:
-          cancel: İptal etmek
-          explanation: 'Şu anda "%{authorization}" ile yetkilendirilmiş olmanıza rağmen, aşağıdaki verileri eksik olduğumuz için yeniden yetkilendirmeniz gerekiyor:'
+          cancel: Cancel
+          explanation: 'Even though you''re currently authorized with "%{authorization}", we need you to reauthorize because we lack the following data:'
           invalid_field: "%{field}"
-          reauthorize: yeniden yetki
-          title: Lütfen yeniden yetkilendirin
+          reauthorize: Reauthorize
+          title: Please reauthorize
         missing:
-          authorize: '"%{authorization}" ile yetkilendir'
-          explanation: Bu eylemi gerçekleştirmek için "%{authorization}" ile yetkilendirilmeniz gerekir.
-          title: İzin gerekmekte
+          authorize: Authorize with "%{authorization}"
+          explanation: In order to perform this action, you need to be authorized with "%{authorization}".
+          title: Authorization required
         pending:
-          explanation: Bu işlemi gerçekleştirmek için "%{authorization}" ile yetkilendirilmeniz gerekir, ancak yetkilendirmeniz hala devam ediyor
-          resume: '"%{authorization}" yetkilendirme işleminizi kontrol edin'
-          title: Yetkilendirme devam ediyor
+          explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
+          resume: Check your "%{authorization}" authorization progress
+          title: Authorization is still in progress
         unauthorized:
-          explanation: Maalesef, bu eylemi, yetki verilerinizden bazıları eşleşmediğinden gerçekleştiremezsiniz.
-          invalid_field: "%{field} değer %{value} geçerli değil."
-          ok: Tamam
-          title: Yetkili değil
+          explanation: Sorry, you can't perform this action as some of your authorization data doesn't match.
+          invalid_field: "%{field} value %{value} isn't valid."
+          ok: Ok
+          title: Not authorized
         unconfirmed:
-          confirmation_instructions: 'Onay talimatlarını almadıysanız tekrar talep edebilirsiniz:'
-          explanation_html: Bu eylemi gerçekleştirmek için yetkilendirilmeniz gerekir, bunu yapmadan önce e-postanızı doğrulamanız gerekir <strong>%{email}</strong>.
-          request_confirmation_instructions: Onay talimatı iste
-          title: E-postanızı onaylayın
+          confirmation_instructions: 'If you haven''t received the confirmation instructions you can request them again:'
+          explanation_html: In order to perform this action you need to be authorized, before doing that you need to confirm your email <strong>%{email}</strong>.
+          request_confirmation_instructions: Request confirmation instructions
+          title: Confirm your email
     collapsible_list:
       hidden_elements_count:
-        one: ve %{count} daha
-        other: ve %{count} daha
-      see_less: "(daha az görün)"
-      see_more: "(daha fazla gör)"
+        one: and %{count} more
+        other: and %{count} more
+      see_less: "(see less)"
+      see_more: "(see more)"
     components:
       dummy:
         actions:
           bar: Bar
-          foo: foo
-        name: Kukla Bileşen
+          foo: Foo
+        name: Dummy Component
         settings:
           global:
-            amendments_enabled: Değişiklikler etkinleştirildi
-            comments_enabled: Yorumlar etkin
-            dummy_global_attribute_1: Kukla Özellik 1
-            dummy_global_attribute_2: Kukla Özellik 2
-            enable_pads_creation: Pedlerin oluşturulmasını etkinleştir
-            resources_permissions_enabled: Kaynak izinleri etkin
+            amendments_enabled: Amendments enabled
+            comments_enabled: Comments enabled
+            dummy_global_attribute_1: Dummy Attribute 1
+            dummy_global_attribute_2: Dummy Attribute 2
+            enable_pads_creation: Enable pads creation
+            resources_permissions_enabled: Resources permissions enabled
           step:
-            comments_blocked: Yorumlar engellendi
-            dummy_step_attribute_1: Kukla Adım Niteliği 1
-            dummy_step_attribute_2: Kukla Adım Öznitelik 2
-    contact: Temas
+            comments_blocked: Comments blocked
+            dummy_step_attribute_1: Dummy Step Attribute 1
+            dummy_step_attribute_2: Dummy Step Attribute 2
+    contact: Contact
     content_blocks:
       footer_sub_hero:
-        name: Altbilgi alt kahraman başlığı
+        name: Footer sub hero banner
       hero:
-        name: Kahraman görüntüsü
+        name: Hero image
       highlighted_content_banner:
-        name: Vurgulanan içerik banner'ı
+        name: Highlighted content banner
       how_to_participate:
-        name: Nasıl katılacağım
+        name: How to participate
       html:
-        html_content: HTML içeriği
-        name: HTML bloğu
+        html_content: HTML content
+        name: HTML block
       last_activity:
-        name: Son Aktivite
-        title: Son Aktivite
-        view_all: Hepsini gör
+        name: Last activity
+        title: Last activity
+        view_all: View all
       metrics:
-        name: Organizasyon metrikleri
+        name: Organization metrics
       stats:
-        name: Organizasyon istatistikleri
+        name: Organization stats
       sub_hero:
-        name: Alt kahraman afişi
+        name: Sub hero banner
     core:
       actions:
-        unauthorized: Bu eylemi gerçekleştirmek için yetkiniz yok
+        unauthorized: You are not authorized to perform this action
     data_portability:
       export:
-        ready: hazır
+        ready: Ready
       show:
-        download_data: Verileri indir
-        download_data_description: Hesapla ilişkili tüm bilgilerin bulunduğu bir dosya <strong>%{user_email}</strong>gönderilecektir.
-        request_data: Veri iste
+        download_data: Download the data
+        download_data_description: A file with all the information associated with the account will be sent to <strong>%{user_email}</strong>
+        request_data: Request data
     datepicker:
-      help_text: 'Beklenen format: %{datepicker_format}'
+      help_text: 'Expected format: %{datepicker_format}'
     devise:
       omniauth_registrations:
         create:
-          email_already_exists: Başka bir hesap aynı e-posta adresini kullanıyor
+          email_already_exists: Another account is using the same email address
         new:
-          complete_profile: Tam profil
-          nickname_help: İçinde kısa, benzersiz tanıtıcı %{organization}
-          sign_up: Lütfen profilinizi tamamlayın
-          subtitle: Kayıt işlemini tamamlamak için lütfen aşağıdaki formu doldurunuz.
-          username_help: Yayınlarınızda görünen genel ad. Anonimlik garantilemek amacıyla herhangi bir isim olabilir.
+          complete_profile: Complete profile
+          nickname_help: Your short, unique identifier in %{organization}
+          sign_up: Please complete your profile
+          subtitle: Please fill in the following form in order to complete the sign up
+          username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
-          already_have_an_account?: Zaten hesabınız var mı?
-          newsletter: İlgili bilgiler içeren bir ara bülteni alın
-          newsletter_title: İletişim izni
-          nickname_help: İçinde kısa, benzersiz tanıtıcı %{organization}
-          sign_in: Oturum aç
-          sign_up: kaydol
+          already_have_an_account?: Already have an account?
+          newsletter: Receive an occasional newsletter with relevant information
+          newsletter_title: Contact permission
+          nickname_help: Your short, unique identifier in %{organization}
+          sign_in: Log in
+          sign_up: Sign up
           sign_up_as:
-            legend: Olarak kaydol
-          subtitle: Tartışmalara katılmak ve teklifleri desteklemek için kaydolun.
-          terms: kullanım şartları ve koşulları
-          tos_agreement: Kaydolarak %{link}kabul ediyorsunuz.
-          tos_title: Kullanım Şartları
-          username_help: Yayınlarınızda görünen genel ad. Anonimlik garantilemek amacıyla herhangi bir isim olabilir.
+            legend: Sign up as
+          subtitle: Sign up to participate in discussions and support proposals.
+          terms: the terms and conditions of use
+          tos_agreement: By signing up you agree to %{link}.
+          tos_title: Terms of Service
+          username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       sessions:
         new:
-          are_you_new?: Platformda yeni misiniz?
-          register: Hesap oluştur
-          sign_in_disabled: Harici bir hesaba erişebilirsiniz
-          sign_up_disabled: Kaydolma devre dışı, mevcut bir kullanıcıyı kullanmak için kullanabilirsiniz
+          are_you_new?: New to the platform?
+          register: Create an account
+          sign_in_disabled: You can access with an external account
+          sign_up_disabled: Sign up is disabled, you can use an existing user to access
       shared:
         newsletter_modal:
           buttons:
-            check: Kontrol et ve devam et
-            close_modal: Yakın kalıcı
-            uncheck: İşaretini kaldır
+            check: Check and continue
+            close_modal: Close modal
+            uncheck: Keep uncheck
           notice: |-
-            <p>Hey, bir haber bülteni almak istemediğine emin misin?<br>
-            Lütfen aşağıdaki haber bülteni onay kutusunu tekrar işaretleyin.<br>
-            Size ara sıra e-postaları alabilmeniz bizim için çok önemlidir
-            her zaman bu değiştirebilir, önemli duyurular yapmak için
-            bildirimleri ayarları sayfasında.</p>
-            <p>Eğer kutuyu işaretlemezseniz, platformdaki yeni katılımcı fırsatlar hakkında ilgili bilgileri
-            kaçırıyor olabilirsiniz.<br>
-            Hala alıcı haber kaçınmak istiyorsak, mükemmel
-            kararınızı anlıyoruz.</p>
-            <p>Bunu okuduğunuz için teşekkürler!</p>
-          title: Bülten bildirimleri
+            <p>Hey, are you sure you don't want to receive a newsletter?<br>
+            Please consider again ticking the newsletter checkbox below.<br>
+            It is very important for us that you can receive occasional emails
+            to make important announcements, you can always change this on your
+            notifications settings page.</p>
+            <p>If you don't tick the box you might be missing relevant information
+            about new participatory opportunities within the platform.<br>
+            If you still want to avoid receiving newsletters, we perfectly
+            understand your decision.</p>
+            <p>Thanks for reading this!</p>
+          title: Newsletter notifications
         omniauth_buttons:
-          or: Veya
+          or: Or
     doorkeeper:
       authorizations:
         new:
-          authorize: Uygulamayı yetkilendir
-          by_organization_link_html: <small class="heading-small">x %{link}</small>
-          cancel: İptal etmek
-          connect_your_account_html: Hesabınıza bağlanarak bağlanın <strong>%{organization}</strong>
-          publish_content: İçeriği sizin için yayınlayın
-          see_email: E-postanızı görün
-          see_name: İsmini gör
-          see_username: Kullanıcı adınızı görün
-          this_application_will_be_able_to: 'Bu uygulama şunları yapabilecek:'
-          this_application_will_not_be_able_to: 'Bu uygulama mümkün olmayacaktır:'
-          update_profile: profilinizi güncelleyin
-          wants_to_use_your_account_html: "<strong>%{application_name}</strong> hesabınızı kullanmak istiyor"
+          authorize: Authorize application
+          by_organization_link_html: <small class="heading-small">by %{link}</small>
+          cancel: Cancel
+          connect_your_account_html: Connect your account by signing in to <strong>%{organization}</strong>
+          publish_content: Publish content for you
+          see_email: See your email
+          see_name: See your name
+          see_username: See your username
+          this_application_will_be_able_to: 'This application will be able to:'
+          this_application_will_not_be_able_to: 'This application will not be able to:'
+          update_profile: Update your profile
+          wants_to_use_your_account_html: "<strong>%{application_name}</strong> wants to use your account"
     errors:
       internal_server_error:
-        title: Sunucumuzla ilgili bir sorun oluştu
-        try_later: Lütfen daha sonra tekrar deneyiniz.
+        title: There was a problem with our server
+        try_later: Please try again later.
       not_found:
-        back_home: Eve dön
-        content_doesnt_exist: Bu adres yanlış veya kaldırılmış.
-        title: Aradığınız sayfa bulunamadı
+        back_home: Back home
+        content_doesnt_exist: This address is incorrect or has been removed.
+        title: The page you're looking for can't be found
     events:
       amendments:
-        amendment_created:
-          affected_user:
-            email_intro: '%{amendable_title}için yeni bir emendation oluşturuldu. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi aldınız, çünkü %{amendable_title}yazarı sizsiniz.
-            email_subject: '%{emendation_author_nickname}%{amendable_title} yeni bir değişiklik'
-            notification_title: <a href="%{emendation_path}">yeni bir emendation</a> , <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturuldu.
-          follower:
-            email_intro: '%{amendable_title}için yeni bir emendation oluşturuldu. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi, %{amendable_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-            email_subject: '%{emendation_author_nickname}%{amendable_title} yeni bir değişiklik'
-            notification_title: <a href="%{emendation_path}">yeni bir emendation</a> , <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturuldu.
-        amendment_rejected:
-          affected_user:
-            email_intro: 'Bir emendation %{amendable_title}için reddedildi. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi aldınız, çünkü %{amendable_title}yazarı sizsiniz.
-            email_subject: Bir değişiklik %{emendation_author_nickname}%{amendable_title} için reddedildi
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturulan <a href="%{emendation_path}">emendation</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için reddedildi.
-          follower:
-            email_intro: 'Bir emendation %{amendable_title}için reddedildi. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi, %{amendable_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-            email_subject: Bir değişiklik %{emendation_author_nickname}%{amendable_title} için reddedildi
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturulan <a href="%{emendation_path}">emendation</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için reddedildi.
-        amendment_promoted:
-          affected_user:
-            email_intro: '%{amendable_title} için reddedilen bir tahliye, bağımsız %{amendable_type}yükseltilmiştir. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi aldınız, çünkü %{amendable_title}yazarı sizsiniz.
-            email_subject: '%{emendation_author_nickname} bir emendation tanıtıldı'
-            notification_title: <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} için bir <a href="%{emendation_path}">reddedilmiş emenisyon</a> <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>tarafından desteklenmiştir.
-          follower:
-            email_intro: '%{amendable_title} için reddedilen bir tahliye, bağımsız %{amendable_type}yükseltilmiştir. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi, %{amendable_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-            email_subject: '%{emendation_author_nickname} bir emendation tanıtıldı'
-            notification_title: <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} için bir <a href="%{emendation_path}">reddedilmiş emenisyon</a> <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>tarafından desteklenmiştir.
         amendment_accepted:
           affected_user:
-            email_intro: '%{amendable_title}için bir ödeme kabul edildi. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi aldınız, çünkü %{amendable_title}yazarı sizsiniz.
-            email_subject: '%{emendation_author_nickname}%{amendable_title} bir değişiklik kabul edildi'
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturulan <a href="%{emendation_path}">emendation</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için kabul edildi.
+            email_intro: 'An emendation has been accepted for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An amendment accepted for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been accepted for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
           follower:
-            email_intro: '%{amendable_title}için bir ödeme kabul edildi. Bu sayfadan görebilirsiniz:'
-            email_outro: Bu bildirimi, %{amendable_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-            email_subject: '%{emendation_author_nickname}%{amendable_title} bir değişiklik kabul edildi'
-            notification_title: <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> tarafından oluşturulan <a href="%{emendation_path}">emendation</a> <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}için kabul edildi.
+            email_intro: 'An emendation has been accepted for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An amendment accepted for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been accepted for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_created:
+          affected_user:
+            email_intro: 'A new emendation has been created for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: A new amendment for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">new emendation</a> has been created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'A new emendation has been created for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: A new amendment for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: A <a href="%{emendation_path}">new emendation</a> has been created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+        amendment_promoted:
+          affected_user:
+            email_intro: 'An emendation rejected for %{amendable_title} has been promoted to an independent %{amendable_type}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An emendation from %{emendation_author_nickname} has been promoted
+            notification_title: A <a href="%{emendation_path}">rejected emendation</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} has been promoted by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+          follower:
+            email_intro: 'An emendation rejected for %{amendable_title} has been promoted to an independent %{amendable_type}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An emendation from %{emendation_author_nickname} has been promoted
+            notification_title: A <a href="%{emendation_path}">rejected emendation</a> for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type} has been promoted by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a>.
+        amendment_rejected:
+          affected_user:
+            email_intro: 'An emendation has been rejected for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are an author of %{amendable_title}.
+            email_subject: An amendment rejected for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been rejected for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
+          follower:
+            email_intro: 'An emendation has been rejected for %{amendable_title}. You can see it from this page:'
+            email_outro: You have received this notification because you are following %{amendable_title}. You can stop receiving notifications following the previous link.
+            email_subject: An amendment rejected for %{amendable_title} from %{emendation_author_nickname}
+            notification_title: The <a href="%{emendation_path}">emendation</a> created by <a href="%{emendation_author_path}">%{emendation_author_nickname}</a> has been rejected for <a href="%{amendable_path}">%{amendable_title}</a> %{amendable_type}.
       attachments:
         attachment_created:
-          email_intro: '%{resource_title}yeni bir belge eklendi. Bu sayfadan görebilirsiniz:'
-          email_outro: Bu bildirimi, %{resource_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{resource_title}bir güncelleme'
-          notification_title: Bir <a href="%{resource_path}">yeni bir doküman</a> eklenmiştir <a href="%{attached_to_url}">%{resource_title}</a>
+          email_intro: 'A new document has been added to %{resource_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{resource_title}
+          notification_title: A <a href="%{resource_path}">new document</a> has been added to <a href="%{attached_to_url}">%{resource_title}</a>
       components:
         component_published:
-          email_intro: '%{resource_title} bileşeni şimdi %{participatory_space_title}için aktif. Bu sayfadan görebilirsiniz:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{participatory_space_title}bir güncelleme'
-          notification_title: '%{resource_title} bileşeni şu anda aktiftir <a href="%{resource_path}">%{participatory_space_title}</a>'
+          email_intro: 'The %{resource_title} component is now active for %{participatory_space_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The %{resource_title} component is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
       email_event:
-        email_greeting: Merhaba %{user_name}
-        email_intro: '"%{resource_title}" için bir güncelleme yapıldı. Bu sayfadan görebilirsiniz:'
-        email_outro: Bu bildirimi "%{resource_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-        email_subject: '%{resource_title}bir güncelleme'
+        email_greeting: Hello %{user_name},
+        email_intro: 'There has been an update to "%{resource_title}". You can see it from this page:'
+        email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+        email_subject: An update to %{resource_title}
       gamification:
         badge_earned:
-          email_intro: İyi iş! <a href="%{resource_url}">%{badge_name} rozeti</a> (seviye %{current_level}) kazandınız.
-          email_outro: Web sitemizde etkinlik yaptığınız için bu bildirimi aldınız.
-          email_subject: 'Yeni bir rozet kazandınız: %{badge_name}!'
-          notification_title: İyi iş! <a href="%{resource_path}">%{badge_name} rozeti</a> (seviye %{current_level}) kazandınız.
+          email_intro: Great job! You've earned the <a href="%{resource_url}">%{badge_name} badge</a> (level %{current_level}).
+          email_outro: You have received this notification because you made activity on our website.
+          email_subject: 'You''ve earned a new badge: %{badge_name}!'
+          notification_title: Great job! You've earned the <a href="%{resource_path}">%{badge_name} badge</a> (level %{current_level}).
         level_up:
-          email_intro: İyi iş! Sen seviyeye ulaşan %{current_level} üzerinde <a href="%{resource_url}">%{badge_name} rozet</a>!
-          email_outro: Web sitemizde etkinlik yaptığınız için bu bildirimi aldınız.
-          email_subject: '%{badge_name} rozetde seviye %{current_level} ulaştınız!'
-          notification_title: İyi iş! Sen seviyeye ulaşan %{current_level} üzerinde <a href="%{resource_path}">%{badge_name} rozet</a>!
+          email_intro: Great job! You've reached level %{current_level} on the <a href="%{resource_url}">%{badge_name} badge</a>!
+          email_outro: You have received this notification because you made activity on our website.
+          email_subject: You've reached level %{current_level} on the %{badge_name} badge!
+          notification_title: Great job! You've reached level %{current_level} on the <a href="%{resource_path}">%{badge_name} badge</a>!
       groups:
         demoted_membership:
-          email_intro: <a href="%{resource_url}">%{user_group_name}</a> grubunun yöneticisi, yönetici haklarınızı bu gruba kaldırdı.
-          email_outro: Bu bildirimi aldınız çünkü bu gruba üye iseniz.
-          email_subject: Artık %{user_group_name} grubunun bir yöneticisi değilsiniz!
-          notification_title: Artık <a href="%{resource_path}">%{user_group_name}</a> grubunun yöneticisi değilsiniz.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed your admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are no longer an admin of the %{user_group_name} group!
+          notification_title: You are no longer an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         invited_to_group:
-          email_intro: <a href="%{resource_url}">%{user_group_name}</a> grubunun yöneticisi sizi katılmaya davet etti.
-          email_outro: Bu bildirimi bir gruba davet edildiğiniz için aldınız. Lütfen onaylamak için profilinizdeki Gruplar sekmesini kontrol edin.
-          email_subject: '%{user_group_name} gruba katılmaya davet edildiniz!'
-          notification_title: <a href="%{resource_path}">%{user_group_name}</a> grubuna katılmaya davet edildiniz. Onaylamak için profilinizdeki <a href="%{groups_profile_tab_path}">Gruplar sayfasını</a> kontrol edin!
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has invited you to join it.
+          email_outro: You have received this notification because you have been invited to an group. Please check the Groups tab in your profile to approve it.
+          email_subject: You have been invited to join the %{user_group_name} group!
+          notification_title: You have been invited to join the <a href="%{resource_path}">%{user_group_name}</a> group. Check the <a href="%{groups_profile_tab_path}">Groups page</a> in your profile to approve it!
         join_request_accepted:
-          email_intro: Tebrikler! <a href="%{resource_url}">%{user_group_name}</a> grubunun yöneticisi, katılma isteğinizi kabul etti.
-          email_outro: Bu bildirimi, katılma isteğiniz güncellendiği için aldınız.
-          email_subject: '%{user_group_name} gruba kabul edildi!'
-          notification_title: <a href="%{resource_path}">%{user_group_name}</a> grubuna kabul edildiniz.
+          email_intro: Congratulations! An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has accepted your request to join it.
+          email_outro: You have received this notification because your join request has been updated.
+          email_subject: You have been accepted to the %{user_group_name} group!
+          notification_title: You have been accepted to the <a href="%{resource_path}">%{user_group_name}</a> group.
         join_request_created:
-          email_intro: Birisi %{user_group_name} gruba katılmayı talep etti. Kabul veya onu reddedebilir <a href="%{resource_url}">grup üyeleri sayfa</a>.
-          email_outro: Bu bildirimi aldınız çünkü %{user_group_name} grubunu yönetebilirsiniz.
-          email_subject: Biri %{user_group_name} gruba katılmayı talep etti!
-          notification_title: Birisi %{user_group_name} gruba katılmayı talep etti. Kabul veya onu reddedebilir <a href="%{resource_path}">grup üyeleri sayfa</a>.
+          email_intro: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_url}">the group members page</a>.
+          email_outro: You have received this notification because you can manage the %{user_group_name} group.
+          email_subject: Someone requested to join the %{user_group_name} group!
+          notification_title: Someone requested to join the %{user_group_name} group. You can accept or reject it from <a href="%{resource_path}">the group members page</a>.
         join_request_rejected:
-          email_intro: <a href="%{resource_url}">%{user_group_name}</a> grubunun yöneticisi, katılma isteğinizi reddetti.
-          email_outro: Bu bildirimi, katılma isteğiniz güncellendiği için aldınız.
-          email_subject: '%{user_group_name} gruba katılma isteğiniz reddedildi!'
-          notification_title: <a href="%{resource_path}">%{user_group_name}</a> gruba katılma isteğiniz reddedildi.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group rejected your request to join it.
+          email_outro: You have received this notification because your join request has been updated.
+          email_subject: Your request to join the %{user_group_name} group has been rejected!
+          notification_title: Your request to join the <a href="%{resource_path}">%{user_group_name}</a> group has been rejected.
         promoted_to_admin:
-          email_intro: <a href="%{resource_url}">%{user_group_name}</a> grubunun bir yöneticisi size bu gruba yönetici hakları verdi.
-          email_outro: Bu bildirimi aldınız çünkü bu gruba üye iseniz.
-          email_subject: Artık %{user_group_name} grubunun bir yöneticisisiniz!
-          notification_title: Artık <a href="%{resource_path}">%{user_group_name}</a> grubunun bir yöneticisisiniz.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has given you admin rights to that group.
+          email_outro: You have received this notification because you are a member of that group.
+          email_subject: You are now an admin of the %{user_group_name} group!
+          notification_title: You are now an admin of the <a href="%{resource_path}">%{user_group_name}</a> group.
         removed_from_group:
-          email_intro: <a href="%{resource_url}">%{user_group_name}</a> grubunun yöneticisi sizi bundan kaldırdı.
-          email_outro: Bu bildirimi siz grubun üyesi olduğunuz için aldınız.
-          email_subject: '%{user_group_name} gruptan kaldırıldınız!'
-          notification_title: <a href="%{resource_path}">%{user_group_name}</a> grubundan kaldırıldınız.
+          email_intro: An admin of the <a href="%{resource_url}">%{user_group_name}</a> group has removed you from it.
+          email_outro: You have received this notification because you were a member of that group.
+          email_subject: You have been removed from the %{user_group_name} group!
+          notification_title: You have been removed from the <a href="%{resource_path}">%{user_group_name}</a> group.
       notification_event:
-        notification_title: Bir olay <a href="%{resource_path}">%{resource_title}</a>.
+        notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       users:
         profile_updated:
-          email_intro: <a href="%{resource_url}">profil sayfası</a> arasında %{name} (%{nickname}izlediğiniz), güncellendi.
-          email_outro: Bu bildirimi, %{nickname}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: "%{nickname} profilini güncelledi"
-          notification_title: <a href="%{resource_path}">profil sayfası</a> arasında %{name} (%{nickname}izlediğiniz), güncellendi.
+          email_intro: The <a href="%{resource_url}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
+          email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.
+          email_subject: "%{nickname} updated their profile"
+          notification_title: The <a href="%{resource_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
     export_mailer:
       data_portability_export:
-        click_button: Verilerinizi indirmek için sonraki düğmeye tıklayın. <br/> Dosyaya %{date}kadar sahip olacaksınız.
-        download: İndir
+        click_button: Click the next button to download your data. <br/> You will have the file available until %{date}.
+        download: Download
       export:
-        ready: Lütfen ihracatınızın bir sıkıştırılmış versiyonunu ekte bulabilirsiniz.
-      subject: İhracatınız "%{name}" hazır
+        ready: Please find attached a zipped version of your export.
+      subject: Your export "%{name}" is ready
     filters:
       linked_classes:
-        all: Herşey
-        collaborative_draft: İşbirlikçi taslak
-        dummy_resource: Kukla kaynaklar
-        meeting: Toplantılar
-        project: Projeler
-        proposal: Teklif
-        result: Sonuçlar
+        all: All
+        collaborative_draft: Collaborative draft
+        dummy_resource: Dummy resources
+        meeting: Meetings
+        project: Projects
+        proposal: Proposals
+        result: Results
     fingerprint:
-      check: Parmak izi kontrol edin
-      explanation: Aşağıdaki metin parçası, bu içeriğin kısaltılmış, temsili bir temsilidir. Tek bir değişikliğin tamamen farklı bir değerle sonuçlanacağı için içeriğin müdahale edilmediğinden emin olmak yararlıdır.
-      online_calculator_name: Online MD5 hesap makinesi
-      replicate_help: Bu parmak izi, bir SHA256 karma algoritması kullanılarak hesaplanır. Kendiniz çoğaltmak için, bir %{online_calculator_link} kullanabilir ve kaynak verileri kopyalayıp yapıştırabilirsiniz.
-      source: Kaynak
-      title: Parmak izi
-      value: değer
+      check: Check fingerprint
+      explanation: The piece of text below is a shortened, hashed representation of this content. It's useful to ensure the content hasn't been tampered with, as a single modification would result in a totally different value.
+      online_calculator_name: MD5 calculator online
+      replicate_help: This fingerprint is calculated using a SHA256 hashing algorithm. In order to replicate it yourself, you can use an %{online_calculator_link} and copy-paste the source data.
+      source: Source
+      title: Fingerprint
+      value: Value
     followers:
-      no_followers: Henüz takipçisi yok.
+      no_followers: No followers yet.
     following:
-      no_followings: Henüz kimseyi takip etmiyor.
+      no_followings: Doesn't follow anyone or anything yet.
     follows:
       create:
-        button: Takip et
-        error: Bu kaynağı takip eden bir hata oluştu.
+        button: Follow
+        error: There has been an error following this resource.
       destroy:
-        button: Takibi bırak
-        error: Bu kaynağı takip etmekten bir hata oluştu.
+        button: Stop following
+        error: There has been an error unfollowing this resource.
     forms:
-      current_file: Mevcut dosya
-      current_image: Geçerli resim
-      default_image: Varsayılan görüntü
+      current_file: Current file
+      current_image: Current image
+      default_image: Default image
       errors:
-        error: Bu alanda bir hata var.
-      remove_this_file: Bu dosyayı kaldır
+        error: There's an error in this field.
+      remove_this_file: Remove this file
     gamification:
-      all_badges_link: Tüm mevcut rozetleri görün.
+      all_badges_link: See all available badges.
       badges:
         continuity:
-          conditions:
-            - Buraya sık sık gel
-          description: Bu rozeti, platformu düzenli bir şekilde ziyaret ettiğinizde verilir. Burada olmanızı seviyoruz!
-          description_another: Bu kullanıcı bir noktada %{score} ardışık gün için bağlandı.
-          description_own: Bir noktada %{score} ardışık gün için bağlandınız.
-          name: süreklilik
-          next_level_in: Bir sonraki seviyeye geçmek için %{score} ardışık güne bağlanın!
-          unearned_another: Bu kullanıcı art arda birden fazla gün için giriş yapmadı.
-          unearned_own: Birden fazla ardışık güne bağlı değilsiniz.
+          conditions: '["Come here often"]'
+          description: This badge is granted when you visit the platform in a regular way. We like having you around here!
+          description_another: This user has connected for %{score} consecutive days at some point.
+          description_own: You have connected for %{score} consecutive days at some point.
+          name: Continuity
+          next_level_in: Connect for %{score} consecutive days to get to the next level!
+          unearned_another: This user hasn't signed in for more than one consecutive day.
+          unearned_own: You haven't connected for more than one consecutive day.
         followers:
-          conditions:
-            - Aktif olmak ve diğer insanları takip etmek kesinlikle başka insanların sizi takip etmesini sağlayacaktır.
-          description: Bu rozet belirli sayıda takipçiye ulaştığınızda verilir. %{organization_name} sosyal ve politik bir ağdır, web'inizi platformdaki diğer insanlarla iletişim kurmak için kullanın.
-          description_another: Bu kullanıcının %{score} takipçisi var.
-          description_own: "%{score} kullanıcı sizi takip ediyor."
-          name: İzleyiciler
-          next_level_in: Bir sonraki seviyeye ulaşmak için sizi takip etmek için %{score} kullanıcı daha alın!
-          unearned_another: Bu kullanıcının henüz hiç takipçisi yok.
-          unearned_own: Henüz takipçiniz yok.
+          conditions: '["Being active and following other people will surely make other people follow you."]'
+          description: This badge is granted when you reach a certain number of followers. %{organization_name} is a social and political network, weave your web to communicate with other people in the platform.
+          description_another: This user has %{score} followers.
+          description_own: "%{score} users are following you."
+          name: Followers
+          next_level_in: Get %{score} more users to follow you to reach the next level!
+          unearned_another: This user doesn't have any followers yet.
+          unearned_own: You've got no followers yet.
         index:
-          badge_title: "%{name} rozet"
-          how: Nasıl kazanabilirsin
-          page_description: Rozetler, katılımcı eylemleri ve platformdaki ilerlemeleri tanımaktadır. Platformda keşfetmeye, katılmaya ve etkileşim kurmaya başladığınızda farklı rozetler kazanacaksınız. İşte rozetlerin listesi ve bunları kazanmanın bazı yolları.
-          title: Rozetler
+          badge_title: "%{name} badge"
+          how: How can you earn it
+          page_description: Badges are recognitions to participant actions and progress in the platform. As you start discovering, participating and interacting in the platform, you will earn different badges. Here is the list of badges and some ways you can earn them.
+          title: Badges
         invitations:
-          conditions:
-            - Arkadaşlarınızı davet etmek için kullanıcı sayfanızdaki “arkadaşlarını davet et” bağlantısını kullanın.
-            - İsterseniz, göndermek istediğiniz mesajı özelleştirin
-            - Davetiyeler göndererek ve onları kayıt altına alarak seviye atlayacaksınız.
-          description: Bu rozeti, bazı kişileri davet ettiğinizde ve %{organization_name} kaydolmak ve katılımcı olmak için biraz zaman ayırdıklarında verilir. Yaptığınız için teşekkür ederiz %{organization_name} başkalarına bilinen ve topluluğu genişletmek için yardımcı!
-          description_another: Bu kullanıcı %{score} kullanıcı davet etti.
-          description_own: '%{score} kullanıcıyı davet ettiniz.'
-          name: Davetiyeler
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} kullanıcı daha davet edin!
-          unearned_another: Bu kullanıcı henüz bir kullanıcıyı davet etmedi.
-          unearned_own: Henüz hiç kullanıcı davet etmediniz.
-      description: Rozetler, katılımcı eylemleri ve platformdaki ilerlemeleri tanımaktadır. Platformda keşfetmeye, katılmaya ve etkileşim kurmaya başladığınızda farklı rozetler kazanacaksınız.
-      level: Seviye %{level}
-      reached_top: Bu rozetin en üst seviyesine ulaştınız.
+          conditions: '["Use the “invite friends” link on your user page to invite your friends", "Customize, if you want, the message you are sending", "You’ll level up by sending invitations and getting them registered."]'
+          description: This badge is granted when you’ve invited some people and they have spend a little time to register in %{organization_name} and become participants. Thank you for making %{organization_name} known to others and helping to expand the community!
+          description_another: This user has invited %{score} users.
+          description_own: You have invited %{score} users.
+          name: Invitations
+          next_level_in: Invite %{score} more users to reach the next level!
+          unearned_another: This user hasn't invited any user yet.
+          unearned_own: You have invited no users yet.
+      description: Badges are recognitions to participant actions and progress in the platform. As you start discovering, participating and interacting in the platform, you will earn different badges.
+      level: Level %{level}
+      reached_top: You've reached the top level for this badge.
     group_admins:
       actions:
-        are_you_sure: Emin misiniz? Bu, kullanıcıyı gruptan kaldırmaz.
-        demote_admin: Yönetici kaldır
+        are_you_sure: Are you sure? This won't remove the user from the group.
+        demote_admin: Remove admin
       demote:
-        error: Bu kullanıcıyı yönetici listesinden kaldırırken bir hata oluştu
-        success: Kullanıcı yönetici tarafından başarıyla kaldırıldı
+        error: There was an error removing this user from the admins list
+        success: User removed from admin successfully
       index:
-        current_admins: 'Mevcut yöneticiler:'
-        manage_admins: Yöneticileri yönet
+        current_admins: 'Current admins:'
+        manage_admins: Manage admins
     group_invites:
       accept:
-        error: Bu daveti kabul eden bir hata oluştu
-        success: Davetiye başarıyla kabul edildi
-      accept_invitation: Kabul etmek
-      accept_or_reject_group_invitations: 'Aşağıdaki gruplar, onlara katılmaları için sizi davet etti. İsteklerini kabul etme veya reddetme:'
+        error: There was an error accepting this invitation
+        success: Invitation accepted successfully
+      accept_invitation: Accept
+      accept_or_reject_group_invitations: 'The following groups have invited you to join them. Accept or reject their requests:'
       index:
-        invite: Davet et
-        invite_user: Bir kullanıcıyı davet et
+        invite: Invite
+        invite_user: Invite a user
       invite:
-        error: Bu kullanıcıyı davet eden bir hata oluştu
-        success: Kullanıcı başarıyla davet edildi
+        error: There was an error inviting this user
+        success: User invited successfully
       reject:
-        error: Bu davet reddedilirken bir hata oluştu
-        success: Davet başarıyla reddedildi
-      reject_invitation: reddetmek
+        error: There was an error rejecting this invitation
+        success: Invitation rejected successfully
+      reject_invitation: Reject
     group_members:
       accept:
-        error: Bu katılma isteğini kabul eden bir hata oluştu
-        success: Katılım isteği başarıyla kabul edildi
+        error: There was an error accepting this join request
+        success: Join request accepted successfully
       actions:
-        are_you_sure: Emin misiniz?
-        promote_to_admin: Admin yap
-        remove_from_group: Kullanıcıyı kaldır
+        are_you_sure: Are you sure?
+        promote_to_admin: Make admin
+        remove_from_group: Remove user
       index:
-        current_members_without_admins: 'Mevcut üyeler (yöneticiler olmadan):'
-        manage_members: Üyeleri yönet
+        current_members_without_admins: 'Current members (without admins):'
+        manage_members: Manage members
       promote:
-        error: Bu kullanıcıyı tanıtan bir hata oluştu
-        success: Kullanıcı başarıyla tanıtıldı
+        error: There was an error promoting this user
+        success: User promoted successfully
       reject:
-        error: Bu katılma isteğini reddeden bir hata oluştu
-        success: Katılım isteği başarıyla reddedildi
+        error: There was an error rejecting this join request
+        success: Join request rejected successfully
       remove:
-        error: Bu kullanıcıyı gruptan kaldırırken bir hata oluştu
-        success: Kullanıcı gruptan başarıyla kaldırıldı
+        error: There was an error removing this user from the group
+        success: User removed from the group successfully
     groups:
       actions:
-        are_you_sure: Emin misiniz?
+        are_you_sure: Are you sure?
       create:
-        error: Grup oluştururken bir sorun oluştu
-        success: Grup başarıyla oluşturuldu
+        error: There has been a problem creating the group
+        success: Group created successfully
       edit:
-        edit_user_group: Grubu düzenle
-        update_user_group: Güncelleme grubu
+        edit_user_group: Edit group
+        update_user_group: Update group
       form:
-        document_number_help: Tire veya boşluk kullanmayın
-        email_help: Kuruluşunuzun, derneğin, kolektif, grubun vb. E-posta adresi.
-        fill_in_for_verification: 'Grubunuzun doğrulanmasını istiyorsanız, bu alanları doldurun:'
-        name_help: Organizasyonunuzun adı, dernek, kolektif, grup vb.
-        nickname_help: Kuruluşunuzun, derneğin, kolektif, grubunuzun vb. Kullanıcı adı. Boşluk veya aksan kullanmayın.
-        phone_help: Tire veya boşluk kullanmayın
+        document_number_help: Do not use dashes nor spaces
+        email_help: Email of your organization, association, collective, group, etc.
+        fill_in_for_verification: 'Fill in these fields if you want your group to be verified:'
+        name_help: Name of your organization, association, collective, group, etc.
+        nickname_help: Username of your organization, association, collective, group, etc. Do not use spaces nor accents.
+        phone_help: Do not use dashes nor spaces
       join:
-        error: Grup katılmadan bir sorun oluştu.
-        success: Katılım isteği başarıyla oluşturuldu. Bir yönetici, sizi gruba kabul etmeden önce isteğinizi inceleyecektir.
+        error: There has been a problem joining the group
+        success: Join request created successfully. An admin will review your request before accepting you to the group.
       leave:
-        error: Gruptan ayrılmayla ilgili bir sorun oluştu.
-        success: Grup başarıyla ayrıldı.
+        error: There has been a problem leaving the group
+        success: Group left successfully.
       members:
-        accept_or_reject_join_requests: 'Aşağıdaki kullanıcılar bu gruba katılmak için başvuruda bulundu. İsteklerini kabul etme veya reddetme:'
-        accept_request: Kabul etmek
-        reject_request: reddetmek
+        accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'
+        accept_request: Accept
+        reject_request: Reject
       new:
-        create_user_group: Grup oluştur
-        new_user_group: Yeni Grup
-        subtitle: Bir grup oluşturun ve diğer kullanıcıları toplu bir seviyeye katılmak için katılmaya davet edin.
-      no_user_groups: Henüz herhangi bir gruba ait değil.
+        create_user_group: Create group
+        new_user_group: New group
+        subtitle: Create a group and invite other users to join to participate in a collective level.
+      no_user_groups: Doesn't belong to any group yet.
       roles:
-        admin: yönetici
-        creator: yaratıcı
-        member: üye
+        admin: Administrator
+        creator: Creator
+        member: Member
       update:
-        error: Grup güncellenirken bir sorun oluştu
-        success: Grup başarıyla güncellendi
+        error: There has been a problem updating the group
+        success: Group updated successfully
     help:
       main_topic:
         default_page:
-          content: "<p>In %{organization} , farklı konularda, üst menüde gördüğünüz mekanlara katılabilirsiniz: Süreçler, Meclisler, İnisiyatifler, İstişareler.</p> <p>Her birinde katılım için farklı seçenekler bulacaksınız: bireysel veya diğer insanlarla birlikte teklifler hazırlamak, tartışmalara katılmak, uygulamak için projelere öncelik vermek, yüz yüze toplantılara katılmak ve diğer eylemlere katılmak.</p>\n"
-          title: '%{organization}ne yapabilirim?'
-        description: '%{organization}hakkında daha fazla bilgi edinin'
-        title: Genel Yardım
+          content: "<p>In %{organization} you can participate and decide on different topics, through the spaces you see in the top menu: Processes, Assemblies, Initiatives, Consultations.</p> <p>Within each one you will find different options to participate: make proposals - individually or with other people-, take part in debates, prioritize projects to implement, attend face-to-face meetings and other actions.</p>\n"
+          title: What can I do in %{organization}?
+        description: Read more about %{organization}
+        title: General Help
     last_activities:
       activities:
-        no_activities_warning: Aktivite yok
-      all: Tüm aktivite türleri
+        no_activities_warning: No activity
+      all: All activity types
       index:
-        last_activity: Son Aktivite
-        resource_type: tip
+        last_activity: Last activity
+        resource_type: Type
     log:
       base_presenter:
-        create: "%{user_name} oluşturuldu %{resource_name}"
-        create_with_space: "%{user_name} oluşturuldu %{resource_name} in %{space_name}"
-        delete: "%{user_name} silindi %{resource_name}"
-        delete_with_space: "%{user_name} silindi %{resource_name} %{space_name}"
-        unknown_action: "%{user_name} bir eylem gerçekleştirdi %{resource_name}"
-        unknown_action_with_space: "%{user_name} %{space_name}%{resource_name} eylem gerçekleştirdi"
-        update: "%{user_name} güncellendi %{resource_name}"
-        update_with_space: "%{user_name} güncellendi %{resource_name} in %{space_name}"
+        create: "%{user_name} created %{resource_name}"
+        create_with_space: "%{user_name} created %{resource_name} in %{space_name}"
+        delete: "%{user_name} deleted %{resource_name}"
+        delete_with_space: "%{user_name} deleted %{resource_name} in %{space_name}"
+        unknown_action: "%{user_name} performed some action on %{resource_name}"
+        unknown_action_with_space: "%{user_name} performed some action on %{resource_name} in %{space_name}"
+        update: "%{user_name} updated %{resource_name}"
+        update_with_space: "%{user_name} updated %{resource_name} in %{space_name}"
       value_types:
         area_presenter:
-          not_found: 'Alan veritabanında bulunamadı (ID: %{id})'
+          not_found: 'The area was not found on the database (ID: %{id})'
         area_type_presenter:
-          not_found: 'Alan türü veritabanında bulunamadı (ID: %{id})'
+          not_found: 'The area type was not found on the database (ID: %{id})'
         scope_presenter:
-          not_found: 'Veritabanında kapsam bulunamadı (ID: %{id})'
+          not_found: 'The scope was not found on the database (ID: %{id})'
         scope_type_presenter:
-          not_found: 'Veritabanında kapsam tipi bulunamadı (ID: %{id})'
+          not_found: 'The scope type was not found on the database (ID: %{id})'
     managed_users:
-      expired_session: Mevcut kimliğe bürünme oturumunun süresi doldu.
+      expired_session: The current impersonation session has expired.
     members:
-      no_members: Bu kullanıcı grubunun henüz üye yok.
+      no_members: This user groups doesn't have any member yet.
     menu:
-      help: yardım et
-      home: Ev
+      help: Help
+      home: Home
     messaging:
       conversation_mailer:
         new_conversation:
-          greeting: Merhaba %{recipient}!
-          intro: "%{sender} sizinle yeni bir sohbet başlattı. Görmek için buraya tıklayın:"
-          outro: Decidim'in tadını çıkar!
-          subject: "%{sender} sizinle bir konuşma başlattı"
+          greeting: Hi, %{recipient}!
+          intro: "%{sender} has started a new conversation with you. Click here to see it:"
+          outro: Enjoy decidim!
+          subject: "%{sender} has started a conversation with you"
         new_message:
-          greeting: Merhaba %{recipient}!
-          intro: "%{sender} , konuşmanıza yeni mesajlar gönderdi. Görmek için buraya tıklayın:"
-          outro: Decidim'in tadını çıkar!
-          subject: '%{sender}yeni mesajınız var'
+          greeting: Hi, %{recipient}!
+          intro: "%{sender} has posted new messages in your conversation. Click here to see them:"
+          outro: Enjoy decidim!
+          subject: You have new messages from %{sender}
       conversations:
         create:
-          error: Konuşma başlamadı. Daha sonra tekrar deneyin
+          error: Conversation not started. Try again later
         index:
-          no_conversations: Henüz konuşma yok
-          title: Konuşmalar
+          no_conversations: You have no conversations yet
+          title: Conversations
         reply:
-          send: göndermek
-          title: cevap
+          send: Send
+          title: Reply
         show:
-          title: '%{usernames}ile Söyleşi'
+          title: Conversation with %{usernames}
         start:
-          send: göndermek
-          title: Bir görüşme başlat
+          send: Send
+          title: Start a conversation
         update:
-          error: Mesaj gönderilmedi. Daha sonra tekrar deneyin
+          error: Message not sent. Try again later
     metrics:
       download:
-        csv: Veri indir (csv)
+        csv: Download data (csv)
       followers:
-        description: Kuruluşta takip eden kullanıcı sayısı
-        object: takipçileri
-        title: İzleyiciler
+        description: Number of users that follow this participation space
+        object: followers
+        title: Followers
       participants:
-        description: Kuruluştaki aktif kullanıcı sayısı
-        object: katılımcılar
-        title: Katılımcılar
+        description: Number of active user in organization
+        object: participants
+        title: Participants
       users:
-        description: Kuruluştaki kullanıcı sayısı
-        object: kullanıcılar
-        title: Kullanıcılar
+        description: Number of user in organization
+        object: users
+        title: Users
     newsletter_mailer:
       newsletter:
-        note: Bu e-postayı, %{organization_name}bültenlere abone olduğunuz için aldınız. Eğer ayarlarınızı değiştirebilirsiniz <a href="%{link}">bildirimleri sayfa</a>.
-        see_on_website: Bu e-postayı doğru göremiyor musunuz? Onu <a href="%{link}" target="_blank">web sitesinde görüntüle</a>.
-        unsubscribe: Bu tür bir e-posta almayı iptal etmek için, <a href="%{link}" target="_blank" class="unsubscribe">Abonelikten çıkma</a>.
+        note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
+        see_on_website: Can’t see this email correctly? View it on the <a href="%{link}" target="_blank">website</a>.
+        unsubscribe: To opt out of receiving this type of email, <a href="%{link}" target="_blank" class="unsubscribe">Unsubscribe</a>.
     newsletters:
       unsubscribe:
-        check_subscription: Tercihlerinizi değiştirmek isterseniz, bunu yapabilirsiniz <a href="%{link}" target="_blank">yapılandırma sayfasında</a>
-        error: Abonelik iptal edildiğinde bir hata oluştu
-        success: Abonelikten başarıyla çıktınız.
-        token_error: Bağlantının süresi doldu.
-        unsubscribe: aboneliğini
+        check_subscription: If you want to change your preferences, you can do so in the <a href="%{link}" target="_blank">configuration page</a>
+        error: There's been an error unsubscribing
+        success: You are unsubscribed successfully.
+        token_error: The link has expired.
+        unsubscribe: Unsubscribe
     newsletters_opt_in:
-      unathorized: Üzgünüz, bu bağlantı artık mevcut değil
+      unathorized: Sorry, this link is no longer available
       update:
-        error: Ters şeyler oldu
-        success: Bülten ayarları başarıyla güncellendi
+        error: Something wrong happened
+        success: Newsletter settings updated successfully
     newsletters_opt_in_mailer:
       notify:
-        body_1: Kişisel verilerin işlenmesi ve korunması, hepimiz için giderek daha önemli hale gelmektedir. 25 Mayıs 2018 tarihli yeni Genel Veri Koruma Yönetmeliği (GDPR) ile bireyler kişisel verileri üzerinde daha iyi bir kontrole sahiptir. Bu nedenle, %{organization_name}faaliyetleri hakkında ilgili bilgileri göndermeye devam etmek için "OK" e ihtiyacımız var.
-        body_2: 'Bize nasıl izin verirsin? Aşağıdaki düğmeyi tıklamanız yeterlidir:'
-        body_3: Bu onay ile platformun hizmetleri hakkında bilgi almaya devam edebilirsiniz. Aksine, sizin tarafınızdan olumlu bir onay almazsak, size mesajlarımızı göndermeyi bırakacağız. Bilgilendirilmek istediğinizi onaylarsanız, istediğiniz zaman iptal etme seçeneğiniz olur.
-        button: Evet, alakalı bilgileri almaya devam etmek istiyorum
-        greetings: Selamlar,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
-        hello: Merhaba,
-        subject: '%{organization_name}ilgili bilgileri almaya devam etmek istiyor musunuz?'
+        body_1: The processing of personal data and its protection is becoming increasingly important for all of us. With the new General Data Protection Regulation (GDPR) of May 25, 2018, individuals have better control over their personal data. For this reason we need your "OK" to continue sending relevant information about the activities of the %{organization_name}.
+        body_2: 'How can you give us your consent? Just click the following button:'
+        body_3: With this consent you will be able to continue receiving information about the services of the platform. If, on the contrary, we do not receive a positive confirmation on your part we will stop sending you our messages. If you confirm that you want to keep being informed, you will always have the option to cancel at any time.
+        button: Yes, I want to continue receiving relevant information
+        greetings: Greetings,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
+        hello: Hello,
+        subject: Do you want to keep receiving relevant information about %{organization_name}?
+    notification_mailer:
+      shared:
+        note: You received this message because you're subscribed to notification by email on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
     notifications:
-      no_notifications: Henüz bildirim yok.
+      no_notifications: No notifications yet.
     notifications_settings:
       show:
-        email_on_notification: Her bildirim aldığımda bir e-posta almak istiyorum.
-        everything_followed: Takip ettiğim her şey
-        newsletters: Haber bültenleri
-        newsletter_notifications: Bülten almak istiyorum
-        own_activity: Kendi aktivitem, birisi teklifime yorum yaptığında veya bana bahsettiğinde
-        receive_notifications_about: Hakkında bildirim almak istiyorum
-        send_notifications_by_email: Bildirimleri e-posta ile gönder
-        update_notifications_settings: Değişiklikleri Kaydet
+        email_on_notification: I want to receive an email every time I receive a notification.
+        everything_followed: Everything I follow
+        newsletter_notifications: I want to receive newsletters
+        newsletters: Newsletters
+        own_activity: My own activity, like when someone comments in my proposal or mentions me
+        receive_notifications_about: I want to get notifications about
+        send_notifications_by_email: Send notifications by email
+        update_notifications_settings: Save changes
       update:
-        error: Bildirim ayarlarınız güncellenirken bir hata oluştu.
-        success: Bildirim ayarlarınız başarıyla güncellendi.
+        error: There's been an error updating your notifications settings.
+        success: Your notifications settings were updated successfully.
     open_data:
-      not_available_yet: Açık Veri dosyaları henüz mevcut değil, lütfen birkaç dakika içinde tekrar deneyin.
+      not_available_yet: The Open Data files are not yet available, please try again in a few minutes.
     own_user_groups:
       index:
-        pending: kadar
-        rejected: Reddedilen
-        verified: Doğrulanmış
+        pending: Pending
+        rejected: Rejected
+        verified: Verified
     pad_iframe:
-      disclaimer: Bu pedin içeriği kayıtlı kullanıcılar tarafından yazılmakta ve görüşlerini ifade etmektedir. İçeriğinden %{organization} sorumlu tutulamaz.
-      explanation: Toplantı sırasında notları ortaklaşa almak için bu alanı kullanın, böylece dakika sonra yazmak daha kolay olur.
-      pad: ped
+      disclaimer: The contents of this pad are written by registered users and express their opinions. %{organization} cannot be held responsible for its contents.
+      explanation: Use this pad to collaboratively take notes during the meeting so it's easier to write down the minute afterwards.
+      pad: Pad
     pages:
       home:
         extended:
-          debates: Tartışmalar
-          debates_explanation: Tartışmak ve tartışmak, görüşlerinizi paylaşmak ve ilgili konuları zenginleştirmek.
-          how_to_participate: Bir sürece nasıl katılırım?
-          meetings: Toplantılar
-          meetings_explanation: Genel toplantılara nerede ve ne zaman katılabileceğinizi öğrenin.
-          more_info: Daha fazla bilgi
-          proposals: Teklif
-          proposals_explanation: Teklif hazırlayın, mevcut olanları destekleyin ve görmek istediğiniz değişiklikleri tanıtın.
+          debates: Debates
+          debates_explanation: Debate and discuss, share your views and enrich the relevant topics.
+          how_to_participate: How do I take part in a process?
+          meetings: Meetings
+          meetings_explanation: Find out where and when you can participate in public meetings.
+          more_info: More info
+          proposals: Proposals
+          proposals_explanation: Make proposals, support existing ones and promote the changes you want to see.
         footer_sub_hero:
-          footer_sub_hero_body: Daha açık, şeffaf ve işbirlikçi bir toplum inşa edelim.<br /> Katıl, katıl ve karar ver.
-          footer_sub_hero_headline: '%{organization} katılımcı platformuna hoş geldiniz.'
-          register: Kayıt olmak
+          footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.
+          footer_sub_hero_headline: Welcome to %{organization} participatory platform.
+          register: Register
         hero:
-          participate: Katıl
-          welcome: '%{organization}hoşgeldin!'
+          participate: Participate
+          welcome: Welcome to %{organization}!
         metrics:
-          headline: Rakamlara katılım
+          headline: Participation in figures
         statistics:
-          answers_count: Tamamlanmış Anketler
-          assemblies_count: meclisleri
-          comments_count: Yorumlar
-          conferences_count: Konferanslar
-          debates_count: Tartışmalar
-          endorsements_count: Cirolar
-          headline: Mevcut durum %{organization}
-          meetings_count: Toplantılar
-          orders_count: oy
-          pages_count: Sayfalar
-          processes_count: Süreçler
-          projects_count: Projeler
-          proposals_accepted: Kabul Edilen Teklifler
-          proposals_count: Teklif
-          results_count: Sonuçlar
-          surveys_count: Anketler
-          users_count: Katılımcılar
-          votes_count: oy
+          answers_count: Completed Surveys
+          assemblies_count: Assemblies
+          comments_count: Comments
+          conferences_count: Conferences
+          debates_count: Debates
+          endorsements_count: Endorsements
+          headline: Current state of %{organization}
+          meetings_count: Meetings
+          orders_count: Votes
+          pages_count: Pages
+          processes_count: Processes
+          projects_count: Projects
+          proposals_accepted: Accepted Proposals
+          proposals_count: Proposals
+          results_count: Results
+          surveys_count: Surveys
+          users_count: Participants
+          votes_count: Votes
         sub_hero:
-          register: Kayıt olmak
+          register: Register
       index:
-        read_more: Daha fazla oku
-        standalone_pages: Sayfalar
-        subheading: '%{name}yardım sayfalarında gezinin'
-        title: yardım et
-        topics: Başlıklar
-      participatory_space:
-        metrics:
-          headline: Rakamlara katılım
-          link: Bütün istatistikleri göster
+        read_more: Read more
+        standalone_pages: Pages
+        subheading: Navigate through the help pages of %{name}
+        title: Help
+        topics: Topics
       terms_and_conditions:
         accept:
-          error: Şartları ve koşulları kabul ederken bir hata oluştu.
-          success: Harika! Şartları ve koşulları kabul ettiniz.
+          error: There's been an error while accepting the terms and conditions.
+          success: Great! You have accepted the terms and conditions.
         form:
-          agreement: Bu şartları kabul ediyorum
-          legend: Kullanım şartlarını ve koşullarını kabul et
+          agreement: I agree this terms
+          legend: Agree to the terms and conditions of use
         refuse:
-          modal_body: Eğer kabul ederseniz, platformu kullanmak mümkün olmayacaktır şunları yapabilirsiniz <a href="%{data_portability_path}">verileri indirme</a> ve / veya <a href="%{delete_path}">Hesabınızı silmek</a>.
-          modal_btn_continue: Şartları kabul et ve devam et
-          modal_btn_exit: Daha sonra inceleyeceğim
-          modal_button: Şartları reddetme
-          modal_close: Yakın kalıcı
-          modal_title: Güncellenmiş Şartlar ve Koşulları gerçekten reddediyor musunuz?
+          modal_body: If you refuse, you won't be able to use the platform, you can <a href="%{data_portability_path}">download your data</a> and/or <a href="%{delete_path}">delete your account</a>.
+          modal_btn_continue: Accept terms and continue
+          modal_btn_exit: I'll review it later
+          modal_button: Refuse the terms
+          modal_close: Close modal
+          modal_title: Do you really refuse the updated Terms and Conditions?
         required_review:
-          alert: Hizmet Şartlarımızı güncelledik, lütfen bunları inceleyin.
-          body: Hizmet Şartlarımıza ait güncellemeleri incelemek için lütfen biraz zaman ayırın. Aksi halde platformu kullanamazsınız.
-          title: 'Gerekli: Hizmet şartlarımızı güncellemeleri inceleyin'
+          alert: We've updated our Terms of Service, please review them.
+          body: Please take a moment to review updates to our Terms of Services. Otherwise you won't be able to use the platform.
+          title: 'Required: Review updates to our terms of service'
     participatory_space_private_users:
-      not_allowed: Bu içeriği görüntüleyemezsiniz
+      not_allowed: You are not allowed to view this content
     profile:
-      deleted: Silinmiş kullanıcı
-      view: Görünüm
+      deleted: Deleted user
+      view: View
     profiles:
-      default_officialization_text_for_user_groups: Bu kullanıcı grubu genel olarak doğrulandı, adı gerçek adıyla doğrulandı
-      default_officialization_text_for_users: Bu katılımcı kamuya açıklanmış, adı veya rolünün gerçek adı ve rolüyle uyumlu olduğu doğrulanmıştır.
+      default_officialization_text: Justification
+      default_officialization_text_for_user_groups: This user group is publicly verified, its name has been verified to correspond with its real name
+      default_officialization_text_for_users: This participant is publicly verified, his/her name or role has been verified to correspond with his/her real name and role
       show:
-        activity: Aktivite
-        badges: Rozetler
-        followers: İzleyiciler
-        following: Şöyledir
-        groups: Gruplar
-        members: Üyeler
-        timeline: Zaman çizelgesi
-        view_full_profile: Tüm profili Görüntüle
+        activity: Activity
+        badges: Badges
+        followers: Followers
+        following: Follows
+        groups: Groups
+        members: Members
+        timeline: Timeline
+        view_full_profile: View full profile
       sidebar:
         badges:
-          info: Platformda belirli faaliyetler gerçekleştirilerek rozetler kazanılır.
-          title: Rozetler
+          info: Badges are earned by performing specific activity in the platform.
+          title: Badges
       user:
-        confirmation_instructions_sent: E-posta doğrulama talimatları gönderildi
-        create_user_group: Grup oluştur
-        edit_profile: Profili Düzenle
-        edit_user_group: Grup profilini düzenle
-        fill_in_email_to_confirm_it: Lütfen onaylamak için grubunuzun e-posta adresini doldurun
-        invite_user: Kullanıcı davet et
-        join_user_group: Gruba katılma isteği
-        leave_user_group: Gruptan ayrıl
-        manage_user_group_admins: Yöneticileri yönet
-        manage_user_group_users: Üyeleri yönet
-        resend_email_confirmation_instructions: E-posta doğrulama talimatlarını tekrar gönder
+        confirmation_instructions_sent: Email confirmation instructions sent
+        create_user_group: Create group
+        edit_profile: Edit profile
+        edit_user_group: Edit group profile
+        fill_in_email_to_confirm_it: Please, fill in your group's email to confirm it
+        invite_user: Invite user
+        join_user_group: Request to join group
+        leave_user_group: Leave group
+        manage_user_group_admins: Manage admins
+        manage_user_group_users: Manage members
+        resend_email_confirmation_instructions: Resend email confirmation instructions
     reported_mailer:
       hide:
-        hello: Merhaba %{name}
-        manage_moderations: Denetimleri yönet
-        report_html: <p>Aşağıdaki <a href="%{url}">içerik</a> otomatik olarak gizlendi.</p>
-        subject: Bir kaynak otomatik olarak gizlendi
+        hello: Hello %{name},
+        manage_moderations: Manage moderations
+        report_html: <p>The following <a href="%{url}">content</a> has been hidden automatically.</p>
+        subject: A resource has been hidden automatically
       report:
-        hello: Merhaba %{name}
-        manage_moderations: Denetimleri yönet
-        report_html: <p>Aşağıdaki <a href="%{url}">içerik</a> bildirilmiştir.</p>
-        subject: Bir kaynak rapor edildi
+        hello: Hello %{name},
+        manage_moderations: Manage moderations
+        report_html: <p>The following <a href="%{url}">content</a> has been reported.</p>
+        subject: A resource has been reported
     reports:
       create:
-        error: Rapor oluşturulurken bir hata oluştu. Lütfen tekrar dene.
-        success: Rapor başarıyla oluşturuldu ve bir yönetici tarafından incelenecek.
+        error: An error ocurred while creating the report. Please, try it again.
+        success: The report has been created successfully and it will be reviewed by an admin.
     scopes:
-      global: Küresel kapsamı
+      global: Global scope
       picker:
-        cancel: İptal etmek
-        choose: seçmek
-        title: '%{field}Seç'
-      prompt: Bir kapsam seçin
-      scopes: kapsamları
+        cancel: Cancel
+        choose: Select
+        title: Select %{field}
+      prompt: Select a scope
+      scopes: Scopes
     search:
-      results_found_for_term: '%{count} Arama için sonuçlar: "%{term}"'
-      term_input_placeholder: Arama
+      results_found_for_term: '%{count} Results for the search: "%{term}"'
+      term_input_placeholder: Search
     searches:
       filters:
-        back: Sonuçlara dön
-        jump_to: 'Atlamak:'
+        back: Back to results
+        jump_to: 'Jump to:'
         state:
-          active: Aktif
-          all: Herşey
-          future: gelecek
-          past: geçmiş
+          active: Active
+          all: All
+          future: Future
+          past: Past
       filters_small_view:
-        close_modal: Yakın kalıcı
-        filter: filtre
-        filter_by: Tarafından filtre
-        unfold: açılmak
+        close_modal: Close modal
+        filter: Filter
+        filter_by: Filter by
+        unfold: Unfold
       results:
         results:
-          one: "%{count} sonuç"
-          other: "%{count} sonuç"
-        view_all: Tümünü görüntüle (%{count})
+          one: "%{count} result"
+          other: "%{count} results"
+        view_all: View all (%{count})
     shared:
       embed_modal:
-        close_window: Pencereyi kapat
-        embed: Lütfen bu kodu sayfanıza yapıştırın
-        embed_link: Göm
+        close_window: Close window
+        embed: Please paste this code in your page
+        embed_link: Embed
       extended_navigation_bar:
-        more: Daha
-        unfold: açılmak
+        more: More
+        unfold: Unfold
       flag_modal:
-        already_reported: Bu içerik zaten bildirilmiştir ve bir yönetici tarafından incelenecektir.
-        close: Kapat
-        description: Bu içerik uygunsuz mu?
-        does_not_belong: Yasadışı etkinlik, intihar tehditleri, kişisel bilgiler veya %{organization_name}ait olmadığını düşündüğünüz başka bir şey içeriyor.
-        offensive: Irkçılığı, cinsiyetçiliği, sarsıntıları, kişisel saldırıları, ölüm tehditlerini, intihar isteklerini veya herhangi bir nefret söylemini içerir.
-        report: Rapor
-        spam: Tıklama, reklam, dolandırıcılık veya komut dosyası botları içerir.
-        title: Sorun bildir
+        already_reported: This content is already reported and it will be reviewed by an admin.
+        close: Close
+        description: Is this content inappropriate?
+        does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+        offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+        report: Report
+        spam: Contains clickbait, advertising, scams or script bots.
+        title: Report a problem
       floating_help:
-        help: yardım et
+        help: Help
       follow_button:
-        sign_in_before_follow: Bu eylemi gerçekleştirmeden önce lütfen giriş yapın
+        sign_in_before_follow: Please sign in before performing this action
       login_modal:
-        please_sign_in: Lütfen giriş yapın
-        sign_up: kaydol
+        please_sign_in: Please sign in
+        sign_up: Sign up
       reference:
-        reference: 'Referans: %{reference}'
+        reference: 'Reference: %{reference}'
       results_per_page:
-        label: 'Sayfa başına sonuç:'
+        label: 'Results per page:'
       share_modal:
-        close_window: Pencereyi kapat
-        share: Pay
-        share_link: Linki paylaş
+        close_window: Close window
+        share: Share
+        share_link: Share link
       version_author:
-        deleted: Silinmiş kullanıcı
+        deleted: Deleted user
     user_activity:
       index:
-        no_activities_warning: Bu kullanıcının henüz herhangi bir etkinliği olmadı.
+        no_activities_warning: This user hasn't had any activity yet.
     user_interests:
       show:
-        no_scopes: Bu organizasyonun henüz bir kapsamı yok!
-        my_interests: İlgi alanlarım
-        select_your_interests: Profil Zaman Çizelgesi sekmesinde kendileriyle ilgili etkinlikleri almak için ilgilendiğiniz konuları seçin.
-        update_my_interests: İlgi alanlarımı güncelle
+        my_interests: My interests
+        no_scopes: This organization doesn't have any scope yet!
+        select_your_interests: Select the topics you're interested in to receive events related to them in your profile Timeline tab.
+        update_my_interests: Update my interests
       update:
-        error: İlgi alanlarınız güncellenirken bir hata oluştu.
-        success: İlgi alanlarınız başarıyla güncellendi.
+        error: There was an error while updating your interests.
+        success: Your interests have been successfully updated.
     welcome_notification:
-      default_body: <p>Merhaba {{name}}, {{organization}} katıldığınız için teşekkürler ve hoş geldiniz!</p><ul><li>Burada neler yapabileceğiniz hakkında hızlı bir fikir edinmek istiyorsanız, <a href="{{help_url}}">Yardım</a> bölümüne bakın.</li><li>Okuduktan sonra ilk rozetinizi alacaksınız. İşte bu <a href="{{badges_url}}">tüm rozetlerle listesi</a> size katılmak olarak alabilirsiniz {{organization}}</li><li>onlarla Son ama en az, diğer insanları birleştirmek, paylaşmak yapan ve katılan olma deneyimi {{organization}}. Öneriler, yorumlar, tartışmalar yapın, ortak iyiliğe nasıl katkıda bulunacağınızı düşünün, ikna edeceğiniz argümanlar sunun, ikna olun, ikna olun, fikirlerinizi somut ve doğrudan bir şekilde ifade edin, sabır ve kararla karşılık verin, fikirlerinizi savunun ve saklayın. İşbirliği yapmak ve diğer insanların fikirlerine katılmak için açık bir zihin.</li></ul>
-      default_subject: '{{organization}}katıldığınız için teşekkürler!'
+      default_body: <p>Hi {{name}}, thanks for joining {{organization}} and welcome!</p><ul><li>If you want to get a quick idea of what you can do here, have a look at the <a href="{{help_url}}">Help</a> section.</li><li>Once you have read it you will get your first badge. Here's a <a href="{{badges_url}}">list of all the badges</a> you can get as you participate in {{organization}}</li><li>Last but not least, join other people, share with them the experience of being engaged and participating in {{organization}}. Make proposals, comments, debate, think about how to contribute to the common good, provide arguments to convince, listen and read to be convinced, express your ideas in a concrete and direct way, respond with patience and decision, defend your ideas and keep an open mind to collaborate and join other people's ideas.</li></ul>
+      default_subject: Thanks for joining {{organization}}!
   devise:
     confirmations:
-      confirmed: E-posta adresiniz başarıyla onaylandı.
+      confirmed: Your email address has been successfully confirmed.
       new:
-        resend_confirmation_instructions: Onay talimatlarını tekrar gönder
-      send_instructions: E-posta adresinizi birkaç dakika içinde nasıl doğrulayacağınız ile ilgili talimatları içeren bir e-posta alacaksınız.
-      send_paranoid_instructions: E-posta adresiniz veritabanımızda mevcutsa, birkaç dakika içinde e-posta adresinizi nasıl doğrulayacağınız ile ilgili talimatları içeren bir e-posta alacaksınız.
+        resend_confirmation_instructions: Resend confirmation instructions
+      send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
-      already_authenticated: Zaten oturum açtınız.
-      inactive: Hesabınız henüz aktifleştirilmedi.
-      invalid: '%{authentication_keys} veya şifre geçersiz.'
-      invited: Bekleyen bir davetiniz var, hesabınızı oluşturmayı bitirmek için kabul edin.
-      last_attempt: Hesabınız kilitlenmeden önce bir kez daha denemeniz var.
-      locked: Hesabınız kilitli.
-      not_found_in_database: '%{authentication_keys} veya şifre geçersiz.'
-      timeout: Oturumunuzun süresi doldu. Devam etmek için lütfen tekrar oturum açın.
-      unauthenticated: Devam etmeden önce giriş yapmalı veya kaydolmalısınız.
+      already_authenticated: You are already signed in.
+      inactive: Your account is not activated yet.
+      invalid: Invalid %{authentication_keys} or password.
+      invited: You have a pending invitation, accept it to finish creating your account.
+      last_attempt: You have one more attempt before your account is locked.
+      locked: Your account is locked.
+      not_found_in_database: Invalid %{authentication_keys} or password.
+      timeout: Your session expired. Please sign in again to continue.
+      unauthenticated: You need to sign in or sign up before continuing.
     invitations:
       edit:
-        header: Hesabınızı oluşturmayı bitirin
-        nickname_help: Benzersiz tanımlayıcınız %{organization}.
-        submit_button: Kayıt etmek
-        subtitle: Davetiyeyi kabul ederseniz, lütfen takma adınızı ve şifrenizi ayarlayın.
-      invitation_removed: Davetiniz kaldırıldı.
-      invitation_token_invalid: Sağlanan davet jetonu geçerli değil!
+        header: Finish creating your account
+        nickname_help: Your unique identifier in %{organization}.
+        submit_button: Save
+        subtitle: If you accept the invitation please set your nickname and password.
+      invitation_removed: Your invitation was removed.
+      invitation_token_invalid: The invitation token provided is not valid!
       new:
-        header: Davetiye gönder
-        submit_button: Davet gönder
-      no_invitations_remaining: Kalan davet yok
-      send_instructions: Davet e-postası %{email}gönderildi.
-      updated: Şifreniz başarıyla ayarlandı. Şimdi oturum açtınız.
-      updated_not_active: Şifreniz başarıyla ayarlandı.
+        header: Send invitation
+        submit_button: Send an invitation
+      no_invitations_remaining: No invitations remaining
+      send_instructions: An invitation email has been sent to %{email}.
+      updated: Your password was set successfully. You are now signed in.
+      updated_not_active: Your password was set successfully.
     mailer:
       confirmation_instructions:
-        action: Hesabımı onayla
-        greeting: Hoşgeldin %{recipient}!
-        instruction: 'Hesap e-postanızı aşağıdaki bağlantıdan onaylayabilirsiniz:'
-        subject: Onaylama talimatları
+        action: Confirm my account
+        greeting: Welcome %{recipient}!
+        instruction: 'You can confirm your account email through the link below:'
+        subject: Confirmation instructions
       email_changed:
-        greeting: Merhaba %{recipient}!
-        message: E-postanızın %{email}olarak değiştirildiğini bildirmek için sizinle iletişim kurarız.
-        subject: E-posta Değişti
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your email is being changed to %{email}.
+        subject: Email Changed
       invitation_instructions:
-        accept: Daveti kabul etmek
-        accept_until: Bu davetiye %{due_date}.
-        decline: Davet reddet
-        hello: Merhaba %{email}
+        accept: Accept invitation
+        accept_until: This invitation will be due in %{due_date}.
+        decline: Decline invitation
+        hello: Hello %{email},
         ignore: |-
-          Davetiyeyi kabul etmek istemiyorsanız, lütfen bu e-postayı yoksayın.<br />
-          Yukarıdaki bağlantıya erişip takma adınızı ve şifrenizi ayarlayana kadar hesabınız oluşturulmaz.
-        invited_you_as_admin: "%{invited_by} sizi %{application}yönetici olarak davet etti. Aşağıdaki bağlantıdan kabul edebilirsiniz."
-        invited_you_as_private_user: "%{invited_by} özel bir kullanıcı olarak davet etti %{application}. Aşağıdaki bağlantıdan kabul edebilirsiniz."
-        someone_invited_you: Birisi sizi %{application}davet etti. Aşağıdaki bağlantıdan kabul edebilirsiniz.
-        someone_invited_you_as_admin: Birisi sizi %{application}yönetici olarak davet etti, aşağıdaki bağlantıdan kabul edebilirsiniz.
-        someone_invited_you_as_private_user: Birisi sizi %{application}private_user olarak davet etti, aşağıdaki bağlantıdan kabul edebilirsiniz.
-        subject: Davet talimatları
+          If you don't want to accept the invitation, please ignore this email.<br />
+          Your account won't be created until you access the link above and set your nickname and password.
+        invited_you_as_admin: "%{invited_by} has invited you as an admin of %{application}. You can accept it through the link below."
+        invited_you_as_private_user: "%{invited_by} has invited you as a private user of %{application}. You can accept it through the link below."
+        someone_invited_you: Someone has invited you to %{application}. You can accept it through the link below.
+        someone_invited_you_as_admin: Someone has invited you as an admin of %{application}, you can accept it through the link below.
+        someone_invited_you_as_private_user: Someone has invited you as private_user of %{application}, you can accept it through the link below.
+        subject: Invitation instructions
       invite_admin:
-        subject: '%{organization}yönetmeye davet edildiniz'
+        subject: You've been invited to manage %{organization}
       invite_collaborator:
-        subject: '%{organization}ortak çalışmaya davet edildiniz'
+        subject: You've been invited to collaborate on %{organization}
       invite_private_user:
-        subject: '%{organization}özel bir katılımcı sürecine davet edildiniz'
+        subject: You've been invited to a private participatory process on %{organization}
       organization_admin_invitation_instructions:
-        subject: '%{organization}yönetmeye davet edildiniz'
+        subject: You've been invited to manage %{organization}
       password_change:
-        greeting: Merhaba %{recipient}!
-        message: Şifrenizin değiştirildiğini size bildirmek için sizinle iletişim kuruyoruz.
-        subject: şifre değişti
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your password has been changed.
+        subject: Password changed
       reset_password_instructions:
-        action: Şifremi Değiştir
-        greeting: Merhaba %{recipient}!
-        instruction: Birisi şifrenizi değiştirmek için bir bağlantı istedi ve bunu aşağıdaki bağlantıdan yapabilirsiniz.
-        instruction_2: Bunu istemediyseniz, lütfen bu e-postayı yoksayın.
-        instruction_3: Yukarıdaki bağlantıya erişip yeni bir tane oluşturana kadar şifreniz değişmeyecek.
-        subject: Şifre talimatlarını sıfırla
+        action: Change my password
+        greeting: Hello %{recipient}!
+        instruction: Someone has requested a link to change your password, and you can do this through the link below.
+        instruction_2: If you didn't request this, please ignore this email.
+        instruction_3: Your password won't change until you access the link above and create a new one.
+        subject: Reset password instructions
       unlock_instructions:
-        action: Hesabımın kilidini aç
-        greeting: Merhaba %{recipient}!
-        instruction: 'Hesabınızın kilidini açmak için aşağıdaki bağlantıyı tıklayın:'
-        message: Hesabınız, fazla sayıda başarısız giriş denemesi nedeniyle kilitlendi.
-        subject: Talimat kilidini
+        action: Unlock my account
+        greeting: Hello %{recipient}!
+        instruction: 'Click the link below to unlock your account:'
+        message: Your account has been locked due to an excessive amount of unsuccessful sign in attempts.
+        subject: Unlock instructions
     omniauth_callbacks:
-      failure: '"%{reason}" olduğu için %{kind} kimliğinizi doğrulayamadı.'
-      success: '%{kind} hesaptan başarıyla doğrulandı.'
+      failure: Could not authenticate you from %{kind} because "%{reason}".
+      success: Successfully authenticated from %{kind} account.
     passwords:
       edit:
-        change_my_password: Şifremi Değiştir
-        change_your_password: Şifreni değiştir
-        confirm_new_password: Yeni şifreyi onayla
-        new_password: Yeni Şifre
+        change_my_password: Change my password
+        change_your_password: Change your password
+        confirm_new_password: Confirm new password
+        new_password: New password
       new:
-        forgot_your_password: Parolanızı mı unuttunuz?
-        send_me_reset_password_instructions: Bana şifre sıfırlama talimatlarını gönder
-      no_token: Şifre sıfırlama e-postasından gelmeden bu sayfaya erişemezsiniz. Şifre sıfırlama e-postasından geliyorsanız, lütfen sağlanan URL’yi kullandığınızdan emin olun.
-      send_instructions: Birkaç dakika içinde şifrenizi nasıl sıfırlayacağınızla ilgili talimatları içeren bir e-posta alacaksınız.
-      send_paranoid_instructions: E-posta adresiniz veritabanımızda bulunuyorsa, birkaç dakika içinde e-posta adresinizde bir şifre kurtarma bağlantısı alacaksınız.
-      updated: Şifreniz başarıyla değiştirildi. Şimdi oturum açtınız.
-      updated_not_active: Şifreniz başarıyla değiştirildi.
+        forgot_your_password: Forgot your password?
+        send_me_reset_password_instructions: Send me reset password instructions
+      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+      updated: Your password has been changed successfully. You are now signed in.
+      updated_not_active: Your password has been changed successfully.
     registrations:
-      destroyed: Hoşçakal! Hesabınız başarıyla iptal edildi. Kısa süre sonra tekrar görmeyi umuyoruz.
+      destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
       edit:
-        are_you_sure: Emin misiniz?
-        cancel_my_account: Hesabımı iptal et
-        currently_waiting_confirmation_for_email: 'Şu an için bekleme onayı: %{email}'
-        leave_blank_if_you_don_t_want_to_change_it: değiştirmek istemiyorsanız boş bırakın
-        title: '%{resource}düzenle'
-        unhappy: Mutsuz?
-        update: Güncelleştirme
-        we_need_your_current_password_to_confirm_your_changes: değişikliklerinizi onaylamak için mevcut şifrenize ihtiyacımız var
+        are_you_sure: Are you sure?
+        cancel_my_account: Cancel my account
+        currently_waiting_confirmation_for_email: 'Currently waiting confirmation for: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
+        title: Edit %{resource}
+        unhappy: Unhappy?
+        update: Update
+        we_need_your_current_password_to_confirm_your_changes: we need your current password to confirm your changes
       new:
-        sign_up: kaydol
-      signed_up: Hoşgeldiniz! Başarıyla kaydoldunuz.
-      signed_up_but_inactive: Başarıyla kaydoldunuz. Ancak, hesabınız henüz aktif olmadığından sizi oturum açamadık.
-      signed_up_but_locked: Başarıyla kaydoldunuz. Ancak, hesabınız kilitlendiğinden sizi oturum açamadık.
-      signed_up_but_unconfirmed: E-posta adresinize onay bağlantısına sahip bir mesaj gönderildi. Hesabınızı etkinleştirmek için lütfen bağlantıyı takip edin.
-      update_needs_confirmation: Hesabınızı başarıyla güncellediniz, ancak yeni e-posta adresinizi doğrulamamız gerekiyor. Lütfen yeni e-posta adresinizi onaylamak için e-postanızı kontrol edin ve onaylama bağlantısını takip edin.
-      updated: Hesabınız başarıyla güncellendi.
+        sign_up: Sign up
+      signed_up: Welcome! You have signed up successfully.
+      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
+      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
+      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
+      update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.
+      updated: Your account has been updated successfully.
     sessions:
-      already_signed_out: Başarıyla imzalandı.
+      already_signed_out: Signed out successfully.
       new:
-        sign_in: Oturum aç
-      signed_in: Başarıyla imzalandı.
-      signed_out: Başarıyla imzalandı.
+        sign_in: Log in
+      signed_in: Signed in successfully.
+      signed_out: Signed out successfully.
     shared:
       links:
-        back: Geri
-        didn_t_receive_confirmation_instructions: Onaylama talimatları almadı mı?
-        didn_t_receive_unlock_instructions: Kilit açma talimatları almadı mı?
-        forgot_your_password: Parolanızı mı unuttunuz?
-        sign_in: Oturum aç
-        sign_in_with_provider: '%{provider}ile giriş yap'
-        sign_up: kaydol
+        back: Back
+        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+        forgot_your_password: Forgot your password?
+        sign_in: Log in
+        sign_in_with_provider: Sign in with %{provider}
+        sign_up: Sign up
       minimum_password_length:
-        one: "(En az%{count} karakter)"
-        other: "(En az%{count} karakter)"
+        one: "(%{count} character minimum)"
+        other: "(%{count} characters minimum)"
     unlocks:
       new:
-        resend_unlock_instructions: Kilit açma talimatlarını tekrar gönder
-      send_instructions: Hesabınızın birkaç dakika içinde nasıl açılacağıyla ilgili talimatları içeren bir e-posta alacaksınız.
-      send_paranoid_instructions: Hesabınız varsa, birkaç dakika içinde kilidini açmak için talimatları içeren bir e-posta alacaksınız.
-      unlocked: Hesabınız başarıyla açıldı. Devam etmek için giriş yapın.
+        resend_unlock_instructions: Resend unlock instructions
+      send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
+      send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
+      unlocked: Your account has been unlocked successfully. Please sign in to continue.
   doorkeeper:
     scopes:
-      public: Genel bilgileriniz.
+      public: Your public information.
   errors:
     messages:
-      already_confirmed: zaten onaylandı, lütfen giriş yapmayı deneyin
-      confirmation_period_expired: '%{period}içinde onaylanması gerekiyor, lütfen yeni bir tane isteyin'
-      content_type_whitelist_error: dosya türü geçerli değil
-      cycle_detected: bir kapsamın ebeveyni torunlarından biri olamaz
-      expired: süresi doldu, lütfen yeni bir tane isteyin
-      file_size_is_less_than_or_equal_to: dosya boyutu %{count}eşit veya daha küçük olmalıdır
-      long_words: çok uzun kelimeler içeriyor (35 karakterden fazla)
-      must_start_with_caps: büyük harfle başlamalıdır
-      nesting_too_deep: bir alt kategorinin içinde olamaz
-      not_found: bulunamadı
-      not_locked: kilitli değildi
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
+      content_type_whitelist_error: the file type is not valid
+      cycle_detected: a scope's parent can't be one of its descendants
+      expired: has expired, please request a new one
+      file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
+      long_words: contains words that are too long (over 35 characters)
+      must_start_with_caps: must start with a capital letter
+      nesting_too_deep: can't be inside of a subcategory
+      not_found: not found
+      not_locked: was not locked
       not_saved:
-        one: '1 hata bu yasak %{resource} kaydedilmesini:'
-        other: "%{count} hataları bu yasak %{resource} kaydedilmesini:"
-      too_many_marks: çok fazla ardışık noktalama işareti kullanıyor (örneğin! ve?)
-      too_much_caps: çok fazla büyük harf kullanıyor (metnin% 25'inden fazlası)
-      too_short: çok kısa (15 karakterin altında)
+        one: '1 error prohibited this %{resource} from being saved:'
+        other: "%{count} errors prohibited this %{resource} from being saved:"
+      too_many_marks: is using too many consecutive punctuation marks (e.g. ! and ?)
+      too_much_caps: is using too many capital letters (over 25% of the text)
+      too_short: is too short (under 15 characters)
   forms:
-    required: gereklidir
+    required: Required
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
-    sentence_for_humans: Eğer insansan, bu alanı görmezden gel
-    timestamp_error_message: Üzgünüm, bu çok hızlıydı! Lütfen yeniden gönderin.
+    sentence_for_humans: If you are human, ignore this field
+    timestamp_error_message: Sorry, that was too quick! Please resubmit.
   layouts:
     decidim:
       cookie_warning:
-        description_html: Bu sitede çerezler kullanılıyor. Siteye göz atmaya devam ederek, çerezleri kullanmamızı kabul edersiniz. Hakkında daha fazla bilgi edinin %{link}.
-        link_label: İşte
-        ok: katılıyorum
+        description_html: This site uses cookies. By continuing to browse the site, you agree to our use of cookies. Find out more about it %{link}.
+        link_label: here
+        ok: I agree
       edit_link:
-        edit: Düzenle
+        edit: Edit
       footer:
-        download_open_data: Açık Veri dosyalarını indir
-        made_with_open_source: Web sitesi <a target="_blank" href="https://github.com/decidim/decidim">ücretsiz yazılımla yapılmıştır</a>.
+        download_open_data: Download Open Data files
+        made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
       header:
-        close_menu: Menüyü kapat
-        navigation: navigasyon
-        sign_in: Oturum aç
-        sign_up: Kaydol
+        close_menu: Close menu
+        navigation: Navigation
+        sign_in: Sign In
+        sign_up: Sign Up
       impersonation_warning:
-        close_session: Oturumu kapat
-        description_html: Kullanıcının kimliğine bürünüyorsunuz <b>%{user_name}</b>.
-        expire_time_html: Seansınız <b><span class="minutes">%{minutes}</span> dakika</b>bitecek.
+        close_session: Close session
+        description_html: You are impersonating the user <b>%{user_name}</b>.
+        expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       notifications_dashboard:
-        mark_all_as_read: Tümünü okundu olarak işaretle
+        mark_all_as_read: Mark all as read
       user_menu:
-        admin_dashboard: Yönetici kontrol paneli
-        conversations: Konuşmalar
-        notifications: Bildirimler
-        profile: Hesabım
-        public_profile: Genel profilim
-        sign_out: oturumu Kapat
+        admin_dashboard: Admin dashboard
+        conversations: Conversations
+        notifications: Notifications
+        profile: My account
+        public_profile: My public profile
+        sign_out: Sign out
       user_profile:
-        account: hesap
-        authorizations: Yetkileri
-        delete_my_account: Hesabımı sil
-        my_data: Benim verim
-        my_interests: İlgi alanlarım
-        notifications_settings: Bildirimler ayarları
-        title: Kullanıcı ayarları
-        user_groups: Gruplar
+        account: Account
+        authorizations: Authorizations
+        delete_my_account: Delete my account
+        my_data: My data
+        my_interests: My interests
+        notifications_settings: Notifications settings
+        title: User settings
+        user_groups: Groups
       widget:
-        see_more: Daha fazla gör
+        see_more: See more
   locale:
-    name: ingilizce
+    name: English
   password_validator:
-    domain_included_in_password: bu alan adına çok benzer
-    email_included_in_password: e-postanıza çok benzer
-    fallback: geçerli değil
-    name_included_in_password: adınıza çok benzer
-    not_enough_unique_characters: yeterli benzersiz karakter yok
-    password_not_allowed: Müsade edilmez
-    password_too_common: çok yaygın
-    password_too_long: çok uzun
-    password_too_short: çok kısa
+    domain_included_in_password: is too similar to this domain name
+    email_included_in_password: is too similar to your email
+    fallback: is not valid
+    name_included_in_password: is too similar to your name
+    not_enough_unique_characters: does not have enough unique characters
+    password_not_allowed: is not allowed
+    password_too_common: is too common
+    password_too_long: is too long
+    password_too_short: is too short
   social_share_button:
-    delicious: Lezzetli
+    delicious: Delicious
     douban: Douban
-    email: E-posta
+    email: Email
     facebook: Facebook
     google_bookmark: Google Bookmark
     google_plus: Google+
-    hacker_news: Hacker Haberler
+    hacker_news: Hacker News
     linkedin: Linkedin
-    pinterest: pinterest
+    pinterest: Pinterest
     qq: Qzone
     reddit: Reddit
-    share_to: '%{name}Paylaş'
+    share_to: Share to %{name}
     tumblr: Tumblr
-    twitter: heyecan
+    twitter: Twitter
     vkontakte: Vkontakte
     wechat: WeChat
-    wechat_footer: WeChat'inizi açın, "Keşfet" butonuna tıklayın ve "QR Kodunu Tara" menüsüne tıklayın.
+    wechat_footer: Open your WeChat, click "Discover" button then click the "Scan QR Code" menu.
     weibo: Sina Weibo
     xing: Xing
   time:
@@ -1259,8 +1270,8 @@ tr:
       time_of_day: "%H:%M"
   views:
     pagination:
-      first: "&laquo; İlk"
-      last: Son &raquo;
-      next: Sonraki &rsaquo;
-      previous: "&lsaquo; Önceki"
+      first: "&laquo; First"
+      last: Last &raquo;
+      next: Next &rsaquo;
+      previous: "&lsaquo; Prev"
       truncate: "&hellip;"

--- a/decidim-core/config/locales/uk.yml
+++ b/decidim-core/config/locales/uk.yml
@@ -16,6 +16,10 @@ uk:
         personal_url: Особиста веб-адреса
         remove_avatar: Видалити аватар
     models:
+      decidim/amendable/amendment_accepted_event: Amendmen accepted
+      decidim/amendable/amendment_created_event: Amendmen created
+      decidim/amendable/amendment_rejected_event: Amendmen rejected
+      decidim/amendable/emendation_promoted_event: Amendmen promoted
       decidim/attachment_created_event: Вкладений файл
       decidim/component_published_event: Діюча складова
       decidim/demoted_membership: No longer a group admin
@@ -1163,6 +1167,17 @@ uk:
       too_short: is too short (under 15 characters)
   forms:
     required: Обов'язкове поле
+  instructions:
+    decidim:
+      system:
+        organizations:
+          smtp_settings:
+            address: Address
+            from_email: From email
+            from_label: From label
+            password: Password
+            port: Port
+            user_name: User name
   invisible_captcha:
     sentence_for_humans: Якщо ви людина, ігноруйте це поле
     timestamp_error_message: Вибачте, це було занадто швидко! Будь ласка, подайте повідомлення знову.

--- a/decidim-core/db/migrate/20181219130325_add_smtp_settings_to_decidim_organizations.rb
+++ b/decidim-core/db/migrate/20181219130325_add_smtp_settings_to_decidim_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSmtpSettingsToDecidimOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :smtp_settings, :jsonb
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -23,6 +23,13 @@ if !Rails.env.production? || ENV["SEED"]
     instagram_handler: Faker::Hipster.word,
     youtube_handler: Faker::Hipster.word,
     github_handler: Faker::Hipster.word,
+    smtp_settings: {
+      from: Faker::Internet.email,
+      user_name: Faker::Twitter.unique.screen_name,
+      encrypted_password: Decidim::AttributeEncryptor.encrypt(Faker::Internet.password(8)),
+      address: ENV["DECIDIM_HOST"] || "localhost",
+      port: ENV["DECIDIM_SMTP_PORT"] || "25"
+    },
     host: ENV["DECIDIM_HOST"] || "localhost",
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
       Decidim::Faker::Localized.sentence(15)

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -16,6 +16,8 @@ if !Rails.env.production? || ENV["SEED"]
     table.tr("_", "/").classify.safe_constantize
   end.compact.each(&:reset_column_information)
 
+  smtp_email = Faker::Internet.email
+
   organization = Decidim::Organization.first || Decidim::Organization.create!(
     name: Faker::Company.name,
     twitter_handler: Faker::Hipster.word,
@@ -24,7 +26,9 @@ if !Rails.env.production? || ENV["SEED"]
     youtube_handler: Faker::Hipster.word,
     github_handler: Faker::Hipster.word,
     smtp_settings: {
-      from: Faker::Internet.email,
+      from: "#{smtp_email} <#{smtp_email}>",
+      from_email: smtp_email,
+      from_label: smtp_email,
       user_name: Faker::Twitter.unique.screen_name,
       encrypted_password: Decidim::AttributeEncryptor.encrypt(Faker::Internet.password(8)),
       address: ENV["DECIDIM_HOST"] || "localhost",

--- a/decidim-core/lib/decidim/attribute_encryptor.rb
+++ b/decidim-core/lib/decidim/attribute_encryptor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  class AttributeEncryptor
+    def self.encrypt(string)
+      cryptor.encrypt_and_sign(string) if string.present?
+    end
+
+    def self.decrypt(string_encrypted)
+      cryptor.decrypt_and_verify(string_encrypted) if string_encrypted.present?
+    end
+
+    def self.cryptor
+      key = ActiveSupport::KeyGenerator.new("attribute").generate_key(
+        Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+      )
+      ActiveSupport::MessageEncryptor.new(key)
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -6,6 +6,7 @@ require "decidim/core/version"
 # Decidim configuration.
 module Decidim
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
+  autoload :JsonbAttributes, "decidim/jsonb_attributes"
   autoload :FormBuilder, "decidim/form_builder"
   autoload :AuthorizationFormBuilder, "decidim/authorization_form_builder"
   autoload :FilterFormBuilder, "decidim/filter_form_builder"
@@ -54,6 +55,7 @@ module Decidim
   autoload :MetricManifest, "decidim/metric_manifest"
   autoload :MetricOperation, "decidim/metric_operation"
   autoload :MetricOperationManifest, "decidim/metric_operation_manifest"
+  autoload :AttributeEncryptor, "decidim/attribute_encryptor"
   autoload :NewsletterEncryptor, "decidim/newsletter_encryptor"
   autoload :Searchable, "decidim/searchable"
   autoload :SearchResourceFieldsMapper, "decidim/search_resource_fields_mapper"

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -87,6 +87,15 @@ FactoryBot.define do
     badges_enabled { true }
     user_groups_enabled { true }
     send_welcome_notification { true }
+    smtp_settings do
+      {
+        "from" => "test@example.org",
+        "user_name" => "test",
+        "encrypted_password" => Decidim::AttributeEncryptor.encrypt("demo"),
+        "port" => "25",
+        "address" => "smtp.example.org"
+      }
+    end
 
     after(:create) do |organization|
       tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: organization)

--- a/decidim-core/lib/decidim/jsonb_attributes.rb
+++ b/decidim-core/lib/decidim/jsonb_attributes.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A set of convenient methods to generate dynamic jsonb objects in a way is
+  # compatilbe with Virtus and ActiveModel thus making it easy to integrate
+  # into Rails forms and similar workflows.
+  module JsonbAttributes
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Public: Mirrors Virtus `attribute` interface to define attributes in
+      # custom jsonb objects.
+      #
+      # name - Attribute's name
+      # fields - The attribute's child fields
+      #
+      # Example:
+      #   jsonb_attribute(:settings, [[:custom_setting, String], [:another_setting, Boolean])
+      #   # This will generate `custom_setting`, `custom_setting=` and
+      #   # `another_setting`, `another_setting=` and will keep them
+      #   # syncronized with a hash in `settings`:
+      #   # settings = { "custom_setting" => "demo", "another_setting" => "demo"}
+      #
+      # Returns nothing.
+      def jsonb_attribute(name, fields, *options)
+        attribute name, Hash, default: {}
+
+        fields.each do |f, type|
+          attribute f, type, *options
+          define_method f do
+            field = public_send(name) || {}
+            field[f.to_s] || field[f.to_sym]
+          end
+
+          define_method "#{f}=" do |value|
+            field = public_send(name) || {}
+            public_send("#{name}=", field.merge(f => super(value)))
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/jsonb_attributes_spec.rb
+++ b/decidim-core/spec/lib/jsonb_attributes_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe JsonbAttributes do
+    let(:klass) do
+      Class.new do
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "dummy")
+        end
+
+        include ActiveModel::Model
+        include Virtus.model
+        include JsonbAttributes
+      end
+    end
+
+    let(:model) { klass.new }
+
+    describe "#jsonb_attribute do" do
+      before do
+        klass.class_eval do
+          jsonb_attribute :settings, [
+            [:custom_setting, String],
+            [:another_setting, String]
+          ]
+        end
+      end
+
+      it "creates a getter for each attribute" do
+        model.settings = { custom_setting: "demo", another_setting: "random" }
+
+        expect(model.custom_setting).to eq("demo")
+        expect(model.another_setting).to eq("random")
+      end
+
+      it "creates a setter for each attribute" do
+        model.custom_setting = "new setting"
+        model.another_setting = "random setting"
+
+        expect(model.settings).to include(custom_setting: "new setting")
+        expect(model.settings).to include(another_setting: "random setting")
+      end
+
+      it "coerces values" do
+        model.custom_setting = 1
+        expect(model.custom_setting).to eq("1")
+      end
+    end
+  end
+end

--- a/decidim-debates/config/locales/fi-pl.yml
+++ b/decidim-debates/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -59,6 +60,9 @@ fi-pl:
           update:
             invalid: Keskustelun päivittämisessä tapahtui virhe.
             success: Keskustelu päivitetty onnistuneesti.
+        exports:
+          comments: comments
+          debates: debates
         models:
           debate:
             name: Keskustelu
@@ -140,7 +144,7 @@ fi-pl:
       badges:
         commented_debates:
           conditions:
-            - Valitse avoin keskustelu ja osallistu siihen
+          - Valitse avoin keskustelu ja osallistu siihen
           description: Tämä kunniamerkki myönnetään, kun osallistut aktiivisesti eri keskusteluihin.
           description_another: Tämä käyttäjä on osallistunut %{score} keskusteluun.
           description_own: Olet osallistunut %{score} keskusteluun.

--- a/decidim-debates/config/locales/id-ID.yml
+++ b/decidim-debates/config/locales/id-ID.yml
@@ -1,138 +1,158 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       debate:
-        category_id: Kategori
-        decidim_category_id: Kategori
-        description: Deskripsi
-        end_time: Berakhir pada
-        information_updates: Pembaruan informasi
-        instructions: Instruksi untuk berpartisipasi
-        start_time: Mulai dari
-        title: Judul
-        user_group_id: Buat debat sebagai
+        category_id: Category
+        decidim_category_id: Category
+        description: Description
+        end_time: Ends at
+        information_updates: Information updates
+        instructions: Instructions to participate
+        start_time: Starts at
+        title: Title
+        user_group_id: Create debate as
     models:
-      decidim/debates/create_debate_event: Perdebatan
-      decidim/debates/creation_disabled_event: Debat dinonaktifkan
-      decidim/debates/creation_enabled_event: Debat diaktifkan
+      decidim/debates/create_debate_event: Debate
+      decidim/debates/creation_disabled_event: Debates disabled
+      decidim/debates/creation_enabled_event: Debates enabled
   activerecord:
     models:
       decidim/debates/debate:
-        other: Debat
+        one: Debate
+        other: Debates
   decidim:
     components:
       debates:
         actions:
-          create: Membuat
-        name: Debat
+          create: Create
+        name: Debates
         settings:
           global:
-            announcement: Pengumuman
-            comments_enabled: Komentar diaktifkan
+            announcement: Announcement
+            comments_enabled: Comments enabled
           step:
-            announcement: Pengumuman
-            comments_blocked: Komentar diblokir
+            announcement: Announcement
+            comments_blocked: Comments blocked
+            creation_enabled: Debate creation by users enabled
     debates:
       actions:
-        confirm_destroy: Apakah kamu yakin
-        destroy: Menghapus
+        confirm_destroy: Are you sure?
+        destroy: Delete
         edit: Edit
-        new: Baru %{name}
-        title: Tindakan
+        new: New %{name}
+        title: Actions
       admin:
         debates:
+          create:
+            invalid: There has been a problem while creating the debate.
+            success: Debate created successfully.
+          destroy:
+            success: Debate deleted successfully.
           edit:
-            title: Edit debat
-            update: Perbarui debat
+            title: Edit debate
+            update: Update debate
           index:
-            title: Debat
+            title: Debates
           new:
-            create: Buat debat
-            title: Debat baru
+            create: Create debate
+            title: New debate
+          update:
+            invalid: There has been a problem while updating this debate.
+            success: Debate updated successfully.
+        exports:
+          comments: comments
+          debates: debates
         models:
           debate:
-            name: Perdebatan
+            name: Debate
       admin_log:
         debate:
-          create: "%{user_name} menciptakan debat %{resource_name} pada %{space_name} ruang"
-          update: "%{user_name} memperbarui perdebatan %{resource_name} pada %{space_name} ruang"
+          create: "%{user_name} created the %{resource_name} debate on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} debate on the %{space_name} space"
       debates:
         count:
           debates_count:
-            other: "%{count} debat"
+            one: "%{count} debate"
+            other: "%{count} debates"
+        create:
+          invalid: There has been a problem while creating the debate.
+          success: Debate created successfully.
         debate:
-          participate: Ikut
+          participate: Participate
         filters:
-          all: Semua
-          category: Kategori
-          category_prompt: Pilih Kategori
-          citizens: Warga
-          official: Resmi
-          origin: Asal
-          search: Pencarian
+          all: All
+          category: Category
+          category_prompt: Select a category
+          citizens: Citizens
+          official: Official
+          origin: Origin
+          search: Search
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Saring menurut
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         index:
-          new_debate: Debat baru
+          new_debate: New debate
         new:
-          back: Kembali
-          create: Membuat
-          select_a_category: Silakan pilih kategori
-          title: Debat baru
+          back: Back
+          create: Create
+          select_a_category: Please select a category
+          title: New debate
         share:
-          close_window: Tutup jendela
-          share: Bagikan
-          share_link: Membagikan tautan
+          close_window: Close window
+          share: Share
+          share_link: Share link
       last_activity:
-        new_debate_at_html: "<span>Debat baru di %{link}</span>"
+        new_debate_at_html: "<span>New debate at %{link}</span>"
       models:
         debate:
           fields:
-            end_time: Tanggal akhir
-            official_debate: Debat resmi
-            start_time: Mulai tanggal
-            title: Judul
+            end_time: End date
+            official_debate: Official debate
+            start_time: Start date
+            title: Title
     events:
       debates:
         create_debate_event:
           space_followers:
             email_intro: |-
-              Hai,
-              Debat baru "%{resource_title}" telah dibuat di %{space_title} ruang partisipatif, periksa dan berkontribusi:
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{space_title} ruang partisipatif. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-            email_subject: Perdebatan baru "%{resource_title}" pada %{space_title}
-            notification_title: Debat <a href="%{resource_path}">%{resource_title}</a> dibuat pada <a href="%{space_path}">%{space_title}</a>.
+              Hi,
+              A new debate "%{resource_title}" has been created on the %{space_title} participatory space, check it out and contribute:
+            email_outro: You have received this notification because you are following the %{space_title} participatory space. You can stop receiving notifications following the previous link.
+            email_subject: New debate "%{resource_title}" on %{space_title}
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was created on <a href="%{space_path}">%{space_title}</a>.
           user_followers:
             email_intro: |-
-              Hai,
-              %{author_name} %{author_nickname}, yang Anda ikuti, telah membuat debat baru "%{resource_title}". Lihat dan berkontribusi:
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{author_nickname}. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-            email_subject: Perdebatan baru "%{resource_title}" oleh %{author_nickname}
-            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> menciptakan debat <a href="%{resource_path}">%{resource_title}</a>.
+              Hi,
+              %{author_name} %{author_nickname}, who you are following, has created a new debate "%{resource_title}". Check it out and contribute:
+            email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+            email_subject: New debate "%{resource_title}" by %{author_nickname}
+            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> created the <a href="%{resource_path}">%{resource_title}</a> debate.
         creation_disabled:
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Pembuatan debat dinonaktifkan pada %{participatory_space_title}
-          notification_title: Pembuatan debat sekarang dinonaktifkan di <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'Debate creation is no longer active in %{participatory_space_title}. You can still participate in opened debates from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debate creation disabled in %{participatory_space_title}
+          notification_title: Debate creation is now disabled in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         creation_enabled:
-          email_intro: 'Anda sekarang dapat memulai debat baru dalam %{participatory_space_title}! Mulai berpartisipasi di halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Debat sekarang tersedia dalam %{participatory_space_title}
-          notification_title: Anda sekarang dapat memulai <a href="%{resource_path}">debat baru</a> dalam <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can now start new debates in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debates now available in %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         commented_debates:
-          conditions:
-            - Pilih debat terbuka untuk ikut serta
-          description: Lencana ini diberikan ketika Anda berpartisipasi aktif dalam berbagai debat dengan meninggalkan komentar Anda.
-          description_own: Anda telah berpartisipasi dalam %{score} debat.
-          name: Debat
-          next_level_in: Berpartisipasi dalam %{score} debat lagi untuk mencapai level selanjutnya!
-          unearned_own: Anda belum berpartisipasi dalam debat apa pun.
+          conditions: '["Choose an open debate to take part in"]'
+          description: This badge is granted when you actively participate in the different debates by leaving your comments.
+          description_another: This user has participated in %{score} debates.
+          description_own: You have participated in %{score} debates.
+          name: Debates
+          next_level_in: Participate in %{score} more debates to reach the next level!
+          unearned_another: This user hasn't participated in any debate yet.
+          unearned_own: You haven't participated in any debates yet.
     metrics:
       debates:
-        description: Jumlah perdebatan dibuat
-        object: debat
-        title: Debat
+        description: Number of debates created
+        object: debates
+        title: Debates

--- a/decidim-debates/config/locales/tr-TR.yml
+++ b/decidim-debates/config/locales/tr-TR.yml
@@ -1,155 +1,158 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       debate:
-        category_id: Kategori
-        decidim_category_id: Kategori
-        description: Açıklama
-        end_time: Biter
-        information_updates: Bilgi güncellemeleri
-        instructions: Katılma talimatları
-        start_time: Den başlar
-        title: Başlık
-        user_group_id: Olarak tartışma oluştur
+        category_id: Category
+        decidim_category_id: Category
+        description: Description
+        end_time: Ends at
+        information_updates: Information updates
+        instructions: Instructions to participate
+        start_time: Starts at
+        title: Title
+        user_group_id: Create debate as
     models:
-      decidim/debates/create_debate_event: tartışma
-      decidim/debates/creation_disabled_event: Tartışmalar devre dışı bırakıldı
-      decidim/debates/creation_enabled_event: Tartışmalar etkin
+      decidim/debates/create_debate_event: Debate
+      decidim/debates/creation_disabled_event: Debates disabled
+      decidim/debates/creation_enabled_event: Debates enabled
   activerecord:
     models:
       decidim/debates/debate:
-        one: tartışma
-        other: Tartışmalar
+        one: Debate
+        other: Debates
   decidim:
     components:
       debates:
         actions:
-          create: yaratmak
-        name: Tartışmalar
+          create: Create
+        name: Debates
         settings:
           global:
-            announcement: duyuru
-            comments_enabled: Yorumlar etkin
+            announcement: Announcement
+            comments_enabled: Comments enabled
           step:
-            announcement: duyuru
-            comments_blocked: Yorumlar engellendi
-            creation_enabled: "Etkin kullanıcılar tarafından tartışma oluştur\n"
+            announcement: Announcement
+            comments_blocked: Comments blocked
+            creation_enabled: Debate creation by users enabled
     debates:
       actions:
-        confirm_destroy: Emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        new: Yeni %{name}
-        title: Eylemler
+        confirm_destroy: Are you sure?
+        destroy: Delete
+        edit: Edit
+        new: New %{name}
+        title: Actions
       admin:
         debates:
           create:
-            invalid: Tartışma oluşturulurken bir sorun oluştu.
-            success: Tartışma başarıyla oluşturuldu.
+            invalid: There has been a problem while creating the debate.
+            success: Debate created successfully.
           destroy:
-            success: Tartışma başarıyla silindi.
+            success: Debate deleted successfully.
           edit:
-            title: Tartışmayı düzenle
-            update: Tartışmayı güncelle
+            title: Edit debate
+            update: Update debate
           index:
-            title: Tartışmalar
+            title: Debates
           new:
-            create: Tartışma oluştur
-            title: Yeni tartışma
+            create: Create debate
+            title: New debate
           update:
-            invalid: Bu tartışmayı güncellerken bir sorun oluştu.
-            success: Tartışma başarıyla güncellendi.
+            invalid: There has been a problem while updating this debate.
+            success: Debate updated successfully.
+        exports:
+          comments: comments
+          debates: debates
         models:
           debate:
-            name: tartışma
+            name: Debate
       admin_log:
         debate:
-          create: "%{user_name} , %{space_name} alanda %{resource_name} tartışmasını yarattı"
-          update: "%{user_name} , %{space_name} uzayda %{resource_name} tartışmasını güncelledi"
+          create: "%{user_name} created the %{resource_name} debate on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} debate on the %{space_name} space"
       debates:
         count:
           debates_count:
-            one: "%{count} tartışma"
-            other: "%{count} tartışmalar"
+            one: "%{count} debate"
+            other: "%{count} debates"
         create:
-          invalid: Tartışma oluşturulurken bir sorun oluştu.
-          success: Tartışma başarıyla oluşturuldu.
+          invalid: There has been a problem while creating the debate.
+          success: Debate created successfully.
         debate:
-          participate: Katıl
+          participate: Participate
         filters:
-          all: Herşey
-          category: Kategori
-          category_prompt: bir kategori seç
-          citizens: Vatandaşlar
-          official: Resmi
-          origin: Menşei
-          search: Arama
+          all: All
+          category: Category
+          category_prompt: Select a category
+          citizens: Citizens
+          official: Official
+          origin: Origin
+          search: Search
         filters_small_view:
-          close_modal: Kalıcı modal
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         index:
-          new_debate: Yeni tartışma
+          new_debate: New debate
         new:
-          back: Geri
-          create: yaratmak
-          select_a_category: Lütfen bir kategori seçin
-          title: Yeni tartışma
+          back: Back
+          create: Create
+          select_a_category: Please select a category
+          title: New debate
         share:
-          close_window: Pencereyi kapat
-          share: Pay
-          share_link: Linki paylaş
+          close_window: Close window
+          share: Share
+          share_link: Share link
       last_activity:
-        new_debate_at_html: "<span> %{link}</span>yeni tartışma"
+        new_debate_at_html: "<span>New debate at %{link}</span>"
       models:
         debate:
           fields:
-            end_time: Bitiş tarihi
-            official_debate: Resmi tartışma
-            start_time: Başlangıç tarihi
-            title: Başlık
+            end_time: End date
+            official_debate: Official debate
+            start_time: Start date
+            title: Title
     events:
       debates:
         create_debate_event:
           space_followers:
             email_intro: |-
-              Merhaba,
-               %{space_title} katılımcı alanda yeni bir "%{resource_title}" tartışması oluşturuldu, inceleyin ve katkıda bulunun:
-            email_outro: '%{space_title} katılımcı alanı takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-            email_subject: '%{space_title}yeni tartışma "%{resource_title}"'
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> tartışması <a href="%{space_path}">%{space_title}</a>oluşturuldu.
+              Hi,
+              A new debate "%{resource_title}" has been created on the %{space_title} participatory space, check it out and contribute:
+            email_outro: You have received this notification because you are following the %{space_title} participatory space. You can stop receiving notifications following the previous link.
+            email_subject: New debate "%{resource_title}" on %{space_title}
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was created on <a href="%{space_path}">%{space_title}</a>.
           user_followers:
             email_intro: |-
-              Merhaba,
-              %{author_name} %{author_nickname}, takip ettiğiniz, yeni bir "%{resource_title}" tartışması yarattı. Şuna bir bakın ve katkıda bulunun:
-            email_outro: '%{author_nickname}takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-            email_subject: Yeni tartışma "%{resource_title}" ile %{author_nickname}
-            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <a href="%{resource_path}">%{resource_title}</a> tartışmasını yarattı.
+              Hi,
+              %{author_name} %{author_nickname}, who you are following, has created a new debate "%{resource_title}". Check it out and contribute:
+            email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+            email_subject: New debate "%{resource_title}" by %{author_nickname}
+            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> created the <a href="%{resource_path}">%{resource_title}</a> debate.
         creation_disabled:
-          email_intro: 'Tartışma oluşturma %{participatory_space_title} artık etkin değil. Bu sayfadan açılan tartışmalara hala katılabilirsiniz:'
-          email_outro: '%{participatory_space_title}takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-          email_subject: Tartışma oluşturma %{participatory_space_title}devre dışı
-          notification_title: Tartışma oluşturma şimdi <a href="%{participatory_space_url}">%{participatory_space_title}</a>devre dışı bırakıldı
+          email_intro: 'Debate creation is no longer active in %{participatory_space_title}. You can still participate in opened debates from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debate creation disabled in %{participatory_space_title}
+          notification_title: Debate creation is now disabled in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         creation_enabled:
-          email_intro: 'Artık %{participatory_space_title}yeni tartışmalara başlayabilirsiniz! Bu sayfaya katılmaya başlayın:'
-          email_outro: '%{participatory_space_title}takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-          email_subject: Şimdi tartışmalar %{participatory_space_title}
-          notification_title: Şimdi <a href="%{resource_path}">yeni tartışmaya başlayabilirsiniz.</a> <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can now start new debates in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Debates now available in %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         commented_debates:
-          conditions:
-            - Katılmak için açık bir tartışma seçin
-          description: Bu rozet, yorumlarınızı bırakarak farklı tartışmalara aktif olarak katıldığınızda verilir.
-          description_another: Bu kullanıcı %{score} tartışmaya katıldı.
-          description_own: '%{score} tartışmaya katıldınız.'
-          name: Tartışmalar
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} tartışmaya katılın!
-          unearned_another: Bu kullanıcı henüz herhangi bir tartışmaya katılmadı.
-          unearned_own: Henüz herhangi bir tartışmaya katılamadınız.
+          conditions: '["Choose an open debate to take part in"]'
+          description: This badge is granted when you actively participate in the different debates by leaving your comments.
+          description_another: This user has participated in %{score} debates.
+          description_own: You have participated in %{score} debates.
+          name: Debates
+          next_level_in: Participate in %{score} more debates to reach the next level!
+          unearned_another: This user hasn't participated in any debate yet.
+          unearned_own: You haven't participated in any debates yet.
     metrics:
       debates:
-        description: Oluşturulan tartışmaların sayısı
-        object: tartışmalar
-        title: Tartışmalar
+        description: Number of debates created
+        object: debates
+        title: Debates

--- a/decidim-dev/config/locales/fi-pl.yml
+++ b/decidim-dev/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -16,7 +17,7 @@ fi-pl:
       badges:
         test:
           conditions:
-            - Käytä testiympäristöä Decidimille.
+          - Käytä testiympäristöä Decidimille.
           description: Käyttäjät saavat tämän kunniamerkin luomalla testejä.
           description_another: Tämä käyttäjä on luonut %{score} testiä.
           description_own: Olet luonut %{score} testiä.

--- a/decidim-dev/config/locales/id-ID.yml
+++ b/decidim-dev/config/locales/id-ID.yml
@@ -1,12 +1,13 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       dummy_resource:
-        created_at: Dibuat di
-        field: Bidang saya
-        start_date: Mulai tanggal
-        title: Judul
-        updated_at: Diperbarui pada
+        created_at: Created at
+        field: My field
+        start_date: Start date
+        title: Title
+        updated_at: Updated at
   decidim:
     dummy:
       admin:
@@ -15,23 +16,25 @@ id:
     gamification:
       badges:
         test:
-          conditions:
-            - Gunakan lingkungan uji untuk decidim.
-          description_own: Anda telah membuat %{score} tes.
-          name: Tes
-          next_level_in: Buat %{score} tes lagi untuk mencapai level selanjutnya!
-          unearned_own: Anda belum membuat tes.
+          conditions: '["Use a test environment for decidim."]'
+          description: Users get this badge by creating tests.
+          description_another: This user has created %{score} tests.
+          description_own: You have created %{score} tests.
+          name: Tests
+          next_level_in: Create %{score} more tests to reach the next level!
+          unearned_another: This user hasn't created any tests yet.
+          unearned_own: You have created no tests yet.
     pages:
       home:
         statistics:
           bar: Bar
-          dummies_count_high: Dummies tinggi
-          dummies_count_medium: Media Dummies
+          dummies_count_high: Dummies high
+          dummies_count_medium: Dummies medium
           foo: Foo
     participatory_processes:
       statistics:
-        dummies_count_high: Dummies tinggi
-        dummies_count_medium: Media Dummies
+        dummies_count_high: Dummies high
+        dummies_count_medium: Dummies medium
     resource_links:
       test_link:
-        dummy_resource_dummy: Boneka terkait
+        dummy_resource_dummy: Related dummy

--- a/decidim-dev/config/locales/tr-TR.yml
+++ b/decidim-dev/config/locales/tr-TR.yml
@@ -1,40 +1,40 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       dummy_resource:
-        created_at: Adresinde düzenlendi
-        field: Benim alanım
-        start_date: Başlangıç tarihi
-        title: Başlık
-        updated_at: Adresinde güncellendi
+        created_at: Created at
+        field: My field
+        start_date: Start date
+        title: Title
+        updated_at: Updated at
   decidim:
     dummy:
       admin:
         exports:
-          dummies: Aptallar
+          dummies: Dummies
     gamification:
       badges:
         test:
-          conditions:
-            - Decidim için bir test ortamı kullanın.
-          description: Kullanıcılar testler oluşturarak bu rozeti alabilir.
-          description_another: Bu kullanıcı %{score} testi oluşturdu.
-          description_own: '%{score} test oluşturdunuz.'
-          name: Testler
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} test daha oluştur!
-          unearned_another: Bu kullanıcı henüz bir test oluşturmadı.
-          unearned_own: Henüz bir test oluşturmadınız.
+          conditions: '["Use a test environment for decidim."]'
+          description: Users get this badge by creating tests.
+          description_another: This user has created %{score} tests.
+          description_own: You have created %{score} tests.
+          name: Tests
+          next_level_in: Create %{score} more tests to reach the next level!
+          unearned_another: This user hasn't created any tests yet.
+          unearned_own: You have created no tests yet.
     pages:
       home:
         statistics:
           bar: Bar
-          dummies_count_high: Aptallar yüksek
-          dummies_count_medium: Aptallar orta
-          foo: foo
+          dummies_count_high: Dummies high
+          dummies_count_medium: Dummies medium
+          foo: Foo
     participatory_processes:
       statistics:
-        dummies_count_high: Aptallar yüksek
-        dummies_count_medium: Aptallar orta
+        dummies_count_high: Dummies high
+        dummies_count_medium: Dummies medium
     resource_links:
       test_link:
-        dummy_resource_dummy: İlgili kukla
+        dummy_resource_dummy: Related dummy

--- a/decidim-forms/config/locales/fi-pl.yml
+++ b/decidim-forms/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:

--- a/decidim-forms/config/locales/id-ID.yml
+++ b/decidim-forms/config/locales/id-ID.yml
@@ -1,62 +1,80 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       answer:
-        body: Menjawab
+        body: Answer
       question:
-        max_choices: Jumlah pilihan maksimum
-        question_type: Mengetik
+        max_choices: Maximum number of choices
+        question_type: Type
       questionnaire_question:
-        mandatory: Wajib
+        mandatory: Mandatory
     errors:
       models:
         answer:
           attributes:
             choices:
-              missing: tidak lengkap
-              too_many: terlalu banyak
+              missing: are not complete
+              too_many: are too many
   decidim:
     forms:
       admin:
         models:
           components:
-            description: Deskripsi
-            tos: Ketentuan layanan
+            description: Description
+            tos: Terms of service
         questionnaires:
           answer_option:
-            answer_option: Opsi jawaban
-            free_text: Teks gratis
-            remove: Menghapus
-            statement: Pernyataan
+            answer_option: Answer option
+            free_text: Free text
+            remove: Remove
+            statement: Statement
           edit:
-            save: Menyimpan
-            title: Judul
+            save: Save
+            title: Title
           form:
-            add_question: Tambahkan pertanyaan
+            add_question: Add question
+            already_answered_warning: The questionnaire is already answered by some users so you cannot modify its questions.
           question:
-            add_answer_option: Tambahkan opsi jawaban
-            any: Apa saja
-            description: Deskripsi
-            down: Turun
-            question: Pertanyaan
-            remove: Menghapus
-            statement: Pernyataan
-            up: Naik
+            add_answer_option: Add answer option
+            any: Any
+            description: Description
+            down: Down
+            question: Question
+            remove: Remove
+            statement: Statement
+            up: Up
+          update:
+            invalid: There's been errors when saving the questionnaire.
+            success: Questionnaires saved successfully.
       errors:
         answer:
-          body: Tubuh tidak boleh kosong
+          body: Body can't be blank
       question_types:
-        long_answer: Jawaban panjang
-        multiple_option: Opsi berganda
-        short_answer: Jawaban singkat
-        single_option: Opsi tunggal
-        sorting: Penyortiran
+        long_answer: Long answer
+        multiple_option: Multiple option
+        short_answer: Short answer
+        single_option: Single option
+        sorting: Sorting
       questionnaires:
+        answer:
+          invalid: There's been errors when answering the questionnaire.
+          success: Questionnaire answered successfully.
         question:
-          max_choices: 'Pilihan maksimal: %{n}'
+          max_choices: 'Max choices: %{n}'
         show:
-          are_you_sure: Tindakan ini tidak dapat diurungkan dan Anda tidak akan dapat mengedit jawaban Anda. Apakah kamu yakin
+          answer_questionnaire:
+            anonymous_user_message: <a href="%{sign_in_link}">Sign in with your account</a> or <a href="%{sign_up_link}">sign up</a> to answer the questionnaire.
+            title: Answer the questionnaire
+          are_you_sure: This action cannot be undone and you will not be able to edit your answers. Are you sure?
           questionnaire_answered:
-            title: Sudah dijawab
-          submit: Menyerahkan
-          tos_agreement: Dengan berpartisipasi Anda menerima Ketentuan Layanannya
+            body: You have already answered this questionnaire.
+            title: Already answered
+          questionnaire_closed:
+            body: The questionnaire is closed and cannot be answered.
+            title: Questionnaire closed
+          questionnaire_for_private_users:
+            body: The questionnaire is available only for private users
+            title: Questionnaire closed
+          submit: Submit
+          tos_agreement: By participating you accept its Terms of Service

--- a/decidim-forms/config/locales/tr-TR.yml
+++ b/decidim-forms/config/locales/tr-TR.yml
@@ -1,79 +1,80 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       answer:
-        body: Cevap
+        body: Answer
       question:
-        max_choices: Maksimum seçenek sayısı
-        question_type: tip
+        max_choices: Maximum number of choices
+        question_type: Type
       questionnaire_question:
-        mandatory: Zorunlu
+        mandatory: Mandatory
     errors:
       models:
         answer:
           attributes:
             choices:
-              missing: tamamlanmadı
-              too_many: çok fazla
+              missing: are not complete
+              too_many: are too many
   decidim:
     forms:
       admin:
         models:
           components:
-            description: Açıklama
-            tos: Kullanım Şartları
+            description: Description
+            tos: Terms of service
         questionnaires:
           answer_option:
-            answer_option: Cevap seçeneği
-            free_text: Ücretsiz Metin
-            remove: Kaldır
-            statement: Beyan
+            answer_option: Answer option
+            free_text: Free text
+            remove: Remove
+            statement: Statement
           edit:
-            save: Kayıt etmek
-            title: Başlık
+            save: Save
+            title: Title
           form:
-            add_question: Soru ekle
-            already_answered_warning: Anket bazı kullanıcılar tarafından zaten yanıtlanmıştır, bu nedenden dolayı sorularını değiştiremezsiniz.
+            add_question: Add question
+            already_answered_warning: The questionnaire is already answered by some users so you cannot modify its questions.
           question:
-            add_answer_option: Cevap seçeneği ekle
-            any: herhangi
-            description: Açıklama
-            down: Aşağı
-            question: Soru
-            remove: Kaldır
-            statement: Beyan
-            up: yukarı
+            add_answer_option: Add answer option
+            any: Any
+            description: Description
+            down: Down
+            question: Question
+            remove: Remove
+            statement: Statement
+            up: Up
           update:
-            invalid: Anketi kaydederken hatalar oluştu.
-            success: Ayarlar başarıyla kaydedildi
+            invalid: There's been errors when saving the questionnaire.
+            success: Questionnaires saved successfully.
       errors:
         answer:
-          body: Vücut boş olamaz
+          body: Body can't be blank
       question_types:
-        long_answer: Uzun cevap
-        multiple_option: Çoklu seçenek
-        short_answer: Kısa cevap
-        single_option: Tek seçenek
-        sorting: sınıflandırma
+        long_answer: Long answer
+        multiple_option: Multiple option
+        short_answer: Short answer
+        single_option: Single option
+        sorting: Sorting
       questionnaires:
         answer:
-          invalid: Anketi cevaplarken hatalar oldu.
-          success: Anket başarıyla cevaplandı.
+          invalid: There's been errors when answering the questionnaire.
+          success: Questionnaire answered successfully.
         question:
-          max_choices: 'Maksimum seçenek: %{n}'
+          max_choices: 'Max choices: %{n}'
         show:
           answer_questionnaire:
-            anonymous_user_message: Anketi cevaplamak için <a href="%{sign_in_link}">Hesabınızla giriş yapın</a>yada<a href="%{sign_up_link}">Kaydol</a>
-            title: Anketi cevapla
-          are_you_sure: Bu işlem geri alınamaz ve cevaplarınızı düzenleyemezsiniz. Emin misiniz?
+            anonymous_user_message: <a href="%{sign_in_link}">Sign in with your account</a> or <a href="%{sign_up_link}">sign up</a> to answer the questionnaire.
+            title: Answer the questionnaire
+          are_you_sure: This action cannot be undone and you will not be able to edit your answers. Are you sure?
           questionnaire_answered:
-            body: Bu anketi zaten cevapladınız.
-            title: Zaten cevaplandı
+            body: You have already answered this questionnaire.
+            title: Already answered
           questionnaire_closed:
-            body: Anket kapandığı için cevaplayamazsınız.
-            title: Anket kapatıldı
+            body: The questionnaire is closed and cannot be answered.
+            title: Questionnaire closed
           questionnaire_for_private_users:
-            body: Anket sadece özel kullanıcılar için kullanılabilir.
-            title: Anket kapatıldı
-          submit: Gönder
-          tos_agreement: Katılarak Hizmet Şartlarını kabul etmiş olursunuz.
+            body: The questionnaire is available only for private users
+            title: Questionnaire closed
+          submit: Submit
+          tos_agreement: By participating you accept its Terms of Service

--- a/decidim-initiatives/config/locales/ca.yml
+++ b/decidim-initiatives/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ ca:
             email_outro: Has rebut aquesta notificació perquè ets l'autor/a de la iniciativa %{resource_title}.
             email_subject: S'ha completat una nova fita!
             notification_title: La teva iniciativa <a href="%{resource_path}">%{resource_title}</a> ha aconseguit el %{percentage}% de les signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: La iniciativa %{resource_title} ha aconseguit el %{percentage}% de les signatures!
             email_outro: Heu rebut aquesta notificació perquè esteu seguint %{resource_title}. Podeu deixar de rebre notificacions clicant a l'enllaç anterior.
             email_subject: S'ha completat una nova fita!
             notification_title: La iniciativa <a href="%{resource_path}">%{resource_title}</a> ha aconseguit el %{percentage}% de les signatures.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Anar a Inciatives
-            - Segueix els passos per crear una nova iniciativa
+          - Anar a Inciatives
+          - Segueix els passos per crear una nova iniciativa
           description: Aquest distintiu es concedeix quan es llancen noves iniciatives, unint-te amb altres per dur-les a terme.
           description_another: Aquest usuari ha publicat %{score} iniciatives.
           description_own: Tens %{score} iniciatives publicades.
@@ -106,7 +111,9 @@ ca:
       participatory_spaces:
         initiatives:
           contextual: "<p>Una iniciativa és una proposta que pot ser promoguda per qualsevol persona per iniciativa pròpia (independentment d'altres canals o espais de participació) a través de la recollida de signatures (digitals) per a l'organització per dur a terme una acció específica (modificar una regulació, iniciar un projecte , canvieu el nom d'un departament o un carrer, etc.).</p> <p>Els promotors d'una iniciativa poden definir els seus objectius, recollir suport, debatre, divulgar-la i definir punts de trobada on es puguin recollir signatures dels assistents o debats oberts a altres participants.</p> <p>Exemples: una iniciativa pot recollir signatures per convocar una consulta entre totes les persones d'una organització, crear o convocar una assemblea o iniciar un procés d'augment del pressupost per a un territori o àrea de l'organització. Durant el procés de recollida de signatures, més persones poden afegir a aquesta demanda i portar-lo endavant a l'organització.</p>\n"
-          page: "<p>Una iniciativa és una proposta que pot impulsar qualsevol persona per iniciativa pròpia (independentment de la resta de canals o espais de participació) mitjançant la recollida de signatures (digitals) perquè l'organització dugui a terme una acció específica (modificar un reglament, iniciar un projecte, canviar el nom d'un departament o un carrer, etc.).</p> <p>Les persones promotores d'una iniciativa poden definir els objectius de la mateixa, recollir suports, debatre, difondre-la i definir punts de trobada on es puguin recollir firmes dels assistents o debats oberts a altres participants.</p>\n<p>Exemples: Una iniciativa pot recollir firmes per convocar una consulta entre totes les persones d'una organització, o per crear o convocar una assemblea, o per iniciar un procés d'augment de pressupost per a un territori o àmbit de l'organització. Durant el procés de recollida de signatures es poden sumar més persones a aquesta demanda i aconseguir tirar-la endavant en l'organització.</p>\n"
+          page: |
+            <p>Una iniciativa és una proposta que pot impulsar qualsevol persona per iniciativa pròpia (independentment de la resta de canals o espais de participació) mitjançant la recollida de signatures (digitals) perquè l'organització dugui a terme una acció específica (modificar un reglament, iniciar un projecte, canviar el nom d'un departament o un carrer, etc.).</p> <p>Les persones promotores d'una iniciativa poden definir els objectius de la mateixa, recollir suports, debatre, difondre-la i definir punts de trobada on es puguin recollir firmes dels assistents o debats oberts a altres participants.</p>
+            <p>Exemples: Una iniciativa pot recollir firmes per convocar una consulta entre totes les persones d'una organització, o per crear o convocar una assemblea, o per iniciar un procés d'augment de pressupost per a un territori o àmbit de l'organització. Durant el procés de recollida de signatures es poden sumar més persones a aquesta demanda i aconseguir tirar-la endavant en l'organització.</p>
           title: Què són les iniciatives?
     initiatives:
       admin:

--- a/decidim-initiatives/config/locales/de.yml
+++ b/decidim-initiatives/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie der Autor der Initiative %{resource_title}.
             email_subject: Neuer Meilenstein abgeschlossen!
             notification_title: Ihre <a href="%{resource_path}">%{resource_title}</a> -Initiative hat die %{percentage}% der Unterschriften erreicht.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Die Initiative %{resource_title} hat die %{percentage}% Unterschriften erreicht!
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{resource_title}. Sie können den Erhalt von Benachrichtigungen über den vorherigen Link beenden.
             email_subject: Neuer Meilenstein abgeschlossen!
             notification_title: Die <a href="%{resource_path}">%{resource_title}</a> Initiative hat die %{percentage}% der Unterschriften erreicht.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Gehe zum Teilnehmerbereich von Intiativen
-            - Befolgen Sie die Schritte, um eine neue Initiative zu erstellen
+          - Gehe zum Teilnehmerbereich von Intiativen
+          - Befolgen Sie die Schritte, um eine neue Initiative zu erstellen
           description: Dieses Abzeichen wird gewährt, wenn Sie neue Initiativen starten und mit anderen zusammenarbeiten, um sie durchzuführen.
           description_another: Dieser Benutzer hat %{score} Initiativen veröffentlicht.
           description_own: Du hast %{score} Initiativen veröffentlicht.

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -85,11 +85,15 @@ en:
             email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
             email_subject: New milestone completed!
             notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: The initiative %{resource_title} has achieved the %{percentage}% of signatures!
             email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
             email_subject: New milestone completed!
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:

--- a/decidim-initiatives/config/locales/es-PY.yml
+++ b/decidim-initiatives/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -74,32 +75,36 @@ es-PY:
     events:
       initiatives:
         initiative_extended:
-          email_intro: '¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!'
+          email_intro: "¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!"
           email_outro: Has recibido esta notificación porque está siguiendo %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-          email_subject: '¡Ampliado el términio de recogida de firmas para esta iniciativa!'
+          email_subject: "¡Ampliado el términio de recogida de firmas para esta iniciativa!"
           notification_title: La fecha de recogida de firmas para la iniciativa <a href="%{resource_path}">%{resource_title}</a> se ha ampliado.
         milestone_completed:
           affected_user:
-            email_intro: '¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!'
+            email_intro: "¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!"
             email_outro: Has recibido esta notificación porque eres el autor de la iniciativa %{resource_title}.
-            email_subject: '¡Nuevo hito completado!'
+            email_subject: "¡Nuevo hito completado!"
             notification_title: Tu iniciativa <a href="%{resource_path}">%{resource_title}</a> ha conseguido el %{percentage}% de firmas.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
-            email_intro: '¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!'
+            email_intro: "¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!"
             email_outro: Has recibido esta notificación porque estás siguiendo a %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: '¡Nuevo hito completado!'
+            email_subject: "¡Nuevo hito completado!"
             notification_title: La iniciativa <a href="%{resource_path}">%{resource_title}</a> ha logrado el %{percentage}% de las firmas.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ir al espacio de participación de Iniciativas.
-            - Sigue los pasos para crear una nueva iniciativa.
+          - Ir al espacio de participación de Iniciativas.
+          - Sigue los pasos para crear una nueva iniciativa.
           description: Este distintivo se otorga cuando lanza nuevas iniciativas, asociándose con otros para llevarlas a cabo.
           description_another: Este usuario ha publicado %{score} iniciativas.
           description_own: Tienes %{score} iniciativas publicadas.
           name: Iniciativas publicadas
-          next_level_in: '¡Publica %{score} iniciativas más para llegar al siguiente nivel!'
+          next_level_in: "¡Publica %{score} iniciativas más para llegar al siguiente nivel!"
           unearned_another: Este usuario aún no ha publicado ninguna iniciativa.
           unearned_own: Aún no tienes ninguna iniciativa publicada.
     help:
@@ -107,13 +112,13 @@ es-PY:
         initiatives:
           contextual: "<p>Una iniciativa es una propuesta que puede ser promovida por cualquiera por iniciativa propia (independientemente de otros canales o espacios de participación) a través de la recopilación de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar una regulación, iniciar un proyecto). , cambiar el nombre de un departamento o una calle, etc.).</p> <p>Los promotores de una iniciativa pueden definir sus objetivos, obtener apoyo, debatir, difundir y definir puntos de encuentro donde se pueden recopilar firmas de los asistentes o debates abiertos a otros participantes.</p> <p>Ejemplos: una iniciativa puede recopilar firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o área de la organización. Durante el proceso de recolección de firmas, más personas pueden sumarse a esta demanda y llevarla adelante en la organización.</p>\n"
           page: "<p>Una iniciativa es una propuesta que puede ser promovida por cualquiera por iniciativa propia (independientemente de otros canales o espacios de participación) a través de la recopilación de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar una regulación, iniciar un proyecto). , cambiar el nombre de un departamento o una calle, etc.).</p> <p>Los promotores de una iniciativa pueden definir sus objetivos, obtener apoyo, debatir, difundir y definir puntos de encuentro donde se pueden recopilar firmas de los asistentes o debates abiertos a otros participantes.</p> <p>Ejemplos: una iniciativa puede recopilar firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o área de la organización. Durante el proceso de recolección de firmas, más personas pueden sumarse a esta demanda y llevarla adelante en la organización.</p>\n"
-          title: '¿Qué son las iniciativas?'
+          title: "¿Qué son las iniciativas?"
     initiatives:
       admin:
         committee_requests:
           index:
             approve: Aprobar
-            confirm_revoke: '¿Estás seguro?'
+            confirm_revoke: "¿Estás seguro?"
             invite_to_committee_help: Comparte este enlace para invitar a otros usuarios al comité de promoción
             no_members_yet: No hay miembros en el comité promotor
             revoke: Revocar
@@ -124,7 +129,7 @@ es-PY:
         initiatives:
           edit:
             accept: Aceptar iniciativa
-            confirm: '¿Estás seguro?'
+            confirm: "¿Estás seguro?"
             discard: Descartar la iniciativa
             export_votes: Soportes de exportación
             reject: Rechazar la iniciativa
@@ -160,7 +165,7 @@ es-PY:
             success: El alcance ha sido eliminado con éxito
           edit:
             back: Volver
-            confirm_destroy: '¿Estás seguro?'
+            confirm_destroy: "¿Estás seguro?"
             destroy: Borrar
             title: Editar alcance del tipo de iniciativa
             update: Actualizar
@@ -178,7 +183,7 @@ es-PY:
           destroy:
             success: El tipo de iniciativa se ha eliminado correctamente
           edit:
-            confirm_destroy: '¿Estás seguro?'
+            confirm_destroy: "¿Estás seguro?"
             destroy: Borrar
             update: Actualizar
           form:
@@ -224,7 +229,7 @@ es-PY:
         finish:
           back: Volver
           back_to_initiatives: Volver a iniciativas
-          callout_text: '¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito.'
+          callout_text: "¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito."
           go_to_my_initiatives: Ir a mis iniciativas
           more_information: "(Más información)"
         finish_help:
@@ -237,7 +242,7 @@ es-PY:
         previous_form:
           back: Volver
           continue: Continuar
-          help: '¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta.'
+          help: "¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta."
           more_information: "(Más información)"
         promotal_committee:
           back: Volver
@@ -326,7 +331,7 @@ es-PY:
           title: Listado de firmas
         vote_cabin:
           already_voted: Ha sido firmado
-          supports_required: "Se requieren %{total_supports} firmas"
+          supports_required: Se requieren %{total_supports} firmas
           vote: Firmar
           votes_blocked: Firma desactivada
         votes_count:
@@ -383,4 +388,4 @@ es-PY:
           check: Échale un vistazo
           check_and_support: Compruébalo y firma
         no_initiatives_yet:
-          no_initiatives_yet: '¡No hay iniciativas todavía!'
+          no_initiatives_yet: "¡No hay iniciativas todavía!"

--- a/decidim-initiatives/config/locales/es.yml
+++ b/decidim-initiatives/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -74,32 +75,36 @@ es:
     events:
       initiatives:
         initiative_extended:
-          email_intro: '¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!'
+          email_intro: "¡La fecha de finalización de las firmas para la iniciativa %{resource_title} se ha ampliado!"
           email_outro: Has recibido esta notificación porque está siguiendo %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-          email_subject: '¡Ampliado el términio de recogida de firmas para esta iniciativa!'
+          email_subject: "¡Ampliado el términio de recogida de firmas para esta iniciativa!"
           notification_title: La fecha de recogida de firmas para la iniciativa <a href="%{resource_path}">%{resource_title}</a> se ha ampliado.
         milestone_completed:
           affected_user:
-            email_intro: '¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!'
+            email_intro: "¡Tu iniciativa %{resource_title} ha conseguido el %{percentage}% de firmas!"
             email_outro: Has recibido esta notificación porque eres la autora de la iniciativa %{resource_title}.
-            email_subject: '¡Nuevo hito completado!'
+            email_subject: "¡Nuevo hito completado!"
             notification_title: Tu iniciativa <a href="%{resource_path}">%{resource_title}</a> ha conseguido el %{percentage}% de firmas.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
-            email_intro: '¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!'
+            email_intro: "¡La iniciativa %{resource_title} ha logrado el %{percentage}% de firmas!"
             email_outro: Has recibido esta notificación porque estás siguiendo a %{resource_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
-            email_subject: '¡Nuevo hito completado!'
+            email_subject: "¡Nuevo hito completado!"
             notification_title: La iniciativa <a href="%{resource_path}">%{resource_title}</a> ha logrado el %{percentage}% de las firmas.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ir al espacio de participación de Iniciativas
-            - Sigue los pasos para crear una nueva iniciativa.
+          - Ir al espacio de participación de Iniciativas
+          - Sigue los pasos para crear una nueva iniciativa.
           description: Este distintivo se otorga cuando lanzas nuevas iniciativas, asociándote con otros para llevarlas a cabo.
           description_another: Este usuario ha publicado %{score} iniciativas.
           description_own: Tienes %{score} iniciativas publicadas.
           name: Iniciativas publicadas
-          next_level_in: '¡Publica %{score} iniciativas más para llegar al siguiente nivel!'
+          next_level_in: "¡Publica %{score} iniciativas más para llegar al siguiente nivel!"
           unearned_another: Este usuario aún no ha publicado ninguna iniciativa.
           unearned_own: Aún no tienes ninguna iniciativa publicada.
     help:
@@ -107,13 +112,13 @@ es:
         initiatives:
           contextual: "<p>Una iniciativa es una propuesta que puede impulsar cualquier persona por iniciativa propia (independientemente del resto de canales o espacios de participación) mediante la recogida de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar un reglamento, iniciar un proyecto, cambiar el nombre de un departamento o una calle, etc.).</p> <p>Las personas promotoras de una iniciativa pueden definir los objetivos de la misma, recoger apoyos, debatir, difundirla y definir puntos de encuentro donde se puedan recoger firmas de los asistentes o debates abiertos a otras participantes.</p> <p>Ejemplos: Una iniciativa puede recoger firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o ámbito de la organización. Durante el proceso de recogida de firmas se pueden sumar más personas a esta demanda y lograr llevarla adelante en la organización.</p>\n"
           page: "<p>Una iniciativa es una propuesta que puede impulsar cualquier persona por iniciativa propia (independientemente del resto de canales o espacios de participación) mediante la recogida de firmas (digitales) para que la organización lleve a cabo una acción específica (modificar un reglamento, iniciar un proyecto, cambiar el nombre de un departamento o una calle, etc.).</p> <p>Las personas promotoras de una iniciativa pueden definir los objetivos de la misma, recoger apoyos, debatir, difundirla y definir puntos de encuentro donde se puedan recoger firmas de los asistentes o debates abiertos a otras participantes.</p> <p>Ejemplos: Una iniciativa puede recoger firmas para convocar una consulta entre todas las personas de una organización, o para crear o convocar una asamblea, o para iniciar un proceso de aumento de presupuesto para un territorio o ámbito de la organización. Durante el proceso de recogida de firmas se pueden sumar más personas a esta demanda y lograr llevarla adelante en la organización.</p>\n"
-          title: '¿Qué son las iniciativas?'
+          title: "¿Qué son las iniciativas?"
     initiatives:
       admin:
         committee_requests:
           index:
             approve: Aprobar
-            confirm_revoke: '¿Estás seguro?'
+            confirm_revoke: "¿Estás seguro?"
             invite_to_committee_help: Comparte este enlace para invitar a otros usuarios al comité de promoción
             no_members_yet: No hay miembros en el comité promotor
             revoke: Revocar
@@ -124,7 +129,7 @@ es:
         initiatives:
           edit:
             accept: Aceptar iniciativa
-            confirm: '¿Estás seguro?'
+            confirm: "¿Estás seguro?"
             discard: Descartar la iniciativa
             export_votes: Soportes de exportación
             reject: Rechazar la iniciativa
@@ -160,7 +165,7 @@ es:
             success: El alcance ha sido eliminado con éxito
           edit:
             back: Volver
-            confirm_destroy: '¿Estás seguro?'
+            confirm_destroy: "¿Estás seguro?"
             destroy: Borrar
             title: Editar alcance del tipo de iniciativa
             update: Actualizar
@@ -178,7 +183,7 @@ es:
           destroy:
             success: El tipo de iniciativa se ha eliminado correctamente
           edit:
-            confirm_destroy: '¿Estás seguro?'
+            confirm_destroy: "¿Estás seguro?"
             destroy: Borrar
             update: Actualizar
           form:
@@ -224,7 +229,7 @@ es:
         finish:
           back: Volver
           back_to_initiatives: Volver a iniciativas
-          callout_text: '¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito.'
+          callout_text: "¡Felicidades! Tu iniciativa ciudadana ha sido creada con éxito."
           go_to_my_initiatives: Ir a mis iniciativas
           more_information: "(Más información)"
         finish_help:
@@ -237,7 +242,7 @@ es:
         previous_form:
           back: Volver
           continue: Continuar
-          help: '¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta.'
+          help: "¿En qué consiste la iniciativa? Escribe el título y la descripción. Te rcomendamos un título corto y conciso, y una descripción centrada en la solución propuesta."
           more_information: "(Más información)"
         promotal_committee:
           back: Volver
@@ -326,7 +331,7 @@ es:
           title: Listado de firmas
         vote_cabin:
           already_voted: Ha sido firmado
-          supports_required: "Se requieren %{total_supports} firmas"
+          supports_required: Se requieren %{total_supports} firmas
           vote: Firmar
           votes_blocked: Firma desactivada
         votes_count:
@@ -383,4 +388,4 @@ es:
           check: Échale un vistazo
           check_and_support: Compruébalo y firma
         no_initiatives_yet:
-          no_initiatives_yet: '¡No hay iniciativas todavía!'
+          no_initiatives_yet: "¡No hay iniciativas todavía!"

--- a/decidim-initiatives/config/locales/eu.yml
+++ b/decidim-initiatives/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ eu:
             email_outro: Jakinarazpen hau jaso duzu ekimenaren egilea delako %{resource_title}.
             email_subject: Mugarri berria osatu da!
             notification_title: Zure <a href="%{resource_path}">%{resource_title}</a> ekimenek sinadurak% %{percentage}lortu dituzte.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
-            email_intro: '%{resource_title} ekimena sinadurak% %{percentage}lortu ditu!'
+            email_intro: "%{resource_title} ekimena sinadurak% %{percentage}lortu ditu!"
             email_outro: Jakinarazpen hau jaso duzu %{resource_title}jarraitzen duzulako. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
             email_subject: Mugarri berria osatu da!
             notification_title: <a href="%{resource_path}">%{resource_title}</a> ekimenek sinadurak% %{percentage}lortu dituzte.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Joan zaitez Intiatives-ko partaidetza eremura
-            - Jarraitu urrats berriak ekimen berri bat sortzeko
+          - Joan zaitez Intiatives-ko partaidetza eremura
+          - Jarraitu urrats berriak ekimen berri bat sortzeko
           description: Idazmahaia ekimen berriak abiarazten dituzunean, besteekin elkarlanean aritzea ekartzen baduzu.
           description_another: Erabiltzaile honek argitaratutako %{score} ekimen lortu ditu.
           description_own: Argitaratutako %{score} ekimen dituzu.
@@ -260,12 +265,12 @@ eu:
         create_initiative_event:
           email_intro: "%{author_name} %{author_nickname}, jarraitzen ari zarenak, ekimen berri bat sortu du, egiaztatu eta lagundu:"
           email_outro: Jakinarazpena jaso duzu %{author_nickname}jarraituz gero. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-          email_subject: '%{author_nickname} ekimen berria'
+          email_subject: "%{author_nickname} ekimen berria"
           notification_title: <a href="%{resource_path}">%{resource_title}</a> ekimena <a href="%{author_path}">%{author_name} %{author_nickname}</a> sortu zen.
         endorse_initiative_event:
           email_intro: "%{author_name} %{author_nickname}, jarraitzen ari zarenak, hurrengo ekimena onartu du, agian elkarrizketan lagundu nahi baduzu:"
           email_outro: Jakinarazpena jaso duzu %{author_nickname}jarraituz gero. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
-          email_subject: '%{author_nickname} babestutako ekimena'
+          email_subject: "%{author_nickname} babestutako ekimena"
           notification_title: <a href="%{resource_path}">%{resource_title}</a> ekimena <a href="%{author_path}">%{author_name} %{author_nickname}</a> babesten du.
       index:
         title: Ekimenak
@@ -339,13 +344,13 @@ eu:
           check_initiative_details: Ekimenaren xehetasunak ikus ditzakezu
           here: hemen
         more_information: Hemen ekimenaren sorrera prozesuari buruzko informazio gehiago duzu.
-        progress_report_body_for: '%{title} ekimena %{percentage}eskatutako euskarrien% gainditu du.'
+        progress_report_body_for: "%{title} ekimena %{percentage}eskatutako euskarrien% gainditu du."
         progress_report_for: 'Berrekin ekimenari buruz: %{title}'
         promotal_committee_help: Gogoan izan gutxienez %{member_count} pertsona gonbidatu behar dituzula sustatzaile batzordera. Birbidali hurrengo estekara gonbidatzeko jendea sustatzaile batzordera
-        status_change_body_for: '%{title} ekimena bere egoera aldatu du: %{state}'
-        status_change_for: '%{title} ekimena bere egoera aldatu du'
-        technical_validation_body_for: '%{title} ekimena balidazio teknikoa eskatu du.'
-        technical_validation_for: '%{title} ekimena balidazio teknikoa eskatu du.'
+        status_change_body_for: "%{title} ekimena bere egoera aldatu du: %{state}"
+        status_change_for: "%{title} ekimena bere egoera aldatu du"
+        technical_validation_body_for: "%{title} ekimena balidazio teknikoa eskatu du."
+        technical_validation_for: "%{title} ekimena balidazio teknikoa eskatu du."
       last_activity:
         new_initiative: Ekimen berria
       pages:

--- a/decidim-initiatives/config/locales/fi-pl.yml
+++ b/decidim-initiatives/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ fi-pl:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut aloitteen %{resource_title}.
             email_subject: Uusi virstanpylväs saavutettu!
             notification_title: Aloitteesi <a href="%{resource_path}">%{resource_title}</a> on saavuttanut %{percentage}% allekirjoituksista.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Aloite %{resource_title} on saavuttanut %{percentage}% tarvituista allekirjoituksista!
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat %{resource_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
             email_subject: Uusi virstanpylväs saavutettu!
             notification_title: Aloite <a href="%{resource_path}">%{resource_title}</a> on saavuttanut %{percentage}% tarvituista allekirjoituksista.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Siirry aloitteiden osallisuustilaan
-            - Luo uusi aloite ohjeiden mukaisesti
+          - Siirry aloitteiden osallisuustilaan
+          - Luo uusi aloite ohjeiden mukaisesti
           description: Tämä kunniamerkki myönnetään, kun laadit uusia aloitteita ja keräät verkoston ihmisiä toteuttamaan niitä.
           description_another: Tämä käyttäjä on julkaissut %{score} aloitetta.
           description_own: Olet julkaissut %{score} aloitetta.
@@ -265,7 +270,7 @@ fi-pl:
         endorse_initiative_event:
           email_intro: "%{author_name} %{author_nickname}, jota seuraat, on hyväksynyt seuraavan aloitteen. Ehkä haluat osallistua keskusteluun:"
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat käyttäjää %{author_nickname}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-          email_subject: '%{author_nickname} on suositellut aloitetta'
+          email_subject: "%{author_nickname} on suositellut aloitetta"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> on suositellut aloitetta <a href="%{resource_path}">%{resource_title}</a>.
       index:
         title: Aloitteet

--- a/decidim-initiatives/config/locales/fi.yml
+++ b/decidim-initiatives/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ fi:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut aloitteen %{resource_title}.
             email_subject: Uusi virstanpylväs saavutettu!
             notification_title: Aloitteesi <a href="%{resource_path}">%{resource_title}</a> on saavuttanut %{percentage}% allekirjoituksista.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Aloite %{resource_title} on saavuttanut %{percentage}% tarvituista allekirjoituksista!
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat %{resource_title}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
             email_subject: Uusi virstanpylväs saavutettu!
             notification_title: Aloite <a href="%{resource_path}">%{resource_title}</a> on saavuttanut %{percentage}% tarvituista allekirjoituksista.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Siirry aloitteiden osallisuustilaan
-            - Luo uusi aloite ohjeiden mukaisesti
+          - Siirry aloitteiden osallisuustilaan
+          - Luo uusi aloite ohjeiden mukaisesti
           description: Tämä kunniamerkki myönnetään, kun laadit uusia aloitteita ja keräät verkoston ihmisiä toteuttamaan niitä.
           description_another: Tämä käyttäjä on julkaissut %{score} aloitetta.
           description_own: Olet julkaissut %{score} aloitetta.
@@ -265,7 +270,7 @@ fi:
         endorse_initiative_event:
           email_intro: "%{author_name} %{author_nickname}, jota seuraat, on hyväksynyt seuraavan aloitteen. Ehkä haluat osallistua keskusteluun:"
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat käyttäjää %{author_nickname}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
-          email_subject: '%{author_nickname} on suositellut aloitetta'
+          email_subject: "%{author_nickname} on suositellut aloitetta"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> on suositellut aloitetta <a href="%{resource_path}">%{resource_title}</a>.
       index:
         title: Aloitteet

--- a/decidim-initiatives/config/locales/gl.yml
+++ b/decidim-initiatives/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ gl:
             email_outro: Recibiches esta notificación porque es o autor da iniciativa %{resource_title}.
             email_subject: Novo fito rematado!
             notification_title: A túa iniciativa <a href="%{resource_path}">%{resource_title}</a> acadou o %{percentage}% das sinaturas.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: A iniciativa %{resource_title} alcanzou o %{percentage}% das sinaturas.
             email_outro: Recibiches esta notificación porque estás seguindo %{resource_title}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
             email_subject: Novo fito rematado!
             notification_title: A iniciativa <a href="%{resource_path}">%{resource_title}</a> acadou o %{percentage}% das sinaturas.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ir ao espazo de participación de Intiatives
-            - Segue os pasos para crear unha nova iniciativa
+          - Ir ao espazo de participación de Intiatives
+          - Segue os pasos para crear unha nova iniciativa
           description: Este distintivo concedeuse cando se lanzan novas iniciativas, se asocian con outras persoas para realizalas.
           description_another: Este usuario obtivo %{score} iniciativas publicadas.
           description_own: Tes publicado %{score} iniciativas.
@@ -237,7 +242,7 @@ gl:
         previous_form:
           back: De volta
           continue: Continuar
-          help: '¿Que consiste a iniciativa? Anota o título ea descrición. Recomendamos un título breve e conciso e unha descrición centrada na solución proposta.'
+          help: "¿Que consiste a iniciativa? Anota o título ea descrición. Recomendamos un título breve e conciso e unha descrición centrada na solución proposta."
           more_information: "(Máis información)"
         promotal_committee:
           back: De volta
@@ -281,7 +286,7 @@ gl:
             other: e %{count} persoas máis
         count:
           title:
-            one: "Iniciativa %{count}"
+            one: Iniciativa %{count}
             other: "%{count} iniciativas"
         filters:
           any: Calquera
@@ -326,7 +331,7 @@ gl:
           title: Listado de sinaturas
         vote_cabin:
           already_voted: Xa está asinado
-          supports_required: "Requírense as %{total_supports} firmas"
+          supports_required: Requírense as %{total_supports} firmas
           vote: Iniciar sesión
           votes_blocked: A sinatura está desactivada
         votes_count:

--- a/decidim-initiatives/config/locales/hu.yml
+++ b/decidim-initiatives/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -84,20 +85,24 @@ hu:
             email_outro: Ezt az értesítést azért kaptad, mert Te vagy a %{resource_title} kezdeményezés szerzője.
             email_subject: Új mérföldkő kész áll!
             notification_title: A <a href="%{resource_path}">%{resource_title}</a> kezdeményezésed elérte az aláírások %{percentage}% -át.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: A(z) %{resource_title} kezdeményezést már %{percentage}% aláírta!
             email_outro: Ezt az értesítést azért kaptad, mert követed ezt %{resource_title}. Leállíthathatod az értesítések fogadását az előző linkkel.
             email_subject: Új mérföldkő kész áll!
             notification_title: A(z) <a href="%{resource_path}">%{resource_title}</a> kezdeményezést már %{percentage}% aláírta.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Menjen az Intiatives részvételi helyére
-            - Kövesse az új kezdeményezés létrehozásához szükséges lépéseket
+          - Menjen az Intiatives részvételi helyére
+          - Kövesse az új kezdeményezés létrehozásához szükséges lépéseket
           description: Ezt a jelvényt akkor kapja meg, ha új kezdeményezéseket indít el, és másokkal partnerséget hajt végre.
           description_another: Ez a felhasználó %{score} kezdeményezést kapott.
-          description_own: '%{score} kezdeményezéseid közzétéve.'
+          description_own: "%{score} kezdeményezéseid közzétéve."
           name: Közzétett kezdeményezések
           next_level_in: Szerezz még %{score} kezdeményezéseket a következő szint eléréséhez!
           unearned_another: A felhasználó még nem tett közzé kezdeményezéseket.
@@ -232,7 +237,7 @@ hu:
           help_for_organizations: Ha egyesületként regisztrálsz, fel kell töltened az összes szerv vezetői testületének jegyzőkönyveit, amelyek megfelelnek a Támogató Bizottság feltételeinek
           help_in_person_signatures: Ha úgy döntöttél, hogy az aláírásokat személyesen és online módon kombinálva gyűjtöd, akkor töltsd fel a szükséges adatokat.
           help_text: Ne feledd, hogy a kezdeményezés feldolgozásához hozzá kell férned az adminisztrációs panelhez, ahol a felhasználó menü is található. Ugyanitt töltheted fel a szükséges információkat és indíthatsz eljárást.
-          initiatives_page_link: '%{link} segítségével megnézheted a kezdeményezésekre vonatkozó összes információt.'
+          initiatives_page_link: "%{link} segítségével megnézheted a kezdeményezésekre vonatkozó összes információt."
           page: oldal
         previous_form:
           back: Vissza
@@ -260,12 +265,12 @@ hu:
         create_initiative_event:
           email_intro: "%{author_name} %{author_nickname} (akit követsz) új kezdeményezést hozott létre, nézd meg és tegyél hozzá valamit:"
           email_outro: 'Ezt az értesítést azért kaptad, mert őt követed: "%{author_nickname}". Az értesítéseket a következő linkre kattintva kapcsolhatod ki.'
-          email_subject: '%{author_nickname} új kezdeményezést indított'
+          email_subject: "%{author_nickname} új kezdeményezést indított"
           notification_title: 'A(z) <a href="%{resource_path}">%{resource_title}</a>kezdeményezés létrejött itt, általa: <a href="%{author_path}">%{author_name} %{author_nickname}</a>.'
         endorse_initiative_event:
           email_intro: "%{author_name} %{author_nickname} (akit követsz) támogatta a következő kezdeményezést, nézd meg és tegyél hozzá te is valamit a beszélgetéshez:"
           email_outro: 'Ezt az értesítést azért kaptad, mert őt követed: "%{author_nickname}". Az értesítéseket a következő linkre kattintva kapcsolhatod ki.'
-          email_subject: '%{author_nickname} támogatta a kezdeményezést'
+          email_subject: "%{author_nickname} támogatta a kezdeményezést"
           notification_title: 'A(z) <a href="%{resource_path}">%{resource_title}</a>kezdeményezést támogatta: <a href="%{author_path}">%{author_name} %{author_nickname}</a>.'
       index:
         title: Kezdeményezések
@@ -374,7 +379,7 @@ hu:
         promotal_committee: Kezdeményező bizottság
         select_initiative_type: Válassz
         show_similar_initiatives: Összehasonlítás
-        step: '%{current} lépés a %{total} lépésből'
+        step: "%{current} lépés a %{total} lépésből"
         title: Új kezdeményezés létrehozása
       initiative_header:
         initiative_menu_item: Kezdeményezés

--- a/decidim-initiatives/config/locales/id-ID.yml
+++ b/decidim-initiatives/config/locales/id-ID.yml
@@ -1,379 +1,389 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       initiative:
-        decidim_user_group_id: Penulis
-        description: Deskripsi
-        offline_votes: Dukungan tatap muka
-        scope_id: Cakupan
-        signature_end_date: Akhir periode pengumpulan tanda tangan
-        signature_start_date: Mulai dari periode pengumpulan tanda tangan
-        signature_type: Jenis koleksi tanda tangan
+        decidim_user_group_id: Author
+        description: Description
+        offline_votes: Face-to-face supports
+        scope_id: Scope
+        signature_end_date: End of signature collection period
+        signature_start_date: Start of signature collection period
+        signature_type: Signature collection type
         signature_type_values:
-          any: Campur aduk
-          offline: Tatap muka
-          online: On line
-        title: Judul
+          any: Mixed
+          offline: Face to face
+          online: OnLine
+        title: Title
       initiative_author:
-        address: Alamat
-        city: Kota
-        id_document: DNI / NIE
-        name: Nama dan nama keluarga
-        phone_number: Nomor telepon
-        post_code: Kode Pos
-        province: Propinsi
+        address: Address
+        city: City
+        id_document: DNI/NIE
+        name: Name and Surname
+        phone_number: Phone number
+        post_code: Post code
+        province: Province
       initiatives_committee_member:
-        user: anggota Komite
+        user: Committee member
       initiatives_type:
-        banner_image: Gambar spanduk
-        description: Deskripsi
-        title: Judul
+        banner_image: Banner image
+        description: Description
+        title: Title
       organization_data:
-        address: Alamat
-        id_document: Dokumen ID
-        name: Nama lengkap
+        address: Address
+        id_document: ID document
+        name: Complete name
   activerecord:
     models:
       decidim/initiative:
+        one: Initative
         other: Initatives
       decidim/initiative_comittee:
-        other: Komite-komite
+        one: Comittee
+        other: Comittees
       decidim/initiative_vote:
-        other: Tanda tangan
+        one: Signature
+        other: Signatures
   decidim:
     admin:
       actions:
-        new_initiative_type: Jenis inisiatif baru
+        new_initiative_type: New initiative type
       menu:
-        initiatives: Inisiatif
-        initiatives_types: Jenis inisiatif
+        initiatives: Initiatives
+        initiatives_types: Initiative types
       models:
         initiatives:
           fields:
-            created_at: Dibuat di
+            created_at: Created at
             id: ID
-            state: Negara
-            supports_count: Mendukung
-            title: Inisiatif
+            state: State
+            supports_count: Supports
+            title: Initiatives
         initiatives_type_scope:
           fields:
-            scope: Cakupan
-            supports_required: Mendukung diperlukan
-          name: Ruang lingkup tipe Inisiatif
+            scope: Scope
+            supports_required: Supports required
+          name: Initiative type scope
         initiatives_types:
           fields:
-            created_at: Dibuat di
-            title: Jenis inisiatif
-          name: Jenis inisiatif
+            created_at: Created at
+            title: Initiative types
+          name: Initiative type
       titles:
-        initiatives: Inisiatif
-        initiatives_types: Jenis inisiatif
+        initiatives: Initiatives
+        initiatives_types: Initiative types
     events:
       initiatives:
         initiative_extended:
-          email_intro: Tanggal akhir tanda tangan untuk inisiatif %{resource_title} telah diperpanjang!
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{resource_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Tanggal akhir tanda tangan inisiatif diperpanjang!
-          notification_title: Tanggal akhir tanda tangan untuk inisiatif <a href="%{resource_path}">%{resource_title}</a> telah diperpanjang.
+          email_intro: The signatures end date for the initiative %{resource_title} has been extended!
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: Initiative signatures end date extended!
+          notification_title: The signatures end date for the <a href="%{resource_path}">%{resource_title}</a> initiative has been extended.
         milestone_completed:
           affected_user:
-            email_intro: Inisiatif Anda %{resource_title} telah mencapai %{percentage}% tanda tangan!
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah pembuat inisiatif %{resource_title}.
-            email_subject: Tonggak baru selesai!
-            notification_title: Prakarsa <a href="%{resource_path}">%{resource_title}</a> telah mencapai %{percentage}% tanda tangan.
+            email_intro: Your initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
+            email_subject: New milestone completed!
+            notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
-            email_intro: Inisiatif %{resource_title} telah mencapai %{percentage}% tanda tangan!
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{resource_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-            email_subject: Tonggak baru selesai!
-            notification_title: Inisiatif <a href="%{resource_path}">%{resource_title}</a> telah mencapai %{percentage}% tanda tangan.
+            email_intro: The initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+            email_subject: New milestone completed!
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
-          conditions:
-            - Pergi ke ruang partisipasi dari Intiatives
-            - Ikuti langkah-langkah untuk membuat inisiatif baru
-          description: Lencana ini diberikan ketika Anda meluncurkan inisiatif baru, bermitra dengan orang lain untuk melaksanakannya.
-          description_another: Pengguna ini telah mendapatkan %{score} inisiatif yang dipublikasikan.
-          description_own: Anda punya %{score} inisiatif yang dipublikasikan.
-          name: Inisiatif yang diterbitkan
-          next_level_in: Dapatkan %{score} lebih banyak inisiatif yang diterbitkan untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum mendapatkan inisiatif apa pun yang dipublikasikan.
-          unearned_own: Anda belum ada inisiatif yang dipublikasikan.
+          conditions: '["Go to the participation space of Intiatives", "Follow the steps to create a new initiative"]'
+          description: This badge is granted when you launch new initiatives, partnering with others to carry them out.
+          description_another: This user has gotten %{score} initiatives published.
+          description_own: You've got %{score} initiatives published.
+          name: Published initiatives
+          next_level_in: Get %{score} more initiatives published to reach the next level!
+          unearned_another: This user hasn't gotten any initiatives published yet.
+          unearned_own: You got no initiatives published yet.
     help:
       participatory_spaces:
         initiatives:
-          contextual: "<p>Inisiatif adalah proposal yang dapat dipromosikan oleh siapa pun atas inisiatif mereka sendiri (terlepas dari saluran lain atau ruang partisipasi) melalui pengumpulan tanda tangan (digital) untuk organisasi untuk melakukan tindakan tertentu (memodifikasi peraturan, memulai proyek , ubah nama departemen atau jalan, dll.).</p> <p>Promotor suatu inisiatif dapat menentukan tujuannya, mengumpulkan dukungan, berdebat, menyebarluaskannya dan menentukan titik-titik pertemuan di mana tanda tangan dapat dikumpulkan dari peserta atau debat terbuka untuk peserta lain.</p> <p>Contoh: Suatu inisiatif dapat mengumpulkan tanda tangan untuk mengadakan konsultasi di antara semua orang dari suatu organisasi, atau untuk membuat atau mengadakan pertemuan, atau untuk memulai proses peningkatan anggaran untuk suatu wilayah atau wilayah organisasi. Selama proses pengumpulan tanda tangan, lebih banyak orang dapat menambah permintaan ini dan membawanya ke depan dalam organisasi.</p>\n"
-          page: "<p>Inisiatif adalah proposal yang dapat dipromosikan oleh siapa pun atas inisiatif mereka sendiri (terlepas dari saluran lain atau ruang partisipasi) melalui pengumpulan tanda tangan (digital) untuk organisasi untuk melakukan tindakan tertentu (memodifikasi peraturan, memulai proyek , ubah nama departemen atau jalan, dll.).</p> <p>Promotor suatu inisiatif dapat menentukan tujuannya, mengumpulkan dukungan, berdebat, menyebarluaskannya dan menentukan titik-titik pertemuan di mana tanda tangan dapat dikumpulkan dari peserta atau debat terbuka untuk peserta lain.</p> <p>Contoh: Suatu inisiatif dapat mengumpulkan tanda tangan untuk mengadakan konsultasi di antara semua orang dari suatu organisasi, atau untuk membuat atau mengadakan pertemuan, atau untuk memulai proses peningkatan anggaran untuk suatu wilayah atau wilayah organisasi. Selama proses pengumpulan tanda tangan, lebih banyak orang dapat menambah permintaan ini dan membawanya ke depan dalam organisasi.</p>\n"
-          title: Apa inisiatifnya?
+          contextual: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          page: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          title: What are initiatives?
     initiatives:
       admin:
         committee_requests:
           index:
-            approve: Menyetujui
-            confirm_revoke: Apakah kamu yakin?
-            invite_to_committee_help: Bagikan tautan ini untuk mengundang pengguna lain ke komite promosi
-            no_members_yet: Tidak ada anggota di komite promotor
-            revoke: Mencabut
-            title: anggota Komite
+            approve: Approve
+            confirm_revoke: Are you sure?
+            invite_to_committee_help: Share this link to invite other users to the promotion committee
+            no_members_yet: There are no members in the promoter committee
+            revoke: Revoke
+            title: Committee members
         content_blocks:
           highlighted_initiatives:
-            max_results: Jumlah maksimum elemen untuk ditampilkan
+            max_results: Maximum amount of elements to show
         initiatives:
           edit:
-            accept: Terima inisiatif
-            confirm: Apakah kamu yakin?
-            discard: Buang inisiatif
-            export_votes: Mendukung ekspor
-            reject: Tolak inisiatif
-            send_to_technical_validation: Kirim ke validasi teknis
-            success: Inisiatif telah dikirim ke validasi teknis
-            update: Memperbarui
+            accept: Accept initiative
+            confirm: Are you sure?
+            discard: Discard the initiative
+            export_votes: Export supports
+            reject: Reject initiative
+            send_to_technical_validation: Send to technical validation
+            success: The initiative has been sent to technical validation
+            update: Update
           form:
-            title: Informasi Umum
+            title: General information
           index:
-            actions_title: Tindakan
+            actions_title: Action
             filter:
-              accepted: Diterima
-              all: Semua
-              created: Dibuat
-              discarded: Dibuang
-              published: Diterbitkan
-              rejected: Ditolak
-              validating: Validasi teknis
-            filter_by: Filter berdasarkan
+              accepted: Accepted
+              all: All
+              created: Created
+              discarded: Discarded
+              published: Published
+              rejected: Rejected
+              validating: Technical validation
+            filter_by: Filter by
             preview: Preview
-            print: Mencetak
-            search: Pencarian
+            print: Print
+            search: Search
           show:
-            print: Mencetak
+            print: Print
           update:
-            error: Sebuah kesalahan telah terjadi
-            success: Inisiatif warga telah berhasil diperbarui
+            error: An error has occurred
+            success: The citizen initiative has been successfully updated
         initiatives_type_scopes:
           create:
-            error: Sebuah kesalahan telah terjadi
-            success: Ruang lingkup baru untuk jenis inisiatif yang diberikan telah dibuat
+            error: An error has occurred
+            success: A new scope for the given initiative type has been created
           destroy:
-            success: Ruang lingkup telah berhasil dihapus
+            success: The scope has been successfully removed
           edit:
-            back: Kembali
-            confirm_destroy: Apakah kamu yakin?
-            destroy: Menghapus
-            title: Edit ruang lingkup jenis inisiatif
-            update: Memperbarui
+            back: Back
+            confirm_destroy: Are you sure?
+            destroy: Delete
+            title: Edit initiative type scope
+            update: Update
           new:
-            back: Kembali
-            create: Membuat
-            title: Buat ruang lingkup jenis inisiatif
+            back: Back
+            create: Create
+            title: Create initiative type scope
           update:
-            error: Sebuah kesalahan telah terjadi
-            success: Ruang lingkup telah berhasil diperbarui
+            error: An error has occurred
+            success: The scope has been successfully updated
         initiatives_types:
           create:
-            error: Sebuah kesalahan telah terjadi
-            success: Jenis inisiatif baru telah berhasil dibuat
+            error: An error has occurred
+            success: A new initiative type has been successfully created
           destroy:
-            success: Jenis inisiatif telah berhasil dihapus
+            success: The initiative type has been successfully removed
           edit:
-            confirm_destroy: Apakah kamu yakin?
-            destroy: Menghapus
-            update: Memperbarui
+            confirm_destroy: Are you sure?
+            destroy: Delete
+            update: Update
           form:
-            title: Informasi Umum
+            title: General information
           initiative_type_scopes:
-            title: Cakupan untuk jenis inisiatif
+            title: Scopes for the initiative type
           new:
-            create: Membuat
-            title: Jenis inisiatif baru
+            create: Create
+            title: New initiative type
           update:
-            error: Sebuah kesalahan telah terjadi
-            success: Jenis inisiatif telah berhasil diperbarui
+            error: An error has occurred
+            success: The initiative type has been successfully updated
       admin_log:
         initiative:
-          publish: "%{user_name} menerbitkan %{resource_name} inisiatif"
-          send_to_technical_validation: "%{user_name} mengirim inisiatif %{resource_name} untuk validasi teknis"
-          unpublish: "%{user_name} membuang %{resource_name} inisiatif"
-          update: "%{user_name} memperbarui %{resource_name} inisiatif"
+          publish: "%{user_name} published the %{resource_name} initiative"
+          send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
+          unpublish: "%{user_name} discarded the %{resource_name} initiative"
+          update: "%{user_name} updated the %{resource_name} initiative"
       admin_states:
-        accepted: Diterima
-        created: Dibuat
-        discarded: Dibuang
-        published: Diterbitkan
-        rejected: Ditolak
-        validating: Validasi teknis
+        accepted: Accepted
+        created: Created
+        discarded: Discarded
+        published: Published
+        rejected: Rejected
+        validating: Technical validation
       committee_requests:
         new:
-          continue: Terus
-          help_text: Anda akan meminta menjadi anggota komite promotor inisiatif ini
+          continue: Continue
+          help_text: You are about to request becoming a member of the promoter committee of this initiative
         spawn:
-          success: Permintaan Anda telah dikirim ke penulis inisiatif.
+          success: Your request has been sent to the initiative author.
       content_blocks:
         highlighted_initiatives:
-          name: Inisiatif yang disorot
+          name: Highlighted initiatives
       create_initiative:
         fill_data:
-          back: Kembali
-          continue: Terus
-          fill_data_help: "<ul> <li>Merevisi isi inisiatif Anda. Apakah judul Anda mudah dimengerti? Apakah tujuan dari inisiatif Anda jelas?</li> <li>Anda harus memilih jenis tanda tangan. In-person, online atau kombinasi keduanya</li> <li>Manakah ruang lingkup geografis dari inisiatif ini? Distrik kota?</li> </ul>"
-          initiative_type: Jenis inisiatif
-          more_information: "(Informasi lebih lanjut)"
-          select_scope: Pilih cakupan
+          back: Back
+          continue: Continue
+          fill_data_help: "<ul> <li>Revise the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative? City, district?</li> </ul>"
+          initiative_type: Initiative type
+          more_information: "(More information)"
+          select_scope: Select a scope
         finish:
-          back: Kembali
-          back_to_initiatives: Kembali ke inisiatif
-          callout_text: Selamat! Inisiatif warga Anda telah berhasil dibuat.
-          go_to_my_initiatives: Pergi ke inisiatif saya
-          more_information: "(Informasi lebih lanjut)"
+          back: Back
+          back_to_initiatives: Back to initiatives
+          callout_text: Congratulations! Your citizen initiative has been created successfully.
+          go_to_my_initiatives: Go to my initiatives
+          more_information: "(More information)"
         finish_help:
-          access_reminder: Ingat bahwa Anda akan selalu dapat mengakses inisiatif Anda melalui menu pengguna.
-          help_for_organizations: Jika Anda adalah asosiasi Anda harus mengunggah menit dari dewan manajemen dari semua organisasi yang membentuk Komisi Promosi
-          help_in_person_signatures: Jika Anda telah memilih untuk mengumpulkan tanda tangan secara langsung atau dikombinasikan dengan online, Anda harus mengunggah informasi yang diperlukan.
-          help_text: Ingat bahwa untuk memproses inisiatif dengan baik, Anda harus mengakses panel administrasi tempat Anda akan menemukan menu pengguna, mengunggah informasi yang diperlukan dan mengirimkannya untuk diproses.
-          initiatives_page_link: Anda dapat mencari semua informasi ini di %{link} didedikasikan untuk menginformasikan tentang inisiatif.
-          page: halaman
+          access_reminder: Remember that you will always be able to access your initiatives through the user menu.
+          help_for_organizations: If you are an association you will have to upload the minutes of the management board of all the organisations that form the Promoting Commission
+          help_in_person_signatures: If you have chosen to collect the signatures in-person or combined with online, you will have to upload the required information.
+          help_text: Remember that in order to properly process the initiative you must access the administration panel where you will find the user menu, upload the information required and send it for processing.
+          initiatives_page_link: You can look up all this information on the %{link} dedicated to inform about initiatives.
+          page: page
         previous_form:
-          back: Kembali
-          continue: Terus
-          help: Apa inisiatif terdiri dari? Tuliskan judul dan deskripsi. Kami merekomendasikan judul singkat dan ringkas dan deskripsi yang difokuskan pada solusi yang diusulkan.
-          more_information: "(Informasi lebih lanjut)"
+          back: Back
+          continue: Continue
+          help: What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.
+          more_information: "(More information)"
         promotal_committee:
-          back: Kembali
-          individual_help_text: Inisiatif warga membutuhkan Komisi Promosi yang terdiri dari setidaknya tiga orang (pengawas). Anda harus membagikan tautan berikut dengan orang lain yang merupakan bagian dari inisiatif ini. Ketika kontak Anda menerima tautan ini mereka harus mengikuti langkah-langkah yang ditunjukkan.
-          more_information: "(Informasi lebih lanjut)"
+          back: Back
+          individual_help_text: Citizen initiatives require a Promoting Commission consisting of at least three people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
+          more_information: "(More information)"
         select_initiative_type:
-          back: Kembali
-          more_information: "(Informasi lebih lanjut)"
-          select: Memilih
-          select_initiative_type_help: Inisiatif warga adalah cara yang dapat dilakukan oleh kewarganegaraan sehingga Dewan Kota dapat melakukan tindakan untuk membela kepentingan umum yang berada di dalam wilayah yurisdiksi kota. Inisiatif apa yang ingin Anda luncurkan?
+          back: Back
+          more_information: "(More information)"
+          select: Choose
+          select_initiative_type_help: Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?
         share_committee_link:
-          continue: Terus
-          invite_to_committee_help: Tautan untuk mengundang orang yang akan menjadi bagian dari komite promotor
+          continue: Continue
+          invite_to_committee_help: Link to invite people that will be part of the promoter committee
         show_similar_initiatives:
-          back: Kembali
-          compare_help: Jika salah satu inisiatif berikut serupa dengan inisiatif Anda, kami mendorong Anda untuk mendukungnya. Proposal Anda akan memiliki lebih banyak kemungkinan untuk diselesaikan.
-          continue: Inisiatif saya berbeda
-          more_information: "(Informasi lebih lanjut)"
+          back: Back
+          compare_help: If any of the following initiatives is similar to yours we encourage you to support it. Your proposal will have more possibilities to get done.
+          continue: My initiative is different
+          more_information: "(More information)"
       events:
         create_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, siapa yang Anda ikuti, telah membuat inisiatif baru, lihat dan sumbangkan:"
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{author_nickname}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Inisiatif baru dengan %{author_nickname}
-          notification_title: Inisiatif <a href="%{resource_path}">%{resource_title}</a> dibuat oleh <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          email_intro: "%{author_name} %{author_nickname}, who you are following, has created a new initiative, check it out and contribute:"
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: New initiative by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         endorse_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, siapa yang Anda ikuti, telah mendukung inisiatif berikut, mungkin Anda ingin berkontribusi dalam percakapan:"
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{author_nickname}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Inisiatif yang didukung oleh %{author_nickname}
-          notification_title: Prakarsa <a href="%{resource_path}">%{resource_title}</a> didukung oleh <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          email_intro: "%{author_name} %{author_nickname}, who you are following, has endorsed the following initiative, maybe you want to contribute to the conversation:"
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: Initiative endorsed by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was endorsed by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
       index:
-        title: Inisiatif
+        title: Initiatives
       initiative_votes:
         create:
-          error: Sudah ada kesalahan saat menandatangani inisiatif.
+          error: There's been errors when signing the initiative.
       initiatives:
         author:
-          deleted: Dihapus
+          deleted: Deleted
         author_list:
           hidden_authors_count:
-            other: dan %{count} lebih banyak orang
+            one: and 1 more person
+            other: and %{count} more people
         count:
           title:
-            other: "%{count} inisiatif"
+            one: "%{count} initiative"
+            other: "%{count} initiatives"
         filters:
-          any: Apa saja
-          author: Penulis
-          closed: Tutup
-          myself: Inisiatif saya
-          open: Buka
-          search: Pencarian
-          state: Negara
-          type: Mengetik
-          type_prompt: Pilih jenis
+          any: Any
+          author: Author
+          closed: Closed
+          myself: My initiatives
+          open: Open
+          search: Search
+          state: State
+          type: Type
+          type_prompt: Select a type
         filters_small_view:
-          close_modal: Tutup jendela
+          close_modal: Close window
           filter: Filter
-          filter_by: Filter berdasarkan
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         index_header:
-          new_initiative: Inisiatif baru
+          new_initiative: New initiative
         orders:
-          label: 'Urutkan inisiatif dengan:'
-          most_commented: Sebagian besar berkomentar
-          most_voted: Paling banyak ditandatangani
-          random: Acak
-          recent: Terbaru
+          label: 'Sort initiatives by:'
+          most_commented: Most commented
+          most_voted: Most signed
+          random: Random
+          recent: Most recent
         result:
-          initiative_accepted_reason: Inisiatif ini telah diterima karena
-          initiative_rejected_reason: Inisiatif ini telah ditolak karena kurangnya dukungan.
+          initiative_accepted_reason: This initiative has been accepted because
+          initiative_rejected_reason: This initiative has been rejected due to its lack of supports.
         show:
-          any_vote_method: Inisiatif warga ini mengumpulkan dukungan online serta tatap muka.
-          offline_method: Inisiatif warga ini hanya mengumpulkan dukungan tatap muka.
+          any_vote_method: This citizen initiative collects online support as well as face to face.
+          offline_method: This citizen initiative only collects face to face supports.
         signature_identities:
-          select_identity: Pilih pengenal pengguna
+          select_identity: Select user identifier
         signatures_count:
-          other: " tanda tangan"
+          one: " signature"
+          other: " signatures"
         statistics:
-          assistants_count_title: Asisten
-          comments_count_title: Komentar
-          meetings_count_title: Rapat
-          supports_count_title: Tanda tangan
+          assistants_count_title: Assistants
+          comments_count_title: Comments
+          meetings_count_title: Meetings
+          supports_count_title: Signatures
         supports:
-          title: Daftar tanda tangan
+          title: Listing of signatures
         vote_cabin:
-          already_voted: Sudah ditandatangani
-          supports_required: "%{total_supports} tanda tangan diperlukan"
-          vote: Tanda
-          votes_blocked: Penandatanganan dinonaktifkan
+          already_voted: Already signed
+          supports_required: "%{total_supports} signatures required"
+          vote: Sign
+          votes_blocked: Signing disabled
         votes_count:
           count:
-            other: TANDATANGAN
+            one: SIGNATURE
+            other: SIGNATURES
       initiatives_mailer:
-        creation_subject: Inisiatif warga Anda '%{title}' telah dibuat
+        creation_subject: Your citizen initiative '%{title}' has been created
         initiative_link:
-          check_initiative_details: Anda dapat melihat detail inisiatif
-          here: sini
-        more_information: Di sini Anda memiliki informasi lebih lanjut tentang proses pembuatan inisiatif.
-        progress_report_body_for: Inisiatif %{title} telah mencapai %{percentage}% dari dukungan yang diperlukan.
-        progress_report_for: 'Lanjutkan tentang inisiatif: %{title}'
-        promotal_committee_help: Ingat bahwa Anda harus mengundang setidaknya %{member_count} orang ke komite promotor. Teruskan tautan berikut untuk mengundang orang ke komite promotor
-        status_change_body_for: 'Inisiatif %{title} telah mengubah negaranya menjadi: %{state}'
-        status_change_for: Inisiatif %{title} telah mengubah keadaannya
-        technical_validation_body_for: Inisiatif %{title} telah meminta validasi teknisnya.
-        technical_validation_for: Inisiatif %{title} telah meminta validasi teknisnya.
+          check_initiative_details: You can see the initiative details
+          here: here
+        more_information: Here you have more information about the initiative creation process.
+        progress_report_body_for: The initiative %{title} has reached the %{percentage}% of required supports.
+        progress_report_for: 'Resume about the initiative: %{title}'
+        promotal_committee_help: Remember that you must invite at least %{member_count} people to promoter committee. Forward the following link to invite people to the promoter committee
+        status_change_body_for: 'The initiative %{title} has changed its state to: %{state}'
+        status_change_for: The initiative %{title} has changed its state
+        technical_validation_body_for: The initiative %{title} has requested its technical validation.
+        technical_validation_for: The initiative %{title} has requested its technical validation.
       last_activity:
-        new_initiative: Inisiatif baru
+        new_initiative: New initiative
       pages:
         home:
           highlighted_initiatives:
-            active_initiatives: Inisiatif aktif
-            see_all_initiatives: Lihat semua inisiatif
+            active_initiatives: Active initiatives
+            see_all_initiatives: See all initiatives
       states:
-        accepted: Diterima
-        expired: Kadaluarsa
-      unavailable_scope: Ruang lingkup tidak tersedia
+        accepted: Accepted
+        expired: Expired
+      unavailable_scope: Unavailable scope
     menu:
-      initiatives: Inisiatif
+      initiatives: Initiatives
   layouts:
     decidim:
       admin:
         initiative:
-          attachments: Lampiran
-          committee_members: anggota Komite
-          components: Komponen
-          information: Informasi
+          attachments: Attachments
+          committee_members: Committee members
+          components: Components
+          information: Information
       initiative_creation_header:
-        fill_data: Membuat
-        finish: Selesai
-        previous_form: Mulai
-        promotal_committee: Komite promotor
-        select_initiative_type: Memilih
-        show_similar_initiatives: Membandingkan
-        step: Langkah %{current} dari %{total}
-        title: Buat inisiatif baru
+        fill_data: Create
+        finish: Finish
+        previous_form: Start
+        promotal_committee: Promoter committee
+        select_initiative_type: Choose
+        show_similar_initiatives: Compare
+        step: Step %{current} of %{total}
+        title: Create new initiative
       initiative_header:
-        initiative_menu_item: Prakarsa
+        initiative_menu_item: Initiative
       initiatives:
         initiative:
-          check: Coba lihat
-          check_and_support: Lihat dan tandatangani
+          check: Check it out
+          check_and_support: Check it out and sign
         no_initiatives_yet:
-          no_initiatives_yet: Belum ada inisiatif!
+          no_initiatives_yet: No initiatives yet!

--- a/decidim-initiatives/config/locales/it.yml
+++ b/decidim-initiatives/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ it:
             email_outro: Hai ricevuto questa notifica perché sei l'autore dell'iniziativa %{resource_title}.
             email_subject: Nuova pietra miliare completata!
             notification_title: La tua iniziativa <a href="%{resource_path}">%{resource_title}</a> ha raggiunto il %{percentage}% delle firme.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: L'iniziativa %{resource_title} ha raggiunto l' %{percentage}% delle firme!
             email_outro: Hai ricevuto questa notifica perché stai seguendo %{resource_title}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
             email_subject: Nuova pietra miliare completata!
             notification_title: L'iniziativa <a href="%{resource_path}">%{resource_title}</a> ha raggiunto il %{percentage}% delle firme.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Vai allo spazio di partecipazione delle iniziative
-            - Segui i passaggi per creare una nuova iniziativa
+          - Vai allo spazio di partecipazione delle iniziative
+          - Segui i passaggi per creare una nuova iniziativa
           description: Questo badge è garantito quando lanci nuove iniziative, collaborando con altri per realizzarle.
           description_another: Questo utente ha ottenuto %{score} iniziative pubblicate.
           description_own: Hai pubblicato %{score} iniziative.

--- a/decidim-initiatives/config/locales/nl.yml
+++ b/decidim-initiatives/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u de auteur bent van het initiatief %{resource_title}.
             email_subject: Nieuwe mijlpaal voltooid!
             notification_title: Uw <a href="%{resource_path}">%{resource_title}</a> initiatief heeft de %{percentage}% handtekeningen bereikt.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Het initiatief %{resource_title} heeft de %{percentage}% handtekeningen bereikt!
             email_outro: U hebt deze melding ontvangen omdat u %{resource_title}. Je kunt stoppen met het ontvangen van meldingen na de vorige link.
             email_subject: Nieuwe mijlpaal voltooid!
             notification_title: Het <a href="%{resource_path}">%{resource_title}</a> initiatief heeft de %{percentage}% handtekeningen behaald.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ga naar de participatieruimte van Intiatives
-            - Volg de stappen om een ​​nieuw initiatief te maken
+          - Ga naar de participatieruimte van Intiatives
+          - Volg de stappen om een ​​nieuw initiatief te maken
           description: Deze badge wordt toegekend wanneer u nieuwe initiatieven start en samenwerkt met anderen om ze uit te voeren.
           description_another: Deze gebruiker heeft %{score} initiatieven gepubliceerd.
           description_own: Je hebt %{score} initiatieven gepubliceerd.

--- a/decidim-initiatives/config/locales/pl.yml
+++ b/decidim-initiatives/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -35,19 +36,19 @@ pl:
   activerecord:
     models:
       decidim/initiative:
-        one: Initative
         few: Inicjatywy
         many: Inicjatywy
+        one: Initative
         other: Inicjatywy
       decidim/initiative_comittee:
-        one: Komitet
         few: Komitety
         many: Komitety
+        one: Komitet
         other: Komitety
       decidim/initiative_vote:
-        one: Podpis
         few: Podpisy
         many: Podpisy
+        one: Podpis
         other: Podpisy
   decidim:
     admin:
@@ -90,17 +91,21 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem inicjatywy %{resource_title}.
             email_subject: Nowy kamień milowy zakończony!
             notification_title: Twoja inicjatywa <a href="%{resource_path}">%{resource_title}</a> osiągnęła %{percentage}% podpisów.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Inicjatywa %{resource_title} osiągnęła %{percentage}% podpisów!
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{resource_title}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
             email_subject: Nowy kamień milowy zakończony!
             notification_title: Inicjatywa <a href="%{resource_path}">%{resource_title}</a> osiągnęła %{percentage}% podpisów.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Idź do miejsca uczestnictwa Intiatives
-            - Postępuj zgodnie z instrukcjami, aby utworzyć nową inicjatywę
+          - Idź do miejsca uczestnictwa Intiatives
+          - Postępuj zgodnie z instrukcjami, aby utworzyć nową inicjatywę
           description: Ta odznaka jest przyznawana, gdy uruchamiasz nowe inicjatywy, współpracując z innymi, aby je zrealizować.
           description_another: Ten użytkownik otrzymał %{score} opublikowanych inicjatyw.
           description_own: Masz opublikowanych %{score} inicjatyw.
@@ -283,15 +288,15 @@ pl:
           deleted: Usunięto
         author_list:
           hidden_authors_count:
-            one: i jeszcze 1 osoba
             few: i %{count} więcej osób
             many: i %{count} więcej osób
+            one: i jeszcze 1 osoba
             other: i %{count} więcej osób
         count:
           title:
-            one: "%{count} inicjatywa"
             few: "%{count} inicjatyw"
             many: "%{count} inicjatyw"
+            one: "%{count} inicjatywa"
             other: "%{count} inicjatyw"
         filters:
           any: Każdy
@@ -325,9 +330,9 @@ pl:
         signature_identities:
           select_identity: Wybierz identyfikator użytkownika
         signatures_count:
-          one: " podpis"
           few: " podpisy"
           many: " podpisy"
+          one: " podpis"
           other: " podpisy"
         statistics:
           assistants_count_title: Asystenci
@@ -338,14 +343,14 @@ pl:
           title: Lista podpisów
         vote_cabin:
           already_voted: Już podpisane
-          supports_required: "Wymagane %{total_supports} podpisów"
+          supports_required: Wymagane %{total_supports} podpisów
           vote: Znak
           votes_blocked: Podpisywanie wyłączone
         votes_count:
           count:
-            one: PODPIS
             few: PODPISY
             many: PODPISY
+            one: PODPIS
             other: PODPISY
       initiatives_mailer:
         creation_subject: Twoja inicjatywa obywatelska "%{title}" została utworzona

--- a/decidim-initiatives/config/locales/pt-BR.yml
+++ b/decidim-initiatives/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque é o autor da iniciativa %{resource_title}.
             email_subject: Novo marco concluído!
             notification_title: Sua iniciativa <a href="%{resource_path}">%{resource_title}</a> alcançou os %{percentage}% de assinaturas.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: A iniciativa %{resource_title} obteve %{percentage} de assinaturas!
             email_outro: Você recebeu esta notificação porque está seguindo %{resource_title}. Você pode parar de receber notificações após o link anterior.
             email_subject: Novo marco concluído!
             notification_title: A <a href="%{resource_path}">%{resource_title}</a> iniciativa obteve %{percentage}% de assinaturas.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ir para o espaço de participação de Iniciativas
-            - Siga os passos para criar uma nova iniciativa
+          - Ir para o espaço de participação de Iniciativas
+          - Siga os passos para criar uma nova iniciativa
           description: Esse selo é concedido quando você lança novas iniciativas, estabelecendo parcerias com outras pessoas para realizá-las.
           description_another: Este usuário obteve %{score} iniciativas publicadas.
           description_own: Você tem %{score} iniciativas publicadas.
@@ -326,7 +331,7 @@ pt-BR:
           title: Listagem de assinaturas
         vote_cabin:
           already_voted: Já assinadas
-          supports_required: "São necessárias %{total_supports} assinaturas"
+          supports_required: São necessárias %{total_supports} assinaturas
           vote: Placa
           votes_blocked: Assinatura desativada
         votes_count:

--- a/decidim-initiatives/config/locales/pt.yml
+++ b/decidim-initiatives/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ pt:
             email_outro: Você recebeu esta notificação porque é o autor da iniciativa %{resource_title}.
             email_subject: Novo marco concluído!
             notification_title: Sua iniciativa <a href="%{resource_path}">%{resource_title}</a> alcançou os %{percentage}% de assinaturas.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: A iniciativa %{resource_title} alcançou o %{percentage}% de assinaturas!
             email_outro: Você recebeu esta notificação porque está seguindo %{resource_title}. Você pode parar de receber notificações após o link anterior.
             email_subject: Novo marco concluído!
             notification_title: A iniciativa <a href="%{resource_path}">%{resource_title}</a> alcançou os %{percentage}% de assinaturas.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Ir para o espaço de participação de Intiatives
-            - Siga os passos para criar uma nova iniciativa
+          - Ir para o espaço de participação de Intiatives
+          - Siga os passos para criar uma nova iniciativa
           description: Esse selo é concedido quando você lança novas iniciativas, estabelecendo parcerias com outras pessoas para realizá-las.
           description_another: Este usuário obteve %{score} iniciativas publicadas.
           description_own: Você tem %{score} iniciativas publicadas.

--- a/decidim-initiatives/config/locales/ru.yml
+++ b/decidim-initiatives/config/locales/ru.yml
@@ -1,3 +1,4 @@
+---
 ru:
   activemodel:
     attributes:
@@ -35,19 +36,19 @@ ru:
   activerecord:
     models:
       decidim/initiative:
-        one: Почин
         few: Почина
         many: Починов
+        one: Почин
         other: Починов
       decidim/initiative_comittee:
-        one: Рабочая группа
         few: Рабочих группы
         many: Рабочих групп
+        one: Рабочая группа
         other: Рабочих групп
       decidim/initiative_vote:
-        one: Подпись
         few: Подписи
         many: Подписей
+        one: Подпись
         other: Подписей
   decidim:
     admin:
@@ -60,6 +61,7 @@ ru:
         initiatives:
           fields:
             created_at: 'Создано:'
+            id: ID
             state: Cостояние
             supports_count: Выражений поддержки
             title: Почины
@@ -85,11 +87,36 @@ ru:
           notification_title: Срок сбора подписей в поддержку почина <a href="%{resource_path}">%{resource_title}</a> продлен.
         milestone_completed:
           affected_user:
+            email_intro: Your initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
             email_subject: Достигнута новая веха!
+            notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Почин %{resource_title} достиг %{percentage}% подписей!
+            email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
             email_subject: Достигнута новая веха!
             notification_title: Почин <a href="%{resource_path}">%{resource_title}</a> достиг %{percentage}% подписей.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
+    gamification:
+      badges:
+        initiatives:
+          conditions: '["Go to the participation space of Intiatives", "Follow the steps to create a new initiative"]'
+          description: This badge is granted when you launch new initiatives, partnering with others to carry them out.
+          description_another: This user has gotten %{score} initiatives published.
+          description_own: You've got %{score} initiatives published.
+          name: Published initiatives
+          next_level_in: Get %{score} more initiatives published to reach the next level!
+          unearned_another: This user hasn't gotten any initiatives published yet.
+          unearned_own: You got no initiatives published yet.
+    help:
+      participatory_spaces:
+        initiatives:
+          contextual: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          page: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          title: What are initiatives?
     initiatives:
       admin:
         committee_requests:
@@ -100,6 +127,9 @@ ru:
             no_members_yet: В рабочей группе по продвижению нет ни одного члена
             revoke: Отозвать
             title: Члены рабочей группы
+        content_blocks:
+          highlighted_initiatives:
+            max_results: Maximum amount of elements to show
         initiatives:
           edit:
             accept: Принять почин
@@ -256,15 +286,15 @@ ru:
           deleted: Удален
         author_list:
           hidden_authors_count:
-            one: и еще 1 человек
             few: и еще %{count} людей
             many: и еще %{count} человек
+            one: и еще 1 человек
             other: и еще %{count} человек
         count:
           title:
-            one: "%{count} почин"
             few: "%{count} почина"
             many: "%{count} починов"
+            one: "%{count} почин"
             other: "%{count} починов"
         filters:
           any: Любые
@@ -298,9 +328,9 @@ ru:
         signature_identities:
           select_identity: Выберите псевдоним участника
         signatures_count:
-          one: " подпись"
           few: " подписи"
           many: " подписей"
+          one: " подпись"
           other: " подписей"
         statistics:
           assistants_count_title: Помощников
@@ -311,14 +341,14 @@ ru:
           title: Список подписей
         vote_cabin:
           already_voted: Уже подписали
-          supports_required: "Требуется %{total_supports} подписей"
+          supports_required: Требуется %{total_supports} подписей
           vote: Подписать
           votes_blocked: Подписание отключено
         votes_count:
           count:
-            one: ПОДПИСЬ
             few: ПОДПИСИ
             many: ПОДПИСЕЙ
+            one: ПОДПИСЬ
             other: ПОДПИСЕЙ
       initiatives_mailer:
         creation_subject: Ваш гражданский почин '%{title}' был создан
@@ -333,6 +363,8 @@ ru:
         status_change_for: Состояние почина %{title} изменилось
         technical_validation_body_for: Почин %{title} запросил техническую проверку.
         technical_validation_for: Почин %{title} запросил техническую проверку.
+      last_activity:
+        new_initiative: New initiative
       pages:
         home:
           highlighted_initiatives:
@@ -341,6 +373,7 @@ ru:
       states:
         accepted: Принятые
         expired: Истекшие
+      unavailable_scope: Unavailable scope
     menu:
       initiatives: Почины
   layouts:
@@ -358,6 +391,8 @@ ru:
         promotal_committee: Рабочая группа по продвижению
         select_initiative_type: Выбрать
         show_similar_initiatives: Сравнить
+        step: Step %{current} of %{total}
+        title: Create new initiative
       initiative_header:
         initiative_menu_item: Почин
       initiatives:

--- a/decidim-initiatives/config/locales/sv.yml
+++ b/decidim-initiatives/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -84,17 +85,21 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du är författaren till initiativet %{resource_title}.
             email_subject: Ny milstolpe färdigställd!
             notification_title: Ditt <a href="%{resource_path}">%{resource_title}</a> initiativ har uppnått %{percentage}% av underskrifterna.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Initiativet %{resource_title} har uppnått %{percentage}% av underskrifterna!
             email_outro: Du har fått den här meddelandet eftersom du följer %{resource_title}. Du kan sluta ta emot meddelanden efter föregående länk.
             email_subject: Ny milstolpe färdigställd!
             notification_title: <a href="%{resource_path}">%{resource_title}</a> initiativet har uppnått %{percentage}% av underskrifterna.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
           conditions:
-            - Gå till Intiatives deltagande utrymme
-            - Följ stegen för att skapa ett nytt initiativ
+          - Gå till Intiatives deltagande utrymme
+          - Följ stegen för att skapa ett nytt initiativ
           description: Detta märke beviljas när du startar nya initiativ, samarbetar med andra för att utföra dem.
           description_another: Den här användaren har fått %{score} initiativ publicerade.
           description_own: Du har %{score} initiativ publicerade.

--- a/decidim-initiatives/config/locales/tr-TR.yml
+++ b/decidim-initiatives/config/locales/tr-TR.yml
@@ -1,386 +1,389 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       initiative:
-        decidim_user_group_id: Yazar
-        description: Açıklama
-        offline_votes: Yüz yüze destek
-        scope_id: kapsam
-        signature_end_date: İmza toplama süresinin sonu
-        signature_start_date: İmza toplama döneminin başlangıcı
-        signature_type: İmza koleksiyonu türü
+        decidim_user_group_id: Author
+        description: Description
+        offline_votes: Face-to-face supports
+        scope_id: Scope
+        signature_end_date: End of signature collection period
+        signature_start_date: Start of signature collection period
+        signature_type: Signature collection type
         signature_type_values:
-          any: Karışık
-          offline: Yüz yüze
-          online: İnternet üzerinden
-        title: Başlık
+          any: Mixed
+          offline: Face to face
+          online: OnLine
+        title: Title
       initiative_author:
-        address: Adres
-        city: Kent
-        id_document: DNI / NIE
-        name: Ad ve soyadı
-        phone_number: Telefon numarası
-        post_code: Posta kodu
-        province: il
+        address: Address
+        city: City
+        id_document: DNI/NIE
+        name: Name and Surname
+        phone_number: Phone number
+        post_code: Post code
+        province: Province
       initiatives_committee_member:
-        user: Komite Üyesi
+        user: Committee member
       initiatives_type:
-        banner_image: Banner resmi
-        description: Açıklama
-        title: Başlık
+        banner_image: Banner image
+        description: Description
+        title: Title
       organization_data:
-        address: Adres
-        id_document: Kimlik belgesi
-        name: Tam adı
+        address: Address
+        id_document: ID document
+        name: Complete name
   activerecord:
     models:
       decidim/initiative:
-        one: İnisiyatif
+        one: Initative
         other: Initatives
       decidim/initiative_comittee:
-        one: Komitesi
-        other: Kurullar
+        one: Comittee
+        other: Comittees
       decidim/initiative_vote:
-        one: İmza
-        other: İmzalar
+        one: Signature
+        other: Signatures
   decidim:
     admin:
       actions:
-        new_initiative_type: Yeni girişim türü
+        new_initiative_type: New initiative type
       menu:
-        initiatives: Girişimler
-        initiatives_types: Girişim türleri
+        initiatives: Initiatives
+        initiatives_types: Initiative types
       models:
         initiatives:
           fields:
-            created_at: Düzenlendi
-            id: İD
-            state: Belirtmek, bildirmek
-            supports_count: Destekler
-            title: Girişimler
+            created_at: Created at
+            id: ID
+            state: State
+            supports_count: Supports
+            title: Initiatives
         initiatives_type_scope:
           fields:
-            scope: kapsam
-            supports_required: Gerekli destekler
-          name: Girişim tipi kapsamı
+            scope: Scope
+            supports_required: Supports required
+          name: Initiative type scope
         initiatives_types:
           fields:
-            created_at: Düzenlendi
-            title: Girişim türleri
-          name: Girişimi tipi
+            created_at: Created at
+            title: Initiative types
+          name: Initiative type
       titles:
-        initiatives: Girişimler
-        initiatives_types: Girişim türleri
+        initiatives: Initiatives
+        initiatives_types: Initiative types
     events:
       initiatives:
         initiative_extended:
-          email_intro: Girişim için imzalar bitiş tarihi %{resource_title} uzatıldı!
-          email_outro: Bu bildirimi, %{resource_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: Girişim imzaları bitiş tarihi uzatıldı!
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> girişiminin imza bitiş tarihi uzatıldı.
+          email_intro: The signatures end date for the initiative %{resource_title} has been extended!
+          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_subject: Initiative signatures end date extended!
+          notification_title: The signatures end date for the <a href="%{resource_path}">%{resource_title}</a> initiative has been extended.
         milestone_completed:
           affected_user:
-            email_intro: Girişiminiz %{resource_title} elde etti %{percentage}imzaların%!
-            email_outro: Bu bildirimi aldınız çünkü inisiyatifin %{resource_title}yazarı sizsiniz.
-            email_subject: Yeni kilometre taşı tamamlandı!
-            notification_title: Sizin <a href="%{resource_path}">%{resource_title}</a> girişimi elde etti %{percentage}imzaların%.
+            email_intro: Your initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
+            email_subject: New milestone completed!
+            notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
-            email_intro: İnisiyatif %{resource_title} elde etti %{percentage}imzaların%!
-            email_outro: Bu bildirimi, %{resource_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-            email_subject: Yeni kilometre taşı tamamlandı!
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> girişimi elde etti %{percentage}imzaların%.
+            email_intro: The initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+            email_subject: New milestone completed!
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
     gamification:
       badges:
         initiatives:
-          conditions:
-            - Intiatives'in katılım alanına git
-            - Yeni bir girişim oluşturmak için adımları izleyin
-          description: Bu rozet, yeni girişimler başlattığınızda, bunları gerçekleştirmek için başkalarıyla ortaklık kurduğunuzda verilir.
-          description_another: Bu kullanıcı %{score} yayınlandı.
-          description_own: Yayınlanmış %{score} girişiniz var.
-          name: Yayınlanmış girişimler
-          next_level_in: Bir sonraki seviyeye ulaşmak için yayınlanan %{score} daha alın!
-          unearned_another: Bu kullanıcı henüz yayınlanmış hiçbir girişimde bulunmadı.
-          unearned_own: Henüz yayınlanan hiçbir girişimin yok.
+          conditions: '["Go to the participation space of Intiatives", "Follow the steps to create a new initiative"]'
+          description: This badge is granted when you launch new initiatives, partnering with others to carry them out.
+          description_another: This user has gotten %{score} initiatives published.
+          description_own: You've got %{score} initiatives published.
+          name: Published initiatives
+          next_level_in: Get %{score} more initiatives published to reach the next level!
+          unearned_another: This user hasn't gotten any initiatives published yet.
+          unearned_own: You got no initiatives published yet.
     help:
       participatory_spaces:
         initiatives:
-          contextual: "<p>Bir girişim belirli bir işlemi (bir yönetmelik değiştirmek yürütmek için organizasyon için (dijital) imza toplama yoluyla (bağımsız kanal veya katılım boşluklar diğerinin) kendi inisiyatifleriyle herkes tarafından teşvik edilebilir bir öneri bir proje başlatmak olduğunu , bir bölümün veya bir sokağın adını değiştirir vb.).</p> <p>Bir girişimin destekleyicileri hedeflerini tanımlayabilir, destek toplayabilir, tartışabilir, dağıtabilir ve katılımcılardan imzaların toplanabileceği buluşma noktalarını veya diğer katılımcılara açık tartışmaları tanımlayabilir.</p> <p>Örnekler: Bir inisiyatif, bir örgütün tüm halkı arasında bir istişare toplanması, bir meclis oluşturma veya toplanması ya da kuruluşun bir bölgesi veya bölgesi için bir bütçe artışı sürecinin başlatılması için imza toplayabilir. İmza toplama süreci boyunca, bu talebe daha fazla kişi katılabilir ve organizasyonda ileriye taşıyabilir.</p>\n"
-          page: "<p>Bir girişim belirli bir işlemi (bir yönetmelik değiştirmek yürütmek için organizasyon için (dijital) imza toplama yoluyla (bağımsız kanal veya katılım boşluklar diğerinin) kendi inisiyatifleriyle herkes tarafından teşvik edilebilir bir öneri bir proje başlatmak olduğunu , bir bölümün veya bir sokağın adını değiştirir vb.).</p> <p>Bir girişimin destekleyicileri hedeflerini tanımlayabilir, destek toplayabilir, tartışabilir, dağıtabilir ve katılımcılardan imzaların toplanabileceği buluşma noktalarını veya diğer katılımcılara açık tartışmaları tanımlayabilir.</p> <p>Örnekler: Bir inisiyatif, bir örgütün tüm halkı arasında bir istişare toplanması, bir meclis oluşturma veya toplanması ya da kuruluşun bir bölgesi veya bölgesi için bir bütçe artışı sürecinin başlatılması için imza toplayabilir. İmza toplama süreci boyunca, bu talebe daha fazla kişi katılabilir ve organizasyonda ileriye taşıyabilir.</p>\n"
-          title: Girişimler nelerdir?
+          contextual: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          page: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          title: What are initiatives?
     initiatives:
       admin:
         committee_requests:
           index:
-            approve: onaylamak
-            confirm_revoke: Emin misiniz?
-            invite_to_committee_help: Diğer kullanıcıları promosyon komitesine davet etmek için bu bağlantıyı paylaşın
-            no_members_yet: Promoter komitesinde üye yok
-            revoke: geri almak
-            title: Komite üyeleri
+            approve: Approve
+            confirm_revoke: Are you sure?
+            invite_to_committee_help: Share this link to invite other users to the promotion committee
+            no_members_yet: There are no members in the promoter committee
+            revoke: Revoke
+            title: Committee members
         content_blocks:
           highlighted_initiatives:
-            max_results: Gösterilecek maksimum öğe miktarı
+            max_results: Maximum amount of elements to show
         initiatives:
           edit:
-            accept: Girişimi kabul et
-            confirm: Emin misiniz?
-            discard: Girişimi atın
-            export_votes: İhracat destekleri
-            reject: Girişimi reddet
-            send_to_technical_validation: Teknik doğrulamaya gönder
-            success: Girişim teknik doğrulamaya gönderildi
-            update: Güncelleştirme
+            accept: Accept initiative
+            confirm: Are you sure?
+            discard: Discard the initiative
+            export_votes: Export supports
+            reject: Reject initiative
+            send_to_technical_validation: Send to technical validation
+            success: The initiative has been sent to technical validation
+            update: Update
           form:
-            title: Genel bilgi
+            title: General information
           index:
-            actions_title: Aksiyon
+            actions_title: Action
             filter:
-              accepted: Kabul edilmiş
-              all: Herşey
-              created: düzenlendi
-              discarded: Atılan
-              published: Yayınlanan
-              rejected: Reddedilen
-              validating: Teknik doğrulama
-            filter_by: Tarafından filtre
-            preview: Ön izleme
-            print: baskı
-            search: Arama
+              accepted: Accepted
+              all: All
+              created: Created
+              discarded: Discarded
+              published: Published
+              rejected: Rejected
+              validating: Technical validation
+            filter_by: Filter by
+            preview: Preview
+            print: Print
+            search: Search
           show:
-            print: baskı
+            print: Print
           update:
-            error: bir hata oluştu
-            success: Vatandaş girişimi başarıyla güncellendi
+            error: An error has occurred
+            success: The citizen initiative has been successfully updated
         initiatives_type_scopes:
           create:
-            error: bir hata oluştu
-            success: Verilen inisiyatif türü için yeni bir kapsam oluşturuldu
+            error: An error has occurred
+            success: A new scope for the given initiative type has been created
           destroy:
-            success: Kapsam başarıyla kaldırıldı
+            success: The scope has been successfully removed
           edit:
-            back: Geri
-            confirm_destroy: Emin misiniz?
-            destroy: silmek
-            title: Girişim türü kapsamını düzenle
-            update: Güncelleştirme
+            back: Back
+            confirm_destroy: Are you sure?
+            destroy: Delete
+            title: Edit initiative type scope
+            update: Update
           new:
-            back: Geri
-            create: yaratmak
-            title: Girişim tipi kapsamı oluştur
+            back: Back
+            create: Create
+            title: Create initiative type scope
           update:
-            error: bir hata oluştu
-            success: Kapsam başarıyla güncellendi
+            error: An error has occurred
+            success: The scope has been successfully updated
         initiatives_types:
           create:
-            error: bir hata oluştu
-            success: Yeni bir girişim türü başarıyla oluşturuldu
+            error: An error has occurred
+            success: A new initiative type has been successfully created
           destroy:
-            success: Girişim türü başarıyla kaldırıldı
+            success: The initiative type has been successfully removed
           edit:
-            confirm_destroy: Emin misiniz?
-            destroy: silmek
-            update: Güncelleştirme
+            confirm_destroy: Are you sure?
+            destroy: Delete
+            update: Update
           form:
-            title: Genel bilgi
+            title: General information
           initiative_type_scopes:
-            title: Girişim türü için kapsamlar
+            title: Scopes for the initiative type
           new:
-            create: yaratmak
-            title: Yeni girişim türü
+            create: Create
+            title: New initiative type
           update:
-            error: bir hata oluştu
-            success: Girişim türü başarıyla güncellendi
+            error: An error has occurred
+            success: The initiative type has been successfully updated
       admin_log:
         initiative:
-          publish: "%{user_name} %{resource_name} girişim yayınladı"
-          send_to_technical_validation: "%{user_name} teknik inisiyatife %{resource_name} girişimi gönderdi"
-          unpublish: "%{user_name} %{resource_name} girişim reddetti"
-          update: "%{user_name} , %{resource_name} girişimi güncelledi"
+          publish: "%{user_name} published the %{resource_name} initiative"
+          send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
+          unpublish: "%{user_name} discarded the %{resource_name} initiative"
+          update: "%{user_name} updated the %{resource_name} initiative"
       admin_states:
-        accepted: Kabul edilmiş
-        created: düzenlendi
-        discarded: Atılan
-        published: Yayınlanan
-        rejected: Reddedilen
-        validating: Teknik doğrulama
+        accepted: Accepted
+        created: Created
+        discarded: Discarded
+        published: Published
+        rejected: Rejected
+        validating: Technical validation
       committee_requests:
         new:
-          continue: Devam et
-          help_text: Bu inisiyatifin destekleyici komitesine üye olmayı istemek üzeresiniz
+          continue: Continue
+          help_text: You are about to request becoming a member of the promoter committee of this initiative
         spawn:
-          success: İsteğiniz inisiyatif yazara gönderildi.
+          success: Your request has been sent to the initiative author.
       content_blocks:
         highlighted_initiatives:
-          name: Vurgulanan girişimler
+          name: Highlighted initiatives
       create_initiative:
         fill_data:
-          back: Geri
-          continue: Devam et
-          fill_data_help: "<ul> <li>Girişinizin içeriğini gözden geçirin. Başlığınız anlaşılması kolay mı? Girişimin amacı net mi?</li> <li>İmzanın türünü seçmelisiniz. , Çevrimiçi ya da her ikisinin bir kombinasyonu kişiye ise</li> <li>girişiminin coğrafi kapsamı nedir? Şehir bölge mi?</li> </ul>"
-          initiative_type: Girişimi tipi
-          more_information: "(Daha fazla bilgi)"
-          select_scope: Bir kapsam seçin
+          back: Back
+          continue: Continue
+          fill_data_help: "<ul> <li>Revise the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative? City, district?</li> </ul>"
+          initiative_type: Initiative type
+          more_information: "(More information)"
+          select_scope: Select a scope
         finish:
-          back: Geri
-          back_to_initiatives: Girişimlere geri dönüş
-          callout_text: Tebrikler! Vatandaş girişimi başarıyla oluşturuldu.
-          go_to_my_initiatives: Benim girişimlerime git
-          more_information: "(Daha fazla bilgi)"
+          back: Back
+          back_to_initiatives: Back to initiatives
+          callout_text: Congratulations! Your citizen initiative has been created successfully.
+          go_to_my_initiatives: Go to my initiatives
+          more_information: "(More information)"
         finish_help:
-          access_reminder: Kullanıcı menüsü aracılığıyla girişimlerinize her zaman erişebileceğinizi unutmayın.
-          help_for_organizations: Eğer bir dernekseniz, Teşvik Komisyonunu oluşturan tüm kuruluşların yönetim kurulunun tutanaklarını yüklemeniz gerekecektir.
-          help_in_person_signatures: İmzaları şahsen ya da çevrimiçi olarak bir araya getirmeyi seçtiyseniz, gerekli bilgileri yüklemeniz gerekecektir.
-          help_text: Girişimi doğru şekilde işlemek için kullanıcı menüsünü bulacağınız, gerekli bilgileri yükleyeceğiniz ve işlem için göndereceğiniz yönetim paneline erişmeniz gerektiğini unutmayın.
-          initiatives_page_link: Tüm bu bilgileri inisiyatifler hakkında bilgilendirmek için %{link} bakabilirsiniz.
-          page: sayfa
+          access_reminder: Remember that you will always be able to access your initiatives through the user menu.
+          help_for_organizations: If you are an association you will have to upload the minutes of the management board of all the organisations that form the Promoting Commission
+          help_in_person_signatures: If you have chosen to collect the signatures in-person or combined with online, you will have to upload the required information.
+          help_text: Remember that in order to properly process the initiative you must access the administration panel where you will find the user menu, upload the information required and send it for processing.
+          initiatives_page_link: You can look up all this information on the %{link} dedicated to inform about initiatives.
+          page: page
         previous_form:
-          back: Geri
-          continue: Devam et
-          help: Girişim neden oluşur? Başlığı ve açıklamayı yazınız. Kısa ve özlü bir başlık ve önerilen çözüm üzerinde odaklanmış bir açıklama yapmanızı öneririz.
-          more_information: "(Daha fazla bilgi)"
+          back: Back
+          continue: Continue
+          help: What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.
+          more_information: "(More information)"
         promotal_committee:
-          back: Geri
-          individual_help_text: Vatandaş girişimleri, en az üç kişiden oluşan bir Teşvik Komisyonu (vekilleri) gerektirir. Aşağıdaki bağlantıyı, bu girişimin parçası olan diğer kişilerle paylaşmalısınız. Kişileriniz bu bağlantıyı aldığında, belirtilen adımları izlemelidirler.
-          more_information: "(Daha fazla bilgi)"
+          back: Back
+          individual_help_text: Citizen initiatives require a Promoting Commission consisting of at least three people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
+          more_information: "(More information)"
         select_initiative_type:
-          back: Geri
-          more_information: "(Daha fazla bilgi)"
-          select: Seçmek
-          select_initiative_type_help: Vatandaş girişimleri, vatandaşlığın müdahalede bulunabileceği bir araç olup, Belediye Meclisi'nin, belediyenin yetki alanı dahilindeki genel menfaatlerin savunulması için eylemde bulunabilmesi için. Hangi girişimi başlatmak istiyorsunuz?
+          back: Back
+          more_information: "(More information)"
+          select: Choose
+          select_initiative_type_help: Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?
         share_committee_link:
-          continue: Devam et
-          invite_to_committee_help: Promoter komitesinin bir parçası olacak kişileri davet etmek için bağlantı
+          continue: Continue
+          invite_to_committee_help: Link to invite people that will be part of the promoter committee
         show_similar_initiatives:
-          back: Geri
-          compare_help: Aşağıdaki girişimlerden herhangi biri sizinkilerle benzerse, bunu desteklemenizi öneririz. Teklifinizin yapılması için daha fazla olasılık olacaktır.
-          continue: Benim girişim farklı
-          more_information: "(Daha fazla bilgi)"
+          back: Back
+          compare_help: If any of the following initiatives is similar to yours we encourage you to support it. Your proposal will have more possibilities to get done.
+          continue: My initiative is different
+          more_information: "(More information)"
       events:
         create_initiative_event:
-          email_intro: "Takip ettiğiniz %{author_name} %{author_nickname}, yeni bir girişim oluşturdu, kontrol etti ve katkıda bulundu:"
-          email_outro: Bu bildirimi, %{author_nickname}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{author_nickname}Yeni girişim'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> girişimi <a href="%{author_path}">%{author_name} %{author_nickname}</a>tarafından oluşturuldu.
+          email_intro: "%{author_name} %{author_nickname}, who you are following, has created a new initiative, check it out and contribute:"
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: New initiative by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         endorse_initiative_event:
-          email_intro: "Takip ettiğiniz %{author_name} %{author_nickname}, aşağıdaki girişimi onaylamıştır, belki de sohbete katkıda bulunmak istersiniz:"
-          email_outro: Bu bildirimi, %{author_nickname}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: Giriş tarafından onaylanan %{author_nickname}
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> girişimi <a href="%{author_path}">%{author_name} %{author_nickname}</a>tarafından onaylandı.
+          email_intro: "%{author_name} %{author_nickname}, who you are following, has endorsed the following initiative, maybe you want to contribute to the conversation:"
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: Initiative endorsed by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was endorsed by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
       index:
-        title: Girişimler
+        title: Initiatives
       initiative_votes:
         create:
-          error: Girişimi imzalarken hatalar oldu.
+          error: There's been errors when signing the initiative.
       initiatives:
         author:
-          deleted: silindi
+          deleted: Deleted
         author_list:
           hidden_authors_count:
-            one: ve 1 kişi daha
-            other: ve %{count} kişi daha
+            one: and 1 more person
+            other: and %{count} more people
         count:
           title:
-            one: "%{count} girişim"
-            other: "%{count} girişim"
+            one: "%{count} initiative"
+            other: "%{count} initiatives"
         filters:
-          any: herhangi
-          author: Yazar
-          closed: Kapalı
-          myself: Benim girişimlerim
-          open: Açık
-          search: Arama
-          state: Belirtmek, bildirmek
-          type: tip
-          type_prompt: Bir tip seçin
+          any: Any
+          author: Author
+          closed: Closed
+          myself: My initiatives
+          open: Open
+          search: Search
+          state: State
+          type: Type
+          type_prompt: Select a type
         filters_small_view:
-          close_modal: Pencereyi kapat
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close window
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         index_header:
-          new_initiative: Yeni girişim
+          new_initiative: New initiative
         orders:
-          label: 'Girişimleri şuna göre sırala:'
-          most_commented: En çok yorum yapılan
-          most_voted: En imzalanmış
-          random: rasgele
-          recent: En yeni
+          label: 'Sort initiatives by:'
+          most_commented: Most commented
+          most_voted: Most signed
+          random: Random
+          recent: Most recent
         result:
-          initiative_accepted_reason: Bu girişim kabul edildi çünkü
-          initiative_rejected_reason: Bu girişim destek eksikliğinden dolayı reddedildi.
+          initiative_accepted_reason: This initiative has been accepted because
+          initiative_rejected_reason: This initiative has been rejected due to its lack of supports.
         show:
-          any_vote_method: Bu vatandaş girişimi, yüz yüze olduğu kadar çevrimiçi destek toplar.
-          offline_method: Bu vatandaş girişimi sadece yüz yüze destekleri toplar.
+          any_vote_method: This citizen initiative collects online support as well as face to face.
+          offline_method: This citizen initiative only collects face to face supports.
         signature_identities:
-          select_identity: Kullanıcı tanımlayıcıyı seç
+          select_identity: Select user identifier
         signatures_count:
-          one: " imza"
-          other: " imzalar"
+          one: " signature"
+          other: " signatures"
         statistics:
-          assistants_count_title: Yardımcıları
-          comments_count_title: Yorumlar
-          meetings_count_title: Toplantılar
-          supports_count_title: İmzalar
+          assistants_count_title: Assistants
+          comments_count_title: Comments
+          meetings_count_title: Meetings
+          supports_count_title: Signatures
         supports:
-          title: İmzaların listesi
+          title: Listing of signatures
         vote_cabin:
-          already_voted: Zaten imzalanmış
-          supports_required: "%{total_supports} imza gerekli"
-          vote: İşaret
-          votes_blocked: İmzalama devre dışı
+          already_voted: Already signed
+          supports_required: "%{total_supports} signatures required"
+          vote: Sign
+          votes_blocked: Signing disabled
         votes_count:
           count:
-            one: İMZA
-            other: İMZALAR
+            one: SIGNATURE
+            other: SIGNATURES
       initiatives_mailer:
-        creation_subject: Vatandaş girişimi '%{title}' oluşturuldu
+        creation_subject: Your citizen initiative '%{title}' has been created
         initiative_link:
-          check_initiative_details: Girişim ayrıntılarını görebilirsiniz
-          here: İşte
-        more_information: Girişim oluşturma süreci hakkında daha fazla bilgiye buradan ulaşabilirsiniz.
-        progress_report_body_for: İnisiyatif %{title} ulaşmıştır %{percentage}gerekli desteklerin%.
-        progress_report_for: 'Girişimle ilgili özgeçmiş: %{title}'
-        promotal_committee_help: Promoter komitesine en az %{member_count} kişiyi davet etmeniz gerektiğini unutmayın. İnsanları destekleyici kuruluna davet etmek için aşağıdaki bağlantıyı yönlendirin
-        status_change_body_for: 'Girişim %{title} şu şekilde değiştirdi: %{state}'
-        status_change_for: Girişim %{title} durumu değişti
-        technical_validation_body_for: Girişimi %{title} teknik doğrulamayı talep etti.
-        technical_validation_for: Girişimi %{title} teknik doğrulamayı talep etti.
+          check_initiative_details: You can see the initiative details
+          here: here
+        more_information: Here you have more information about the initiative creation process.
+        progress_report_body_for: The initiative %{title} has reached the %{percentage}% of required supports.
+        progress_report_for: 'Resume about the initiative: %{title}'
+        promotal_committee_help: Remember that you must invite at least %{member_count} people to promoter committee. Forward the following link to invite people to the promoter committee
+        status_change_body_for: 'The initiative %{title} has changed its state to: %{state}'
+        status_change_for: The initiative %{title} has changed its state
+        technical_validation_body_for: The initiative %{title} has requested its technical validation.
+        technical_validation_for: The initiative %{title} has requested its technical validation.
       last_activity:
-        new_initiative: Yeni girişim
+        new_initiative: New initiative
       pages:
         home:
           highlighted_initiatives:
-            active_initiatives: Aktif girişimler
-            see_all_initiatives: Tüm girişimleri görün
+            active_initiatives: Active initiatives
+            see_all_initiatives: See all initiatives
       states:
-        accepted: Kabul edilmiş
-        expired: Süresi doldu
-      unavailable_scope: Kullanılamayan kapsam
+        accepted: Accepted
+        expired: Expired
+      unavailable_scope: Unavailable scope
     menu:
-      initiatives: Girişimler
+      initiatives: Initiatives
   layouts:
     decidim:
       admin:
         initiative:
-          attachments: Ekler
-          committee_members: Komite üyeleri
-          components: Bileşenler
-          information: Bilgi
+          attachments: Attachments
+          committee_members: Committee members
+          components: Components
+          information: Information
       initiative_creation_header:
-        fill_data: yaratmak
-        finish: Bitiş
-        previous_form: başla
-        promotal_committee: Promoter komitesi
-        select_initiative_type: Seçmek
-        show_similar_initiatives: Karşılaştırmak
-        step: '%{total}adımdan %{current}'
-        title: Yeni girişim oluştur
+        fill_data: Create
+        finish: Finish
+        previous_form: Start
+        promotal_committee: Promoter committee
+        select_initiative_type: Choose
+        show_similar_initiatives: Compare
+        step: Step %{current} of %{total}
+        title: Create new initiative
       initiative_header:
-        initiative_menu_item: girişim
+        initiative_menu_item: Initiative
       initiatives:
         initiative:
-          check: Buna bir bak
-          check_and_support: Kontrol et ve imzala
+          check: Check it out
+          check_and_support: Check it out and sign
         no_initiatives_yet:
-          no_initiatives_yet: Henüz giriş yok!
+          no_initiatives_yet: No initiatives yet!

--- a/decidim-initiatives/config/locales/uk.yml
+++ b/decidim-initiatives/config/locales/uk.yml
@@ -1,3 +1,4 @@
+---
 uk:
   activemodel:
     attributes:
@@ -35,19 +36,19 @@ uk:
   activerecord:
     models:
       decidim/initiative:
-        one: Почин
         few: Почини
         many: Починів
+        one: Почин
         other: Починів
       decidim/initiative_comittee:
-        one: Робочий гурт
         few: Робочих гурти
         many: Робочих гуртів
+        one: Робочий гурт
         other: Робочих гуртів
       decidim/initiative_vote:
-        one: Підпис
         few: Підписи
         many: Підписів
+        one: Підпис
         other: Підписів
   decidim:
     admin:
@@ -60,6 +61,7 @@ uk:
         initiatives:
           fields:
             created_at: 'Створено:'
+            id: ID
             state: Стан
             supports_count: Проявів підтримки
             title: Почини
@@ -85,11 +87,36 @@ uk:
           notification_title: Строк збору підписів на підтримку почину <a href="%{resource_path}">%{resource_title}</a> продовжено.
         milestone_completed:
           affected_user:
+            email_intro: Your initiative %{resource_title} has achieved the %{percentage}% of signatures!
+            email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
             email_subject: Досягнута нова віха!
+            notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+          email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: Nouvelle étape franchie !
           follower:
             email_intro: Почин %{resource_title} досяг %{percentage}% підписів!
+            email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
             email_subject: Досягнута нова віха!
             notification_title: Почин <a href="%{resource_path}">%{resource_title}</a> досяг %{percentage}% підписів.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a atteint %{percentage}% des signatures requises.
+    gamification:
+      badges:
+        initiatives:
+          conditions: '["Go to the participation space of Intiatives", "Follow the steps to create a new initiative"]'
+          description: This badge is granted when you launch new initiatives, partnering with others to carry them out.
+          description_another: This user has gotten %{score} initiatives published.
+          description_own: You've got %{score} initiatives published.
+          name: Published initiatives
+          next_level_in: Get %{score} more initiatives published to reach the next level!
+          unearned_another: This user hasn't gotten any initiatives published yet.
+          unearned_own: You got no initiatives published yet.
+    help:
+      participatory_spaces:
+        initiatives:
+          contextual: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          page: "<p>An initiative is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          title: What are initiatives?
     initiatives:
       admin:
         committee_requests:
@@ -100,6 +127,9 @@ uk:
             no_members_yet: У робочого гурту з просування нема жодного члена
             revoke: Відкликати
             title: Члени робочого гурту
+        content_blocks:
+          highlighted_initiatives:
+            max_results: Maximum amount of elements to show
         initiatives:
           edit:
             accept: Прийняти почин
@@ -244,7 +274,7 @@ uk:
         endorse_initiative_event:
           email_intro: "%{author_name} %{author_nickname}, за яким ви стежите, підтримав наступний почин. Чи не бажаєте ви зробити свій внесок у розмову:"
           email_outro: Ви отримали це сповіщення, тому що ви стежите за %{author_nickname}. Ви можете відписатися від цих сповіщень, перейшовши за наведеним вище посиланням.
-          email_subject: '%{author_nickname} підтримав почин'
+          email_subject: "%{author_nickname} підтримав почин"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> підтримав почин <a href="%{resource_path}">%{resource_title}</a>.
       index:
         title: Почини
@@ -256,15 +286,15 @@ uk:
           deleted: Видалено
         author_list:
           hidden_authors_count:
-            one: і ще 1 особа
             few: і ще %{count} людей
             many: і ще %{count} людей
+            one: і ще 1 особа
             other: і ще %{count} людей
         count:
           title:
-            one: "%{count} почин"
             few: "%{count} почини"
             many: "%{count} починів"
+            one: "%{count} почин"
             other: "%{count} починів"
         filters:
           any: Будь-які
@@ -298,9 +328,9 @@ uk:
         signature_identities:
           select_identity: Виберіть псевдонім учасника
         signatures_count:
-          one: " підпис"
           few: " підписи"
           many: " підписів"
+          one: " підпис"
           other: " підписів"
         statistics:
           assistants_count_title: Помічників
@@ -311,14 +341,14 @@ uk:
           title: Перелік підписів
         vote_cabin:
           already_voted: Вже підписалися
-          supports_required: "Необхідно %{total_supports} підписів"
+          supports_required: Необхідно %{total_supports} підписів
           vote: Підписати
           votes_blocked: Підписування вимкнене
         votes_count:
           count:
-            one: ПІДПИС
             few: ПІДПИСИ
             many: ПІДПИСІВ
+            one: ПІДПИС
             other: ПІДПИСІВ
       initiatives_mailer:
         creation_subject: Ваш громадський почин "%{title}" був доданий
@@ -333,6 +363,8 @@ uk:
         status_change_for: Стан почину %{title} змінився
         technical_validation_body_for: Почин %{title} подав запит на технічну перевірку.
         technical_validation_for: Почин %{title} подав запит на технічну перевірку.
+      last_activity:
+        new_initiative: New initiative
       pages:
         home:
           highlighted_initiatives:
@@ -341,6 +373,7 @@ uk:
       states:
         accepted: Прийняті
         expired: Строк дії яких закінчився
+      unavailable_scope: Unavailable scope
     menu:
       initiatives: Почини
   layouts:
@@ -358,6 +391,8 @@ uk:
         promotal_committee: Робочий гурт з просування
         select_initiative_type: Обрати
         show_similar_initiatives: Порівняти
+        step: Step %{current} of %{total}
+        title: Create new initiative
       initiative_header:
         initiative_menu_item: Почин
       initiatives:

--- a/decidim-meetings/config/locales/ca.yml
+++ b/decidim-meetings/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ ca:
             email_outro: Has rebut aquesta notificació perquè has organitzat la trobada "%{resource_title}".
             email_subject: S'ha tancat la trobada "%{resource_title}"
             notification_title: La trobada de <a href="%{resource_path}">%{resource_title}</a> s'ha tancat.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'La trobada de "%{resource_title}" ha estat tancada. Pots llegir les conclusions a la seva pàgina:'
             email_outro: Has rebut aquesta notificació perquè estàs seguint la trobada "%{resource_title}". Pots deixar de seguir-la des de l'enllaç anterior.
             email_subject: S'ha tancat la trobada "%{resource_title}"
             notification_title: La trobada de <a href="%{resource_path}">%{resource_title}</a> s'ha tancat.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: S'ha afegit la trobada "%{resource_title}" a l'espai "%{participatory_space_title}" que estàs seguint.
           email_outro: Has rebut aquesta notificació perquè estàs seguint "%{participatory_space_title}". Pots deixar de seguir-lo des de l'enllaç anterior.
@@ -136,7 +141,7 @@ ca:
       badges:
         attended_meetings:
           conditions:
-            - Inscriu-te a les reunions que vulguis assistir
+          - Inscriu-te a les reunions que vulguis assistir
           description: Aquest distintiu s'aconsegueix assistint a diverses reunions presencials.
           description_another: Aquest usuari ha assistit a %{score} trobades.
           description_own: Has assistit a %{score} trobades.

--- a/decidim-meetings/config/locales/de.yml
+++ b/decidim-meetings/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie die Besprechung "%{resource_title}" organisiert haben.
             email_subject: Das "%{resource_title}" Meeting wurde geschlossen
             notification_title: Das <a href="%{resource_path}">%{resource_title}</a> Treffen wurde geschlossen.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Das "%{resource_title}" Meeting wurde geschlossen. Sie können die Schlussfolgerungen von seiner Seite lesen:'
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie die Besprechung "%{resource_title}" verfolgen. Sie können es aus dem vorherigen Link aufheben.
             email_subject: Das "%{resource_title}" Meeting wurde geschlossen
             notification_title: Das <a href="%{resource_path}">%{resource_title}</a> Treffen wurde geschlossen.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Das Meeting "%{resource_title}" wurde zu "%{participatory_space_title}" hinzugefügt, dem Sie folgen.
           email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie "%{participatory_space_title}" folgen. Sie können es aus dem vorherigen Link aufheben.
@@ -136,7 +141,7 @@ de:
       badges:
         attended_meetings:
           conditions:
-            - Registrieren Sie sich in den Meetings, an denen Sie teilnehmen möchten
+          - Registrieren Sie sich in den Meetings, an denen Sie teilnehmen möchten
           description: Dieses Abzeichen wird gewährt, wenn Sie mehrere persönliche Treffen besuchen.
           description_another: Dieser Benutzer hat an %{score} Meetings teilgenommen.
           description_own: Sie haben an %{score} Sitzungen teilgenommen.
@@ -376,7 +381,7 @@ de:
             validation_pending: Validierung ausstehend
           remaining_slots:
             one: "%{count} Slot bleibt übrig"
-            other: "Noch %{count} Slots"
+            other: Noch %{count} Slots
           view: Aussicht
       meetings_map:
         view_meeting: Besprechung anzeigen
@@ -430,6 +435,7 @@ de:
     participatory_spaces:
       highlighted_meetings:
         past_meetings: Vergangene Treffen
+        see_all: See all (%{count})
         upcoming_meetings: Bevorstehende Treffen
       upcoming_meeting_for_card:
         upcoming_meeting: Kommendes Treffen

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -96,11 +96,15 @@ en:
             email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
             email_subject: The "%{resource_title}" meeting was closed
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
             email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
             email_subject: The "%{resource_title}" meeting was closed
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.

--- a/decidim-meetings/config/locales/es-PY.yml
+++ b/decidim-meetings/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ es-PY:
             email_outro: Ha recibido esta notificación porque organizó la reunión "%{resource_title}".
             email_subject: Se ha cerrado el encuentro "%{resource_title}"
             notification_title: El encuentro <a href="%{resource_path}">%{resource_title}</a> ha sido cerrada.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Se ha cerrado la reunión "%{resource_title}". Puedes leer las conclusiones en su página:'
             email_outro: Ha recibido esta notificación porque está siguiendo la reunión "%{resource_title}". Puedes dejar de seguirlo desde el enlace anterior.
             email_subject: Se ha cerrado el encuentro "%{resource_title}"
             notification_title: El encuentro <a href="%{resource_path}">%{resource_title}</a> ha sido cerrada.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Se ha añadido el encuentro "%{resource_title}" al espacio "%{participatory_space_title}" que estás siguiendo.
           email_outro: Has recibido esta notificación porque sigues "%{participatory_space_title}". Puedes dejar de seguirlo en el enlace anterior.
@@ -136,12 +141,12 @@ es-PY:
       badges:
         attended_meetings:
           conditions:
-            - Regístrate en las reuniones a las que quieres asistir.
+          - Regístrate en las reuniones a las que quieres asistir.
           description: Este distintivo se otorga cuando asiste a varias reuniones cara a cara.
           description_another: Este usuario asistió a %{score} encuentros.
           description_own: Usted ha asistido a %{score} reuniones.
           name: Reuniones asistidas
-          next_level_in: '¡Asiste a %{score} reuniones más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Asiste a %{score} reuniones más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha asistido a ninguna reunión.
           unearned_own: No has asistido a ninguna reunión todavía.
     meetings:
@@ -150,7 +155,7 @@ es-PY:
         attachment_collections: Carpetas
         attachments: Archivos adjuntos
         close: Cerrar
-        confirm_destroy: '¿Está seguro de que quiere eliminar este encuentro?'
+        confirm_destroy: "¿Está seguro de que quiere eliminar este encuentro?"
         destroy: Borrar
         edit: Editar
         minutes: Acta
@@ -375,7 +380,7 @@ es-PY:
             validated: Validado
             validation_pending: VALIDACIÓN PENDIENTE
           remaining_slots:
-            one: "Queda %{count} ranuras"
+            one: Queda %{count} ranuras
             other: "%{count} ranuras restantes"
           view: Ver
       meetings_map:

--- a/decidim-meetings/config/locales/es.yml
+++ b/decidim-meetings/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ es:
             email_outro: Has recibido esta notificación porque organizaste el encuentro "%{resource_title}".
             email_subject: Se ha cerrado el encuentro "%{resource_title}"
             notification_title: El encuentro <a href="%{resource_path}">%{resource_title}</a> ha sido cerrada.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Se ha cerrado la reunión "%{resource_title}". Puedes leer las conclusiones en su página:'
             email_outro: Has recibido esta notificación porque estás siguiendo el encuentro "%{resource_title}". Puedes dejar de seguirlo desde el enlace anterior.
             email_subject: Se ha cerrado el encuentro "%{resource_title}"
             notification_title: El encuentro <a href="%{resource_path}">%{resource_title}</a> ha sido cerrada.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Se ha añadido el encuentro "%{resource_title}" al espacio "%{participatory_space_title}" que estás siguiendo.
           email_outro: Has recibido esta notificación porque sigues "%{participatory_space_title}". Puedes dejar de seguirlo en el enlace anterior.
@@ -136,12 +141,12 @@ es:
       badges:
         attended_meetings:
           conditions:
-            - Regístrate en los encuentros a los que quieres asistir
+          - Regístrate en los encuentros a los que quieres asistir
           description: Este distintivo se otorga cuando asistas a varias reuniones presenciales.
           description_another: Este usuario asistió a %{score} encuentros.
           description_own: Has asistido a %{score} encuentros.
           name: Encuentros a los que has asistido
-          next_level_in: '¡Asiste a %{score} encuentros más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Asiste a %{score} encuentros más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha asistido a ningún encunetro.
           unearned_own: No has asistido a ningún encuentro todavía.
     meetings:
@@ -150,7 +155,7 @@ es:
         attachment_collections: Carpetas
         attachments: Archivos adjuntos
         close: Cerrar
-        confirm_destroy: '¿Está seguro de que quiere eliminar este encuentro?'
+        confirm_destroy: "¿Está seguro de que quiere eliminar este encuentro?"
         destroy: Borrar
         edit: Editar
         minutes: Acta
@@ -375,7 +380,7 @@ es:
             validated: VALIDADO
             validation_pending: VALIDACIÓN PENDIENTE
           remaining_slots:
-            one: "Queda %{count} plaza"
+            one: Queda %{count} plaza
             other: "%{count} plazas restantes"
           view: Ver
       meetings_map:

--- a/decidim-meetings/config/locales/eu.yml
+++ b/decidim-meetings/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ eu:
             email_outro: Jakinarazpen hori jaso duzu "%{resource_title}" bilera antolatu duzulako.
             email_subject: '"%{resource_title}" bilera itxita zegoen'
             notification_title: <a href="%{resource_path}">%{resource_title}</a> bilera itxita zegoen.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: '"%{resource_title}" bilera itxita zegoen. Bere orriko ondorioak irakur ditzakezu:'
             email_outro: Jakinarazpen hau jaso duzu "%{resource_title}" bilera jarraitzen ari zarelako. Aurreko esteka estekan jarrai dezakezu.
             email_subject: '"%{resource_title}" bilera itxita zegoen'
             notification_title: <a href="%{resource_path}">%{resource_title}</a> bilera itxita zegoen.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Bilera "%{resource_title}" | gehitu da "%{participatory_space_title}" " jarraitzen ari zarela.
           email_outro: Jakinarazpena jaso duzu "%{participatory_space_title}" jarraitzen ari zarenagatik. Aurreko esteka estekan jarrai dezakezu.
@@ -136,12 +141,12 @@ eu:
       badges:
         attended_meetings:
           conditions:
-            - Parte hartu nahi duzun bileretan izena eman
+          - Parte hartu nahi duzun bileretan izena eman
           description: Idazmahaia hainbat aurpegi bileretara joaten zarenean ematen da.
           description_another: Erabiltzaile honek %{score} bileratan parte hartu du.
-          description_own: '%{score} bileretan parte hartu duzu.'
+          description_own: "%{score} bileretan parte hartu duzu."
           name: Bilera parte hartzera
-          next_level_in: '%{score} topaketa gehiago parte hartzeko hurrengo mailara iristeko!'
+          next_level_in: "%{score} topaketa gehiago parte hartzeko hurrengo mailara iristeko!"
           unearned_another: Erabiltzaile honek oraindik ez du topaketarik izan.
           unearned_own: Oraindik ez duzu bilerarako parte hartu.
     meetings:
@@ -285,7 +290,7 @@ eu:
               one: Dena den, %{count} erregistratzeko.
               other: Dena den, %{count} matrikulazioak.
             reserved_slots_help: Utzi 0 aukerarik ez baduzu erreserbatutako slotarik
-            reserved_slots_less_than: '%{count} baino gutxiago izan behar du'
+            reserved_slots_less_than: "%{count} baino gutxiago izan behar du"
           update:
             invalid: Arazo bat izan da izen-ematearen konfigurazioa gordetzean.
             success: Topaketen izen-emateen konfigurazioak zuzen gorde dira.

--- a/decidim-meetings/config/locales/fi-pl.yml
+++ b/decidim-meetings/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ fi-pl:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet järjestänyt tapahtuman "%{resource_title}".
             email_subject: Tapahtuma "%{resource_title}" suljettiin
             notification_title: Tapahtuma <a href="%{resource_path}">%{resource_title}</a> suljettiin.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Tapahtuma "%{resource_title}" suljettiin. Voit lukea johtopäätökset sen sivulta:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat tapahtumaa "%{resource_title}". Voit lopettaa seuraamisen edellä esitetyn linkin kautta.
             email_subject: Tapahtuma "%{resource_title}" suljettiin
             notification_title: Tapahtuma <a href="%{resource_path}">%{resource_title}</a> suljettiin.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Tapahtuma "%{resource_title}" on lisätty seuraamaasi kohteeseen "%{participatory_space_title}".
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta "%{participatory_space_title}". Voit lopettaa seuraamisen edellä esitetyn linkin kautta.
@@ -136,7 +141,7 @@ fi-pl:
       badges:
         attended_meetings:
           conditions:
-            - Ilmoittaudu tapahtumiin, joihin haluat osallistua
+          - Ilmoittaudu tapahtumiin, joihin haluat osallistua
           description: Tämä kunniamerkki myönnetään, kun osallistut useisiin tapahtumiin.
           description_another: Tämä käyttäjä on osallistunut %{score} tapahtumaan.
           description_own: Olet osallistunut %{score} tapahtumaan.

--- a/decidim-meetings/config/locales/fi.yml
+++ b/decidim-meetings/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ fi:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet järjestänyt tapahtuman "%{resource_title}".
             email_subject: Tapahtuma "%{resource_title}" suljettiin
             notification_title: Tapahtuma <a href="%{resource_path}">%{resource_title}</a> suljettiin.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Tapahtuma "%{resource_title}" suljettiin. Voit lukea johtopäätökset sen sivulta:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat tapahtumaa "%{resource_title}". Voit lopettaa seuraamisen edellä esitetyn linkin kautta.
             email_subject: Tapahtuma "%{resource_title}" suljettiin
             notification_title: Tapahtuma <a href="%{resource_path}">%{resource_title}</a> suljettiin.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Tapahtuma "%{resource_title}" on lisätty seuraamaasi kohteeseen "%{participatory_space_title}".
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat kohdetta "%{participatory_space_title}". Voit lopettaa seuraamisen edellä esitetyn linkin kautta.
@@ -136,7 +141,7 @@ fi:
       badges:
         attended_meetings:
           conditions:
-            - Ilmoittaudu tapahtumiin, joihin haluat osallistua
+          - Ilmoittaudu tapahtumiin, joihin haluat osallistua
           description: Tämä kunniamerkki myönnetään, kun osallistut useisiin tapahtumiin.
           description_another: Tämä käyttäjä on osallistunut %{score} tapahtumaan.
           description_own: Olet osallistunut %{score} tapahtumaan.

--- a/decidim-meetings/config/locales/gl.yml
+++ b/decidim-meetings/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ gl:
             email_outro: Recibiches esta notificación porque organizaches a reunión "%{resource_title}".
             email_subject: A reunión "%{resource_title}" pechouse
             notification_title: A reunión <a href="%{resource_path}">%{resource_title}</a> foi pechada.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'A reunión "%{resource_title}" pechouse. Podes ler as conclusións da súa páxina:'
             email_outro: Recibiches esta notificación porque estás seguindo a reunión "%{resource_title}". Podes deixar de seguir desde a ligazón anterior.
             email_subject: A reunión "%{resource_title}" pechouse
             notification_title: A reunión <a href="%{resource_path}">%{resource_title}</a> foi pechada.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: A reunión "%{resource_title}" Engadiuse a "%{participatory_space_title}" que estás seguindo.
           email_outro: Recibiches esta notificación porque estás seguindo "%{participatory_space_title}". Podes deixar de seguir desde a ligazón anterior.
@@ -136,7 +141,7 @@ gl:
       badges:
         attended_meetings:
           conditions:
-            - Rexístrese nas reunións que desexa asistir
+          - Rexístrese nas reunións que desexa asistir
           description: Este distintivo é concedido cando asistes a varias reunións cara a cara.
           description_another: Este usuario asistiu a %{score} reunións.
           description_own: Atendeu %{score} reunións.

--- a/decidim-meetings/config/locales/hu.yml
+++ b/decidim-meetings/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ hu:
             email_outro: Ezt az értesítést megkapta, mert szervezte a "%{resource_title}" találkozót.
             email_subject: A(z) "%{resource_title}" ülés lezárult
             notification_title: A(z) <a href="%{resource_path}">%{resource_title}</a> ülés lezárult.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'A(z) "%{resource_title}" ülés lezárult. A következtetéseket ezen az oldalod olvashatod el:'
             email_outro: Ezt az értesítést azért kapta, mert a "%{resource_title}" találkozót követi. Leiratkozhat az előző linkről.
             email_subject: A(z) "%{resource_title}" ülés lezárult
             notification_title: A(z) <a href="%{resource_path}">%{resource_title}</a> ülés lezárult.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: 'A(z) "%{resource_title}" találkozót hozzáadtuk ehhez: "%{participatory_space_title}" (követed).'
           email_outro: 'Ezt az értesítést azért kaptad, mert ezt követed: "%{participatory_space_title}". Leiratkozás az előző link segítségével.'
@@ -136,10 +141,10 @@ hu:
       badges:
         attended_meetings:
           conditions:
-            - Regisztráljon a résztvevő találkozókon
+          - Regisztráljon a résztvevő találkozókon
           description: Ezt a jelvényt akkor kapja meg, ha több személyes találkozót szervez.
           description_another: Ez a felhasználó %{score} találkozón vett részt.
-          description_own: '%{score} találkozóra vett részt.'
+          description_own: "%{score} találkozóra vett részt."
           name: Részt vett az üléseken
           next_level_in: Vegyen részt %{score} további ülések, hogy elérjük a következő szintre!
           unearned_another: Ez a felhasználó még nem vett részt semmilyen találkozón.
@@ -282,8 +287,8 @@ hu:
             invites: Meghívottak
             registration_form: Regisztrációs űrlap
             registrations_count:
-              one: '%{count} regisztráció volt.'
-              other: '%{count} regisztráció volt.'
+              one: "%{count} regisztráció volt."
+              other: "%{count} regisztráció volt."
             reserved_slots_help: Hagyd "0" értéken, ha nincsenek foglalt helyek
             reserved_slots_less_than: 'Legalább ennyinek kell lennie: %{count}'
           update:

--- a/decidim-meetings/config/locales/id-ID.yml
+++ b/decidim-meetings/config/locales/id-ID.yml
@@ -1,442 +1,451 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       agenda:
-        description: Deskripsi
-        duration: Lamanya
-        title: Judul
+        description: Description
+        duration: Duration
+        title: Title
       close_meeting:
-        attendees_count: Jumlah peserta
-        attending_organizations: Daftar organisasi yang hadir
-        closing_report: Melaporkan
-        contributions_count: Jumlah kontribusi
-        proposal_ids: Proposal yang dibuat dalam pertemuan
+        attendees_count: Number of attendees
+        attending_organizations: List of organizations that attended
+        closing_report: Report
+        contributions_count: Number of contributions
+        proposal_ids: Proposals created in the meeting
       meeting:
-        address: Alamat
-        available_slots: Slot yang tersedia untuk rapat ini
-        decidim_category_id: Kategori
-        decidim_scope_id: Cakupan
-        description: Deskripsi
-        end_time: Akhir waktu
-        location: Lokasi
-        location_hints: Petunjuk lokasi
-        organizer_id: Penyelenggara
-        private_meeting: Pertemuan pribadi
-        registration_form_enabled: Formulir pendaftaran diaktifkan
-        registration_terms: Ketentuan pendaftaran
-        registrations_enabled: Pendaftaran diaktifkan
-        start_time: Waktu mulai
-        title: Judul
-        transparent: Transparan
+        address: Address
+        available_slots: Available slots for this meeting
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        end_time: End Time
+        location: Location
+        location_hints: Location hints
+        organizer_id: Organizer
+        private_meeting: Private meeting
+        registration_form_enabled: Registration form enabled
+        registration_terms: Registration terms
+        registrations_enabled: Registrations enabled
+        start_time: Start Time
+        title: Title
+        transparent: Transparent
       minutes:
-        audio_url: Url audio
-        description: Deskripsi
-        video_url: Url video
-        visible: Terlihat
+        audio_url: Audio url
+        description: Description
+        video_url: Video url
+        visible: Is visible
     errors:
       models:
         meeting_agenda:
           attributes:
             base:
-              too_many_minutes: Durasi barang melebihi durasi rapat dengan %{count} menit
-              too_many_minutes_child: Durasi item anak melebihi item agenda "%{parent_title}" durasi induk %{count} menit
+              too_many_minutes: The duration of the items exceed the meeting duration by %{count} minutes
+              too_many_minutes_child: The duration of the item childs exceed the agenda item "%{parent_title}" parent duration by %{count} minutes
         meeting_registration_invite:
           attributes:
             email:
-              already_invited: Email ini sudah diundang
+              already_invited: This email has already been invited
     models:
-      decidim/meetings/close_meeting_event: Pertemuan tertutup
-      decidim/meetings/create_meeting_event: Pertemuan
-      decidim/meetings/meeting_registrations_enabled_event: Pendaftaran diaktifkan
-      decidim/meetings/meeting_registrations_over_percentage_event: Pendaftaran melebihi batas
-      decidim/meetings/upcoming_meeting_event: Pertemuan yang akan datang
-      decidim/meetings/update_meeting_event: Rapat diperbarui
+      decidim/meetings/close_meeting_event: Meeting closed
+      decidim/meetings/create_meeting_event: Meeting
+      decidim/meetings/meeting_registrations_enabled_event: Registrations enabled
+      decidim/meetings/meeting_registrations_over_percentage_event: Registrations over limit
+      decidim/meetings/upcoming_meeting_event: Upcoming meeting
+      decidim/meetings/update_meeting_event: Meeting updated
   activerecord:
     models:
       decidim/meetings/meeting:
-        other: Rapat
+        one: Meeting
+        other: Meetings
       decidim/meetings/minutes:
-        other: Menit
+        one: Minutes
+        other: Minutes
       decidim/meetings/registration:
-        other: Pendaftaran
+        one: Registration
+        other: Registrations
   decidim:
     admin:
       meeting_copies:
         create:
-          error: Terjadi kesalahan saat menduplikasi rapat ini.
-          success: Pertemuan duplikat berhasil.
+          error: There was en error duplicating this meeting.
+          success: Duplicated meeting successfully.
         new:
-          copy: Salinan
-          select: Pilih data mana yang ingin Anda gandakan
-          title: Pertemuan duplikat
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate meeting
     components:
       meetings:
         actions:
-          join: Ikut
-        name: Rapat
+          join: Join
+        name: Meetings
         settings:
           global:
-            announcement: Pengumuman
-            comments_enabled: Komentar diaktifkan
-            default_registration_terms: Ketentuan pendaftaran default
-            enable_pads_creation: Aktifkan pembuatan bantalan
-            resources_permissions_enabled: Izin tindakan dapat diatur untuk setiap pertemuan
+            announcement: Announcement
+            comments_enabled: Comments enabled
+            default_registration_terms: Default registration terms
+            enable_pads_creation: Enable pads creation
+            resources_permissions_enabled: Actions permissions can be set for each meeting
           step:
-            announcement: Pengumuman
-            comments_blocked: Komentar diblokir
+            announcement: Announcement
+            comments_blocked: Comments blocked
     events:
       meetings:
         meeting_closed:
           affected_user:
-            email_intro: 'Rapat Anda "%{resource_title}" ditutup. Anda dapat membaca kesimpulan dari halamannya:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengatur rapat "%{resource_title}".
-            email_subject: Rapat "%{resource_title}" ditutup
-            notification_title: Pertemuan <a href="%{resource_path}">%{resource_title}</a> ditutup.
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
+            email_subject: The "%{resource_title}" meeting was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
-            email_intro: 'Rapat "%{resource_title}" ditutup. Anda dapat membaca kesimpulan dari halamannya:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti rapat "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-            email_subject: Rapat "%{resource_title}" ditutup
-            notification_title: Pertemuan <a href="%{resource_path}">%{resource_title}</a> ditutup.
+            email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+            email_subject: The "%{resource_title}" meeting was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
-          email_intro: Pertemuan "%{resource_title}" telah ditambahkan ke "%{participatory_space_title}" yang Anda ikuti.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{participatory_space_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Pertemuan baru ditambahkan ke %{participatory_space_title}
-          notification_title: Pertemuan <a href="%{resource_path}">%{resource_title}</a> telah ditambahkan ke %{participatory_space_title}
+          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New meeting added to %{participatory_space_title}
+          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         meeting_registration_confirmed:
-          notification_title: Pendaftaran Anda untuk pertemuan <a href="%{resource_url}">%{resource_title}</a> telah dikonfirmasi. Kode registrasi Anda adalah %{registration_code}.
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
-          email_intro: Slot "%{resource_title}" yang ditempati slot lebih dari %{percentage}%.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah admin ruang partisipatif rapat.
-          email_subject: Slot "%{resource_title}" yang ditempati slot lebih dari %{percentage}%
-          notification_title: Slot pertemuan <a href="%{resource_path}">%{resource_title}</a> diduduki lebih dari %{percentage}%.
+          email_intro: The "%{resource_title}" meeting occupied slots are over %{percentage}%.
+          email_outro: You have received this notification because you are an admin of the meeting's participatory space.
+          email_subject: The "%{resource_title}" meeting occupied slots are over %{percentage}%
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting occupied slots are over %{percentage}%.
         meeting_updated:
-          email_intro: 'Rapat "%{resource_title}" telah diperbarui. Anda dapat membaca versi baru dari halamannya:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti rapat "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Rapat "%{resource_title}" telah diperbarui
-          notification_title: Rapat <a href="%{resource_path}">%{resource_title}</a> telah diperbarui.
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
         registration_code_validated:
-          email_intro: Kode registrasi Anda "%{registration_code}" untuk rapat "%{resource_title}" telah divalidasi.
-          email_outro: Anda telah menerima pemberitahuan ini karena kode pendaftaran Anda untuk rapat "%{resource_title}" telah divalidasi.
-          email_subject: Kode registrasi Anda "%{registration_code}" untuk rapat "%{resource_title}" telah divalidasi
-          notification_title: Kode registrasi Anda "%{registration_code}" untuk pertemuan <a href="%{resource_path}">%{resource_title}</a> telah divalidasi.
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
+          email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
+          notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
         registrations_enabled:
-          email_intro: 'Rapat "%{resource_title}" telah memungkinkan pendaftaran. Anda dapat mendaftarkan diri Anda di halamannya:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti rapat "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Rapat "%{resource_title}" telah memungkinkan pendaftaran.
-          notification_title: Pertemuan <a href="%{resource_path}">%{resource_title}</a> telah memungkinkan pendaftaran.
+          email_intro: 'The "%{resource_title}" meeting has enabled registrations. You can register yourself on its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting has enabled registrations.
         upcoming_meeting:
-          email_intro: Pertemuan "%{resource_title}" akan dimulai dalam waktu kurang dari 48 jam.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti rapat "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Pertemuan "%{resource_title}" akan dimulai dalam waktu kurang dari 48 jam.
-          notification_title: Pertemuan <a href="%{resource_path}">%{resource_title}</a> akan dimulai dalam waktu kurang dari 48 jam.
+          email_intro: The "%{resource_title}" meeting will start in less than 48h.
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting will start in less than 48h.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
     gamification:
       badges:
         attended_meetings:
-          conditions:
-            - Daftarkan dalam pertemuan yang ingin Anda hadiri
-          description: Lencana ini diberikan ketika Anda menghadiri beberapa pertemuan tatap muka.
-          description_another: Pengguna ini telah menghadiri %{score} rapat.
-          description_own: Anda telah menghadiri %{score} pertemuan.
-          name: Menghadiri pertemuan
-          next_level_in: Hadiri %{score} pertemuan lagi untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum menghadiri rapat apa pun.
-          unearned_own: Anda belum menghadiri rapat apa pun.
+          conditions: '["Register in the meetings you want to attend"]'
+          description: This badge is granted when you attend several face-to-face meetings.
+          description_another: This user has attended %{score} meetings.
+          description_own: You have attended %{score} meetings.
+          name: Attended meetings
+          next_level_in: Attend %{score} more meetings to reach the next level!
+          unearned_another: This user hasn't attended any meeting yet.
+          unearned_own: You haven't attended any meeting yet.
     meetings:
       actions:
-        agenda: Jadwal acara
-        attachment_collections: Folder
-        attachments: Lampiran
-        close: Dekat
-        confirm_destroy: Anda yakin ingin menghapus rapat ini?
-        destroy: Menghapus
+        agenda: Agenda
+        attachment_collections: Folders
+        attachments: Attachments
+        close: Close
+        confirm_destroy: Are you sure you want to delete this meeting?
+        destroy: Delete
         edit: Edit
-        minutes: Menit
-        new: Pertemuan baru
+        minutes: Minutes
+        new: New meeting
         preview: Preview
-        registrations: Pendaftaran
-        title: Tindakan
+        registrations: Registrations
+        title: Actions
       admin:
         agenda:
           agenda_item:
-            add_agenda_item_child: Tambahkan anak item agenda
-            agenda_item: Item Agenda
-            agenda_item_children: Item Agenda Anak-anak
-            down: Turun
-            remove: Menghapus
-            up: Naik
+            add_agenda_item_child: Add agenda item child
+            agenda_item: Agenda Item
+            agenda_item_children: Agenda Item Childs
+            down: Down
+            remove: Remove
+            up: Up
           agenda_item_child:
-            agenda_item_child: Item Agenda Anak
-            down: Turun
-            remove: Menghapus
-            up: Naik
+            agenda_item_child: Agenda Item Child
+            down: Down
+            remove: Remove
+            up: Up
           create:
-            invalid: Ada masalah saat membuat agenda ini
-            success: Agenda berhasil dibuat
+            invalid: There's been a problem creating this agenda
+            success: Agenda successfully created
           edit:
             title: Edit agenda
-            update: Memperbarui
+            update: Update
           form:
-            add_agenda_item: Tambahkan item agenda
-            agenda_items: Item agenda
-            end_date: Tanggal akhir
-            start_date: Mulai tanggal
+            add_agenda_item: Add agenda item
+            agenda_items: Agenda items
+            end_date: End date
+            start_date: Start date
           new:
-            create: Membuat
-            title: Agenda baru
+            create: Create
+            title: New agenda
           update:
-            invalid: Terjadi masalah saat memperbarui agenda ini
-            success: Agenda berhasil diperbarui
+            invalid: There's been a problem updating this agenda
+            success: Agenda successfully updated
         exports:
-          meetings: Rapat
-          registrations: Pendaftaran
+          meetings: Meetings
+          registrations: Registrations
         invite_join_meeting_mailer:
           invite:
-            decline: Tolak undangan
-            invited_you_to_join_a_meeting: "%{invited_by} telah mengundang Anda untuk bergabung dalam rapat di %{application}. Anda dapat menolak atau menerimanya melalui tautan di bawah ini."
-            join: Bergabunglah dengan rapat '%{meeting_title}'
+            decline: Decline invitation
+            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join a meeting at %{application}. You can decline or accept it through the links below."
+            join: Join meeting '%{meeting_title}'
         invites:
           create:
-            error: Ada masalah saat mengundang pengguna untuk bergabung dengan rapat.
-            success: Pengguna berhasil diundang untuk bergabung dengan rapat.
+            error: There's been a problem while inviting the user to join the meeting.
+            success: User successfully invited to join the meeting.
           form:
-            attendee_type: Tipe penerima tamu
-            existing_user: Pengguna yang sudah ada
-            invite: Undang
-            invite_explanation: Pengguna akan diundang untuk bergabung dengan rapat dan ke organisasi juga.
-            non_user: Pengguna tidak ada
-            select_user: Pilih pengguna
+            attendee_type: Attendee type
+            existing_user: Existing user
+            invite: Invite
+            invite_explanation: The user will be invited to join the meeting and to the organization as well.
+            non_user: Non existing user
+            select_user: Select user
           index:
             filter:
-              accepted: Diterima
-              all: Semua
-              rejected: Ditolak
-              sent: Terkirim
-            filter_by: Filter berdasarkan
-            invite_attendee: Undang hadirin
-            invites: Undangan
-            registrations_disabled: Anda tidak dapat mengundang peserta karena pendaftaran dinonaktifkan.
-            search: Pencarian
+              accepted: Accepted
+              all: All
+              rejected: Rejected
+              sent: Sent
+            filter_by: Filter by
+            invite_attendee: Invite attendee
+            invites: Invites
+            registrations_disabled: You can't invite an attendee because the registrations are disabled.
+            search: Search
         meeting_closes:
           edit:
-            close: Dekat
-            title: Tutup rapat
+            close: Close
+            title: Close meeting
         meeting_copies:
           form:
-            select_organizer: Pilih penyelenggara
+            select_organizer: Select the organizer
         meetings:
           close:
-            invalid: Terjadi masalah saat menutup rapat ini
-            success: Rapat berhasil ditutup
+            invalid: There's been a problem closing this meeting
+            success: Meeting successfully closed
           create:
-            invalid: Ada masalah saat membuat rapat ini
-            success: Pertemuan berhasil dibuat
+            invalid: There's been a problem creating this meeting
+            success: Meeting successfully created
           destroy:
-            success: Rapat berhasil dihapus
+            success: Meeting successfully deleted
           edit:
-            update: Memperbarui
+            update: Update
           form:
-            select_organizer: Pilih penyelenggara
+            select_organizer: Select the organizer
           index:
-            title: Rapat
+            title: Meetings
           new:
-            create: Membuat
-            title: Buat pertemuan
+            create: Create
+            title: Create meeting
           service:
-            description: Deskripsi
-            down: Turun
-            remove: Menghapus
-            service: Layanan
-            title: Judul
-            up: Naik
+            description: Description
+            down: Down
+            remove: Remove
+            service: Service
+            title: Title
+            up: Up
           services:
-            add_service: Tambahkan layanan
-            services: Jasa
+            add_service: Add service
+            services: Services
           update:
-            invalid: Terjadi masalah saat memperbarui rapat ini
-            success: Rapat berhasil diperbarui
+            invalid: There's been a problem updating this meeting
+            success: Meeting successfully updated
         minutes:
           create:
-            invalid: Terjadi masalah saat membuat menit ini
-            success: Menit berhasil dibuat
+            invalid: There's been a problem creating this minutes
+            success: Minutes successfully created
           edit:
-            update: Memperbarui
+            update: Update
           new:
-            create: Membuat
-            title: Buat menit
+            create: Create
+            title: Create minutes
           update:
-            invalid: Terjadi masalah saat memperbarui menit ini
-            success: Notulen berhasil diperbarui
+            invalid: There's been a problem updating this minutes
+            success: Minutes successfully updated
         models:
           meeting:
-            name: Pertemuan
+            name: Meeting
         registrations:
           edit:
-            save: Menyimpan
-            validate: Mengesahkan
-            validate_registration_code: Validasikan kode registrasi
+            save: Save
+            validate: Validate
+            validate_registration_code: Validate registration code
           form:
-            available_slots_help: Biarkan hingga 0 jika Anda memiliki slot tidak terbatas.
-            invites: Undangan
-            registration_form: Formulir pendaftaran
+            available_slots_help: Leave it to 0 if you have unlimited slots available.
+            invites: Invites
+            registration_form: Registration form
             registrations_count:
-              other: Ada %{count} pendaftaran.
-            reserved_slots_help: Biarkan hingga 0 jika Anda tidak memiliki slot yang dipesan
-            reserved_slots_less_than: Harus kurang dari atau sama dengan %{count}
+              one: There has been %{count} registration.
+              other: There has been %{count} registrations.
+            reserved_slots_help: Leave it to 0 if you don't have reserved slots
+            reserved_slots_less_than: Must be less than or equal to %{count}
           update:
-            invalid: Terjadi masalah saat menyimpan pengaturan pendaftaran.
-            success: Pengaturan pendaftaran rapat berhasil disimpan.
+            invalid: There's been a problem saving the registration settings.
+            success: Meeting registrations settings successfully saved.
           validate_registration_code:
-            invalid: Kode registrasi ini tidak valid.
-            success: Kode registrasi berhasil divalidasi.
+            invalid: This registration code is invalid.
+            success: Registration code successfully validated.
       admin_log:
         invite:
-          create: "%{user_name} diundang %{attendee_name} untuk bergabung dengan %{resource_name} pertemuan di %{space_name} ruang"
-          deleted: "%{user_name} diundang %{attendee_name} dari bergabung dengan %{resource_name} pertemuan di %{space_name} ruang"
-          update: "%{user_name} diundang %{attendee_name} untuk bergabung dengan %{resource_name} pertemuan di %{space_name} ruang"
+          create: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
+          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
         meeting:
-          close: "%{user_name} menutup %{resource_name} pertemuan pada %{space_name} ruang"
-          create: "%{user_name} membuat %{resource_name} pertemuan pada %{space_name} ruang"
-          delete: "%{user_name} menghapus %{resource_name} pertemuan pada %{space_name} ruang"
-          export_registrations: "%{user_name} mengekspor registrasi dari %{resource_name} pertemuan pada %{space_name} ruang"
-          update: "%{user_name} memperbarui %{resource_name} pertemuan pada %{space_name} ruang"
+          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} meeting on the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name} space"
+          export_registrations: "%{user_name} exported the registrations of the %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name} space"
           value_types:
             organizer_presenter:
-              not_found: 'Organiser tidak ditemukan di database (ID: %{id})'
+              not_found: 'The organizer was not found on the database (ID: %{id})'
         minutes:
-          create: "%{user_name} membuat menit dari pertemuan %{resource_name} pada %{space_name} ruang"
-          update: "%{user_name} memperbarui notulen rapat %{resource_name} pada %{space_name} ruang"
+          create: "%{user_name} created the minutes of the meeting %{resource_name} on the %{space_name} space"
+          update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
       calendar_modal:
-        calendar_url: URL Kalender
-        close_window: Tutup jendela
-        export_calendar: Ekspor kalender
-      conference_venues: Tempat Konferensi
+        calendar_url: Calendar URL
+        close_window: Close window
+        export_calendar: Export calendar
+      conference_venues: Conference Venues
       content_blocks:
         upcoming_events:
-          name: Acara Mendatang
-          upcoming_events: Pertemuan yang akan datang
-          view_all_events: Lihat semua
+          name: Upcoming events
+          upcoming_events: Upcoming meetings
+          view_all_events: View all
       directory:
         meetings:
           index:
-            all: Semua
-            date: Tanggal
-            meetings: Rapat
-            past: Lalu
-            search: Pencarian
-            space_type: Ruang partisipatif
-            upcoming: Mendatang
+            all: All
+            date: Date
+            meetings: Meetings
+            past: Past
+            search: Search
+            space_type: Participatory space
+            upcoming: Upcoming
       last_activity:
-        new_meeting_at_html: "<span>Pertemuan baru jam %{link}</span>"
+        new_meeting_at_html: "<span>New meeting at %{link}</span>"
       mailer:
         invite_join_meeting_mailer:
           invite:
-            subject: Undangan untuk bergabung dalam rapat
+            subject: Invitation to join a meeting
         registration_mailer:
           confirmation:
-            subject: Pendaftaran pertemuan Anda telah dikonfirmasi
+            subject: Your meeting's registration has been confirmed
       meeting:
-        not_allowed: Anda tidak diizinkan untuk melihat rapat ini
+        not_allowed: You are not allowed to view this meeting
       meetings:
         filters:
-          category: Kategori
-          category_prompt: Pilih Kategori
-          date: Tanggal
-          past: Lalu
-          search: Pencarian
-          upcoming: Mendatang
+          category: Category
+          category_prompt: Select a category
+          date: Date
+          past: Past
+          search: Search
+          upcoming: Upcoming
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Filter berdasarkan
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         meeting_minutes:
-          meeting_minutes: Risalah Pertemuan
-          related_information: Informasi Terkait
+          meeting_minutes: Meeting Minutes
+          related_information: Related Information
         meetings:
-          no_meetings_warning: Tidak ada pertemuan yang sesuai dengan kriteria pencarian Anda atau tidak ada jadwal pertemuan.
-          upcoming_meetings_warning: Saat ini, tidak ada pertemuan yang dijadwalkan, tetapi di sini Anda dapat menemukan semua pertemuan sebelumnya yang terdaftar.
+          no_meetings_warning: No meetings match your search criteria or there isn't any meeting scheduled.
+          upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.
         registration_confirm:
-          cancel: Membatalkan
-          confirm: Memastikan
+          cancel: Cancel
+          confirm: Confirm
         show:
-          attendees: Jumlah peserta
-          contributions: Kontribusi dihitung
-          going: Pergi
-          join: Bergabunglah dengan rapat
-          meeting_report: Laporan pertemuan
-          no_slots_available: Tidak ada slot yang tersedia
-          organizations: Menghadiri organisasi
-          registration_code_help_text: Kode registrasi Anda
+          attendees: Attendees count
+          contributions: Contributions count
+          going: Going
+          join: Join meeting
+          meeting_report: Meeting report
+          no_slots_available: No slots available
+          organizations: Attending organizations
+          registration_code_help_text: Your registration code
           registration_state:
-            validated: DIvalidasi
-            validation_pending: MENUNGGU VALIDASI
+            validated: VALIDATED
+            validation_pending: VALIDATION PENDING
           remaining_slots:
-            other: "%{count} slot tersisa"
-          view: Melihat
+            one: "%{count} slot remaining"
+            other: "%{count} slots remaining"
+          view: View
       meetings_map:
-        view_meeting: Lihat rapat
+        view_meeting: View meeting
       models:
         invite:
           fields:
-            email: E-mail
-            name: Nama
-            sent_at: Dikirim pada
+            email: Email
+            name: Name
+            sent_at: Sent at
             status: Status
           status:
-            accepted: Diterima (%{at})
-            rejected: Ditolak (%{at})
-            sent: Terkirim
+            accepted: Accepted (%{at})
+            rejected: Rejected (%{at})
+            sent: Sent
         meeting:
           fields:
-            closed: Tutup
-            end_time: Tanggal akhir
-            map: Peta
-            start_time: Mulai tanggal
-            title: Judul
-      read_more: "(Baca lebih lajut)"
+            closed: Closed
+            end_time: End date
+            map: Map
+            start_time: Start date
+            title: Title
+      read_more: "(read more)"
       registration_mailer:
         confirmation:
-          confirmed_html: Pendaftaran Anda untuk pertemuan <a href="%{url}">%{title}</a> telah dikonfirmasi.
-          details: Anda akan menemukan rincian rapat dalam lampiran.
-          registration_code: Kode registrasi Anda adalah %{code}.
+          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a> has been confirmed.
+          details: You will find the meeting's details in the attachment.
+          registration_code: Your registration code is %{code}.
       registrations:
         create:
-          invalid: Ada masalah saat bergabung dengan rapat ini.
-          success: Anda telah berhasil bergabung dengan rapat.
+          invalid: There's been a problem joining this meeting.
+          success: You have joined the meeting successfully.
         decline_invitation:
-          invalid: Terjadi masalah saat menolak undangan.
-          success: Anda berhasil menolak undangan.
+          invalid: There's been a problem declining the invitation.
+          success: You have declined the invitation successfully.
         destroy:
-          invalid: Ada masalah saat meninggalkan rapat ini.
-          success: Anda telah berhasil menyelesaikan rapat.
+          invalid: There's been a problem leaving this meeting.
+          success: You have left the meeting successfully.
       types:
-        private_meeting: Pertemuan pribadi
-        transparent: Transparan
+        private_meeting: Private meeting
+        transparent: Transparent
     metrics:
       meetings:
-        description: Jumlah pertemuan yang dibuat
-        object: pertemuan
-        title: Rapat
+        description: Number of meetings created
+        object: meetings
+        title: Meetings
     participatory_processes:
       participatory_process_groups:
         highlighted_meetings:
-          past_meetings: Pertemuan sebelumnya
-          upcoming_meetings: Pertemuan yang akan datang
+          past_meetings: Past meetings
+          upcoming_meetings: Upcoming meetings
     participatory_spaces:
       highlighted_meetings:
-        past_meetings: Pertemuan sebelumnya
-        see_all: Lihat semua (%{count})
-        upcoming_meetings: Pertemuan yang akan datang
+        past_meetings: Past meetings
+        see_all: See all (%{count})
+        upcoming_meetings: Upcoming meetings
       upcoming_meeting_for_card:
-        upcoming_meeting: Pertemuan yang akan datang
+        upcoming_meeting: Upcoming meeting
     resource_links:
       meetings_through_proposals:
-        meeting_result: 'Hasil terkait:'
-        result_meeting: 'Pertemuan terkait:'
+        meeting_result: 'Related results:'
+        result_meeting: 'Related meetings:'
       proposals_from_meeting:
-        meeting_proposal: 'Proposal terkait:'
-        proposal_meeting: 'Pertemuan terkait:'
+        meeting_proposal: 'Related proposals:'
+        proposal_meeting: 'Related meetings:'
   devise:
     mailer:
       join_meeting:
-        subject: Undangan untuk bergabung dalam rapat
+        subject: Invitation to join a meeting

--- a/decidim-meetings/config/locales/it.yml
+++ b/decidim-meetings/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ it:
             email_outro: Hai ricevuto questa notifica perché hai organizzato la riunione "%{resource_title}".
             email_subject: La riunione "%{resource_title}" è stata chiusa
             notification_title: La riunione <a href="%{resource_path}">%{resource_title}</a> è stata chiusa.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'La riunione "%{resource_title}" è stata chiusa. Puoi leggere le conclusioni dalla sua pagina:'
             email_outro: Hai ricevuto questa notifica perché stai seguendo la riunione "%{resource_title}". Puoi smettere di seguirlo dal link precedente.
             email_subject: La riunione "%{resource_title}" è stata chiusa
             notification_title: La riunione <a href="%{resource_path}">%{resource_title}</a> è stata chiusa.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: L'incontro "%{resource_title}" è stato aggiunto a "%{participatory_space_title}" che stai seguendo.
           email_outro: Hai ricevuto questa notifica perché stai seguendo "%{participatory_space_title}". Puoi smettere di seguirlo dal link precedente.
@@ -136,7 +141,7 @@ it:
       badges:
         attended_meetings:
           conditions:
-            - Registrati negli incontri a cui vuoi partecipare
+          - Registrati negli incontri a cui vuoi partecipare
           description: Questo badge è concesso quando si partecipano a numerosi incontri faccia a faccia.
           description_another: Questo utente ha partecipato a %{score} riunioni.
           description_own: Hai partecipato a %{score} riunioni.

--- a/decidim-meetings/config/locales/nl.yml
+++ b/decidim-meetings/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u de vergadering "%{resource_title}" hebt georganiseerd.
             email_subject: Het event "%{resource_title}" is afgelopen
             notification_title: Het <a href="%{resource_path}">%{resource_title}</a> event is afgelopen.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Het event "%{resource_title}" is afgelopen. Je kan het besluit hier lezen:'
             email_outro: U hebt deze melding ontvangen omdat u de vergadering "%{resource_title}" volgt. Je kunt het niet meer volgen vanaf de vorige link.
             email_subject: Het event "%{resource_title}" is afgelopen
             notification_title: Het <a href="%{resource_path}">%{resource_title}</a> event is afgelopen.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Het event "%{resource_title}" is toegevoegd aan "%{participatory_space_title}" dat je volgt.
           email_outro: Je ontvangt deze melding omdat je "%{participatory_space_title}" volgt. Je kan dit ontvolgen door te klikken op de voorgaande link.
@@ -136,7 +141,7 @@ nl:
       badges:
         attended_meetings:
           conditions:
-            - Registreer u in de vergaderingen die u wilt bijwonen
+          - Registreer u in de vergaderingen die u wilt bijwonen
           description: Deze badge wordt toegekend wanneer u verschillende persoonlijke vergaderingen bijwoont.
           description_another: Deze gebruiker heeft %{score} vergaderingen bijgewoond.
           description_own: U hebt %{score} vergaderingen bijgewoond.

--- a/decidim-meetings/config/locales/pl.yml
+++ b/decidim-meetings/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -54,19 +55,19 @@ pl:
   activerecord:
     models:
       decidim/meetings/meeting:
-        one: Spotkanie
         few: Spotkania
         many: Spotkania
+        one: Spotkanie
         other: Spotkania
       decidim/meetings/minutes:
-        one: Minuty
         few: Minuty
         many: Minuty
+        one: Minuty
         other: Minuty
       decidim/meetings/registration:
-        one: Rejestracja
         few: Rejestracje
         many: Rejestracje
+        one: Rejestracja
         other: Rejestracje
   decidim:
     admin:
@@ -101,11 +102,15 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ zorganizowałeś spotkanie "%{resource_title}".
             email_subject: Spotkanie "%{resource_title}" zostało zamknięte
             notification_title: Spotkanie <a href="%{resource_path}">%{resource_title}</a> zostało zamknięte.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Spotkanie "%{resource_title}" zostało zamknięte. Możesz przeczytać wnioski z jej strony:'
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz spotkanie "%{resource_title}". Możesz przestać go obserwować z poprzedniego linku.
             email_subject: Spotkanie "%{resource_title}" zostało zamknięte
             notification_title: Spotkanie <a href="%{resource_path}">%{resource_title}</a> zostało zamknięte.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Spotkanie "%{resource_title}" został dodany do "%{participatory_space_title}" że podążacie.
           email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz "%{participatory_space_title}". Możesz przestać go obserwować z poprzedniego linku.
@@ -142,7 +147,7 @@ pl:
       badges:
         attended_meetings:
           conditions:
-            - Zarejestruj się na spotkaniach, które chcesz wziąć udział
+          - Zarejestruj się na spotkaniach, które chcesz wziąć udział
           description: Ta odznaka jest przyznawana, gdy bierzesz udział w kilku spotkaniach twarzą w twarz.
           description_another: Ten użytkownik uczestniczył w %{score} spotkaniach.
           description_own: Brałeś udział w %{score} spotkaniach.
@@ -288,9 +293,9 @@ pl:
             invites: Zaprasza
             registration_form: Formularz rejestracyjny
             registrations_count:
-              one: Nie było rejestracji %{count}.
               few: Zarejestrowano %{count} rejestracji.
               many: Zarejestrowano %{count} rejestracji.
+              one: Nie było rejestracji %{count}.
               other: Zarejestrowano %{count} rejestracji.
             reserved_slots_help: Pozostaw to 0, jeśli nie masz zarezerwowanych miejsc
             reserved_slots_less_than: Musi być mniejszy lub równy %{count}
@@ -383,10 +388,10 @@ pl:
             validated: WALIDACJA
             validation_pending: OCZEKUJE WERYFIKACJI
           remaining_slots:
-            one: "Pozostało %{count} szczelin"
-            few: "Pozostało %{count} gniazd"
-            many: "Pozostało %{count} gniazd"
-            other: "Pozostało %{count} gniazd"
+            few: Pozostało %{count} gniazd
+            many: Pozostało %{count} gniazd
+            one: Pozostało %{count} szczelin
+            other: Pozostało %{count} gniazd
           view: Widok
       meetings_map:
         view_meeting: Zobacz spotkanie

--- a/decidim-meetings/config/locales/pt-BR.yml
+++ b/decidim-meetings/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque organizou a reunião "%{resource_title}".
             email_subject: A reunião "%{resource_title}" foi fechada
             notification_title: A reunião <a href="%{resource_path}">%{resource_title}</a> foi fechada.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'A reunião "%{resource_title}" foi encerrada. Você pode ler as conclusões da sua página:'
             email_outro: Você recebeu esta notificação porque está seguindo a reunião "%{resource_title}". Você pode deixar de segui-lo no link anterior.
             email_subject: A reunião "%{resource_title}" foi fechada
             notification_title: A reunião <a href="%{resource_path}">%{resource_title}</a> foi fechada.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: A reunião "%{resource_title}" foi adicionado a "%{participatory_space_title}" que você está seguindo.
           email_outro: Você recebeu esta notificação porque está seguindo "%{participatory_space_title}". Você pode ignorá-lo do link anterior.
@@ -136,7 +141,7 @@ pt-BR:
       badges:
         attended_meetings:
           conditions:
-            - Registre-se nas reuniões que você deseja participar
+          - Registre-se nas reuniões que você deseja participar
           description: Este selo é concedido quando você participa de várias reuniões presenciais.
           description_another: Este usuário assistiu a %{score} reuniões.
           description_own: Você participou de %{score} reuniões.

--- a/decidim-meetings/config/locales/pt.yml
+++ b/decidim-meetings/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ pt:
             email_outro: Você recebeu esta notificação porque organizou a reunião "%{resource_title}".
             email_subject: A reunião "%{resource_title}" foi fechada
             notification_title: A reunião <a href="%{resource_path}">%{resource_title}</a> foi fechada.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'A reunião "%{resource_title}" foi encerrada. Você pode ler as conclusões da sua página:'
             email_outro: Você recebeu esta notificação porque está seguindo a reunião "%{resource_title}". Você pode deixar de segui-lo no link anterior.
             email_subject: A reunião "%{resource_title}" foi fechada
             notification_title: A reunião <a href="%{resource_path}">%{resource_title}</a> foi fechada.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: A reunião "%{resource_title}" foi adicionado a "%{participatory_space_title}" que você está seguindo.
           email_outro: Você recebeu esta notificação porque está seguindo "%{participatory_space_title}". Você pode ignorá-lo do link anterior.
@@ -136,7 +141,7 @@ pt:
       badges:
         attended_meetings:
           conditions:
-            - Registre-se nas reuniões que deseja participar
+          - Registre-se nas reuniões que deseja participar
           description: Este crachá é concedido quando você participa de várias reuniões presenciais.
           description_another: Este usuário assistiu a %{score} reuniões.
           description_own: Você participou de %{score} reuniões.

--- a/decidim-meetings/config/locales/ru.yml
+++ b/decidim-meetings/config/locales/ru.yml
@@ -1,3 +1,4 @@
+---
 ru:
   activemodel:
     attributes:
@@ -22,6 +23,7 @@ ru:
         location_hints: Как добраться
         organizer_id: Организация
         private_meeting: Частная встреча
+        registration_form_enabled: Registration form enabled
         registration_terms: Условия регистрации
         registrations_enabled: Регистрация включена
         start_time: Время начала
@@ -53,19 +55,19 @@ ru:
   activerecord:
     models:
       decidim/meetings/meeting:
-        one: Встреча
         few: Встречи
         many: Встреч
+        one: Встреча
         other: Встреч
       decidim/meetings/minutes:
-        one: Протокол
         few: Протокола
         many: Протоколов
+        one: Протокол
         other: Протоколов
       decidim/meetings/registration:
-        one: Зарегистрировался
         few: Зарегистрировалось
         many: Зарегистрировались
+        one: Зарегистрировался
         other: Зарегистрировались
   decidim:
     admin:
@@ -87,6 +89,7 @@ ru:
             announcement: Объявление
             comments_enabled: Комментарии включены
             default_registration_terms: Условия регистрации по умолчанию
+            enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Для каждой встречи можно задать те или иные разрешения на действия
           step:
             announcement: Объявление
@@ -95,17 +98,26 @@ ru:
       meetings:
         meeting_closed:
           affected_user:
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
             email_subject: Встреча "%{resource_title}" закончена
             notification_title: Встреча <a href="%{resource_path}">%{resource_title}</a> закончена.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Встреча «%{resource_title}» закончена. Вы можете прочитать итоги на странице:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
             email_subject: Встреча "%{resource_title}" закончена
             notification_title: Встреча <a href="%{resource_path}">%{resource_title}</a> закончена.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: В "%{participatory_space_title}", за которым вы следите, добавлена встреча "%{resource_title}".
           email_outro: Вы получили это уведомление, потому что вы следите за «%{participatory_space_title}». Вы можете перестать за ним следить, перейдя по приведенной выше ссылке.
           email_subject: В %{participatory_space_title} добавлена новая встреча
           notification_title: В %{participatory_space_title} была добавлена встреча <a href="%{resource_path}">%{resource_title}</a>
+        meeting_registration_confirmed:
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
           email_intro: Число мест, забронированных на встречу "%{resource_title}", превысило %{percentage}% процентов%.
           email_outro: Вы получили это уведомление, потому что вы являетесь администратором пространства соучастия этой встречи.
@@ -117,7 +129,9 @@ ru:
           email_subject: Встреча "%{resource_title}" обновлена
           notification_title: Встреча <a href="%{resource_path}">%{resource_title}</a> обновлена.
         registration_code_validated:
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
           email_outro: Вы получили это уведомление, потому что ваш регистрационный код для встречи «%{resource_title}» был подтвержден.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
           notification_title: Ваш регистрационный код «%{registration_code}» для встречи <a href="%{resource_path}">%{resource_title}</a> был подтвержден.
         registrations_enabled:
           email_intro: 'Открылась регистрация на встречу «%{resource_title}». Вы можете зарегистрироваться на странице:'
@@ -129,6 +143,17 @@ ru:
           email_outro: Вы получили это уведомление, потому что вы следите за встречей «%{resource_title}». Вы можете перестать за ней следить, перейдя по приведенной выше ссылке.
           email_subject: Встреча "%{resource_title}" начнется менее чем через 48 часов.
           notification_title: Встреча <a href="%{resource_path}">%{resource_title}</a> начнется менее чем через 48 часов.
+    gamification:
+      badges:
+        attended_meetings:
+          conditions: '["Register in the meetings you want to attend"]'
+          description: This badge is granted when you attend several face-to-face meetings.
+          description_another: This user has attended %{score} meetings.
+          description_own: You have attended %{score} meetings.
+          name: Attended meetings
+          next_level_in: Attend %{score} more meetings to reach the next level!
+          unearned_another: This user hasn't attended any meeting yet.
+          unearned_own: You haven't attended any meeting yet.
     meetings:
       actions:
         agenda: Повестка дня
@@ -175,6 +200,7 @@ ru:
             invalid: При попытке обновить эту повестку дня произошла ошибка
             success: Повестка дня успешно обновлена
         exports:
+          meetings: Meetings
           registrations: Регистрации
         invite_join_meeting_mailer:
           invite:
@@ -264,6 +290,10 @@ ru:
           form:
             available_slots_help: Оставьте его равным 0, если у вас не ограничено количество мест.
             invites: Приглашения
+            registration_form: Registration form
+            registrations_count:
+              one: There has been %{count} registration.
+              other: There has been %{count} registrations.
             reserved_slots_help: Оставьте его равным 0, если у вас нет забронированных мест
             reserved_slots_less_than: Должен быть меньше или равен %{count}
           update:
@@ -289,6 +319,28 @@ ru:
         minutes:
           create: "%{user_name} создал протокол встречи %{resource_name} в пространстве %{space_name}"
           update: "%{user_name} обновил протокол встречи %{resource_name} в пространстве %{space_name}"
+      calendar_modal:
+        calendar_url: Calendar URL
+        close_window: Close window
+        export_calendar: Export calendar
+      conference_venues: Conference Venues
+      content_blocks:
+        upcoming_events:
+          name: Upcoming events
+          upcoming_events: Upcoming meetings
+          view_all_events: View all
+      directory:
+        meetings:
+          index:
+            all: All
+            date: Date
+            meetings: Meetings
+            past: Past
+            search: Search
+            space_type: Participatory space
+            upcoming: Upcoming
+      last_activity:
+        new_meeting_at_html: "<span>New meeting at %{link}</span>"
       mailer:
         invite_join_meeting_mailer:
           invite:
@@ -328,7 +380,16 @@ ru:
           meeting_report: Отчет о встрече
           no_slots_available: Не осталось мест
           organizations: Участвующие организации
+          registration_code_help_text: Your registration code
+          registration_state:
+            validated: VALIDATED
+            validation_pending: VALIDATION PENDING
+          remaining_slots:
+            one: "%{count} slot remaining"
+            other: "%{count} slots remaining"
           view: Посмотреть
+      meetings_map:
+        view_meeting: View meeting
       models:
         invite:
           fields:
@@ -366,6 +427,11 @@ ru:
       types:
         private_meeting: Частная встреча
         transparent: Прозрачная
+    metrics:
+      meetings:
+        description: Number of meetings created
+        object: meetings
+        title: Meetings
     participatory_processes:
       participatory_process_groups:
         highlighted_meetings:
@@ -374,6 +440,7 @@ ru:
     participatory_spaces:
       highlighted_meetings:
         past_meetings: Прошедшие встречи
+        see_all: See all (%{count})
         upcoming_meetings: Предстоящие встречи
       upcoming_meeting_for_card:
         upcoming_meeting: Предстоящая встреча

--- a/decidim-meetings/config/locales/sv.yml
+++ b/decidim-meetings/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -95,11 +96,15 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du organiserade mötet "%{resource_title}".
             email_subject: Mötet "%{resource_title}" stängdes
             notification_title: Mötet <a href="%{resource_path}">%{resource_title}</a> stängdes.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Mötet "%{resource_title}" stängdes. Du kan läsa slutsatserna från dess sida:'
             email_outro: Du har fått den här meddelandet eftersom du följer mötet "%{resource_title}". Du kan följa det från föregående länk.
             email_subject: Mötet "%{resource_title}" stängdes
             notification_title: Mötet <a href="%{resource_path}">%{resource_title}</a> stängdes.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: Mötet "%{resource_title}" har lagts till i "%{participatory_space_title}" som du följer.
           email_outro: Du har fått den här meddelandet eftersom du följer "%{participatory_space_title}". Du kan avfölja det vid föregående länk.
@@ -136,7 +141,7 @@ sv:
       badges:
         attended_meetings:
           conditions:
-            - Registrera dig i de möten du vill delta i
+          - Registrera dig i de möten du vill delta i
           description: Detta märke beviljas när du deltar i flera möten mellan ansikte mot ansikte.
           description_another: Den här användaren har deltagit i %{score} möten.
           description_own: Du har deltagit i %{score} möten.

--- a/decidim-meetings/config/locales/tr-TR.yml
+++ b/decidim-meetings/config/locales/tr-TR.yml
@@ -1,447 +1,451 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       agenda:
-        description: Açıklama
-        duration: süre
-        title: Başlık
+        description: Description
+        duration: Duration
+        title: Title
       close_meeting:
-        attendees_count: Katılımcı sayısı
-        attending_organizations: Katılan kuruluşların listesi
-        closing_report: Rapor
-        contributions_count: Katkı sayısı
-        proposal_ids: Toplantıda oluşturulan teklifler
+        attendees_count: Number of attendees
+        attending_organizations: List of organizations that attended
+        closing_report: Report
+        contributions_count: Number of contributions
+        proposal_ids: Proposals created in the meeting
       meeting:
-        address: Adres
-        available_slots: Bu toplantı için mevcut yuvalar
-        decidim_category_id: Kategori
-        decidim_scope_id: kapsam
-        description: Açıklama
-        end_time: Bitiş zamanı
-        location: yer
-        location_hints: Yer ipuçları
-        organizer_id: Organizatör
-        private_meeting: Özel toplantı
-        registration_form_enabled: Kayıt formu etkin
-        registration_terms: Kayıt şartları
-        registrations_enabled: Kayıtlar etkinleştirildi
-        start_time: Başlama zamanı
-        title: Başlık
-        transparent: Şeffaf
+        address: Address
+        available_slots: Available slots for this meeting
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        end_time: End Time
+        location: Location
+        location_hints: Location hints
+        organizer_id: Organizer
+        private_meeting: Private meeting
+        registration_form_enabled: Registration form enabled
+        registration_terms: Registration terms
+        registrations_enabled: Registrations enabled
+        start_time: Start Time
+        title: Title
+        transparent: Transparent
       minutes:
-        audio_url: Ses url
-        description: Açıklama
-        video_url: Video linki
-        visible: Görünür
+        audio_url: Audio url
+        description: Description
+        video_url: Video url
+        visible: Is visible
     errors:
       models:
         meeting_agenda:
           attributes:
             base:
-              too_many_minutes: Öğelerin süresi toplantı süresini %{count} dakika aşar.
-              too_many_minutes_child: Öğenin childs'ın süresi, "%{parent_title}" ajanda maddesini %{count} dakika aşar.
+              too_many_minutes: The duration of the items exceed the meeting duration by %{count} minutes
+              too_many_minutes_child: The duration of the item childs exceed the agenda item "%{parent_title}" parent duration by %{count} minutes
         meeting_registration_invite:
           attributes:
             email:
-              already_invited: Bu e-posta zaten davet edildi
+              already_invited: This email has already been invited
     models:
-      decidim/meetings/close_meeting_event: Toplantı kapalı
-      decidim/meetings/create_meeting_event: Toplantı
-      decidim/meetings/meeting_registrations_enabled_event: Kayıtlar etkinleştirildi
-      decidim/meetings/meeting_registrations_over_percentage_event: Limit üzerindeki kayıtlar
-      decidim/meetings/upcoming_meeting_event: Yaklaşan toplantı
-      decidim/meetings/update_meeting_event: Toplantı güncellendi
+      decidim/meetings/close_meeting_event: Meeting closed
+      decidim/meetings/create_meeting_event: Meeting
+      decidim/meetings/meeting_registrations_enabled_event: Registrations enabled
+      decidim/meetings/meeting_registrations_over_percentage_event: Registrations over limit
+      decidim/meetings/upcoming_meeting_event: Upcoming meeting
+      decidim/meetings/update_meeting_event: Meeting updated
   activerecord:
     models:
       decidim/meetings/meeting:
-        one: Toplantı
-        other: Toplantılar
+        one: Meeting
+        other: Meetings
       decidim/meetings/minutes:
-        one: Dakika
-        other: Dakika
+        one: Minutes
+        other: Minutes
       decidim/meetings/registration:
-        one: kayıt
-        other: Kayıtlar
+        one: Registration
+        other: Registrations
   decidim:
     admin:
       meeting_copies:
         create:
-          error: Bu toplantıyı tekrarlayan hata oluştu.
-          success: Kopyalanmış toplantı başarıyla yapıldı.
+          error: There was en error duplicating this meeting.
+          success: Duplicated meeting successfully.
         new:
-          copy: kopya
-          select: Çoğaltmak istediğiniz verileri seçin
-          title: Yinelenen toplantı
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate meeting
     components:
       meetings:
         actions:
-          join: Katılmak
-        name: Toplantılar
+          join: Join
+        name: Meetings
         settings:
           global:
-            announcement: duyuru
-            comments_enabled: Yorumlar etkin
-            default_registration_terms: Varsayılan kayıt şartları
-            enable_pads_creation: Pedlerin oluşturulmasını etkinleştir
-            resources_permissions_enabled: Her toplantı için işlem izinleri ayarlanabilir
+            announcement: Announcement
+            comments_enabled: Comments enabled
+            default_registration_terms: Default registration terms
+            enable_pads_creation: Enable pads creation
+            resources_permissions_enabled: Actions permissions can be set for each meeting
           step:
-            announcement: duyuru
-            comments_blocked: Yorumlar engellendi
+            announcement: Announcement
+            comments_blocked: Comments blocked
     events:
       meetings:
         meeting_closed:
           affected_user:
-            email_intro: '"%{resource_title}" toplantınız kapatıldı. Sonuçları kendi sayfasından okuyabilirsiniz:'
-            email_outro: '"%{resource_title}" toplantısını düzenlediğiniz için bu bildirimi aldınız.'
-            email_subject: '"%{resource_title}" toplantısı kapatıldı'
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı kapatıldı.
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
+            email_subject: The "%{resource_title}" meeting was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
-            email_intro: '"%{resource_title}" toplantısı kapatıldı. Sonuçları kendi sayfasından okuyabilirsiniz:'
-            email_outro: '"%{resource_title}" toplantısını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-            email_subject: '"%{resource_title}" toplantısı kapatıldı'
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı kapatıldı.
+            email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+            email_subject: The "%{resource_title}" meeting was closed
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
-          email_intro: '"%{resource_title}" toplantısı, takip ettiğiniz "%{participatory_space_title}" e eklenmiştir.'
-          email_outro: Bu bildirimi "%{participatory_space_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-          email_subject: Yeni toplantı %{participatory_space_title}eklendi
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı %{participatory_space_title}olarak eklendi.
+          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New meeting added to %{participatory_space_title}
+          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         meeting_registration_confirmed:
-          notification_title: Toplantı için kaydınız <a href="%{resource_url}">%{resource_title}</a> onaylandı. Kayıt kodunuz %{registration_code}.
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
-          email_intro: '"%{resource_title}" toplantısı işgal edilen yuvalar% %{percentage}üzerindedir.'
-          email_outro: Bu bildirimi, toplantının katılımcı alanının yöneticisi olduğunuz için aldınız.
-          email_subject: '"%{resource_title}" toplantısıyla dolu toplantı alanları% %{percentage}üzerindedir'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantı işgal yuvaları% %{percentage}üzerindedir.
+          email_intro: The "%{resource_title}" meeting occupied slots are over %{percentage}%.
+          email_outro: You have received this notification because you are an admin of the meeting's participatory space.
+          email_subject: The "%{resource_title}" meeting occupied slots are over %{percentage}%
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting occupied slots are over %{percentage}%.
         meeting_updated:
-          email_intro: '"%{resource_title}" toplantısı güncellendi. Yeni sürümü kendi sayfasından okuyabilirsiniz:'
-          email_outro: '"%{resource_title}" toplantısını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" toplantısı güncellendi'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı güncellendi.
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting was updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
         registration_code_validated:
-          email_intro: '"%{resource_title}" toplantısı için "%{registration_code}" kayıt kodunuz onaylandı.'
-          email_outro: '"%{resource_title}" toplantısı için kayıt kodunuz onaylandığından bu bildirimi aldınız.'
-          email_subject: '"%{resource_title}" toplantısı için "%{registration_code}" kayıt kodunuz onaylandı'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı için "%{registration_code}" kayıt kodunuz onaylandı.
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
+          email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
+          notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
         registrations_enabled:
-          email_intro: '"%{resource_title}" toplantısı kayıtları etkinleştirdi. Kendini kendi sayfasına kaydedebilirsin:'
-          email_outro: '"%{resource_title}" toplantısını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" toplantısı kayıtları etkinleştirdi.'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı kayıtları etkinleştirdi.
+          email_intro: 'The "%{resource_title}" meeting has enabled registrations. You can register yourself on its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting has enabled registrations.
         upcoming_meeting:
-          email_intro: '"%{resource_title}" toplantısı 48 saatten daha az sürede başlayacak.'
-          email_outro: '"%{resource_title}" toplantısını izlediğiniz için bu bildirimi aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.'
-          email_subject: '"%{resource_title}" toplantısı 48 saatten daha az sürede başlayacak.'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> toplantısı 48 saatten daha az sürede başlayacak.
+          email_intro: The "%{resource_title}" meeting will start in less than 48h.
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_subject: The "%{resource_title}" meeting will start in less than 48h.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
     gamification:
       badges:
         attended_meetings:
-          conditions:
-            - Katılmak istediğiniz toplantılara kayıt olun
-          description: Yüz yüze yapılan toplantılara katıldığınızda bu rozet verilir.
-          description_another: Bu kullanıcı %{score} toplantıya katıldı.
-          description_own: '%{score} toplantıya katıldınız.'
-          name: Katıldığı toplantılar
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} toplantıya katılın!
-          unearned_another: Bu kullanıcı henüz bir toplantıya katılmadı.
-          unearned_own: Henüz bir toplantıya katılmadın.
+          conditions: '["Register in the meetings you want to attend"]'
+          description: This badge is granted when you attend several face-to-face meetings.
+          description_another: This user has attended %{score} meetings.
+          description_own: You have attended %{score} meetings.
+          name: Attended meetings
+          next_level_in: Attend %{score} more meetings to reach the next level!
+          unearned_another: This user hasn't attended any meeting yet.
+          unearned_own: You haven't attended any meeting yet.
     meetings:
       actions:
-        agenda: Gündem
-        attachment_collections: Klasörler
-        attachments: Ekler
-        close: Kapat
-        confirm_destroy: Bu toplantıyı silmek istediğinizden emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        minutes: Dakika
-        new: Yeni toplantı
-        preview: Ön izleme
-        registrations: Kayıtlar
-        title: Eylemler
+        agenda: Agenda
+        attachment_collections: Folders
+        attachments: Attachments
+        close: Close
+        confirm_destroy: Are you sure you want to delete this meeting?
+        destroy: Delete
+        edit: Edit
+        minutes: Minutes
+        new: New meeting
+        preview: Preview
+        registrations: Registrations
+        title: Actions
       admin:
         agenda:
           agenda_item:
-            add_agenda_item_child: Gündem maddesi ekle
-            agenda_item: Gündem maddesi
-            agenda_item_children: Ajanda Öğesi Childs
-            down: Aşağı
-            remove: Kaldır
-            up: yukarı
+            add_agenda_item_child: Add agenda item child
+            agenda_item: Agenda Item
+            agenda_item_children: Agenda Item Childs
+            down: Down
+            remove: Remove
+            up: Up
           agenda_item_child:
-            agenda_item_child: Gündem Maddesi Çocuk
-            down: Aşağı
-            remove: Kaldır
-            up: yukarı
+            agenda_item_child: Agenda Item Child
+            down: Down
+            remove: Remove
+            up: Up
           create:
-            invalid: Bu gündemi oluştururken bir sorun oluştu
-            success: Ajanda başarıyla oluşturuldu
+            invalid: There's been a problem creating this agenda
+            success: Agenda successfully created
           edit:
-            title: Gündemi düzenle
-            update: Güncelleştirme
+            title: Edit agenda
+            update: Update
           form:
-            add_agenda_item: Gündem maddesi ekle
-            agenda_items: Gündem maddeleri
-            end_date: Bitiş tarihi
-            start_date: Başlangıç tarihi
+            add_agenda_item: Add agenda item
+            agenda_items: Agenda items
+            end_date: End date
+            start_date: Start date
           new:
-            create: yaratmak
-            title: Yeni gündem
+            create: Create
+            title: New agenda
           update:
-            invalid: Bu gündemi güncellerken bir sorun oluştu
-            success: Ajanda başarıyla güncellendi
+            invalid: There's been a problem updating this agenda
+            success: Agenda successfully updated
         exports:
-          meetings: Toplantılar
-          registrations: Kayıtlar
+          meetings: Meetings
+          registrations: Registrations
         invite_join_meeting_mailer:
           invite:
-            decline: Davet reddet
-            invited_you_to_join_a_meeting: "%{invited_by} sizi %{application}bir toplantıya davet etti. Aşağıdaki bağlantılardan reddedebilir veya kabul edebilirsiniz."
-            join: '''%{meeting_title}'' toplantısına katıl'
+            decline: Decline invitation
+            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join a meeting at %{application}. You can decline or accept it through the links below."
+            join: Join meeting '%{meeting_title}'
         invites:
           create:
-            error: Kullanıcıyı toplantıya katılmaya davet ederken bir sorun oluştu.
-            success: Kullanıcı toplantıya katılmaya başarıyla davet edildi.
+            error: There's been a problem while inviting the user to join the meeting.
+            success: User successfully invited to join the meeting.
           form:
-            attendee_type: Katılımcı Tipi
-            existing_user: Mevcut kullanıcı
-            invite: Davet et
-            invite_explanation: Kullanıcı toplantıya ve organizasyona da davet edilecektir.
-            non_user: Mevcut olmayan kullanıcı
-            select_user: Kullanıcı seç
+            attendee_type: Attendee type
+            existing_user: Existing user
+            invite: Invite
+            invite_explanation: The user will be invited to join the meeting and to the organization as well.
+            non_user: Non existing user
+            select_user: Select user
           index:
             filter:
-              accepted: Kabul edilmiş
-              all: Herşey
-              rejected: Reddedilen
-              sent: Gönderilen
-            filter_by: Tarafından filtre
-            invite_attendee: Katılımcı davet et
-            invites: Davetler
-            registrations_disabled: Kayıtları devre dışı bırakıldığı için bir katılımcı davet edemezsiniz.
-            search: Arama
+              accepted: Accepted
+              all: All
+              rejected: Rejected
+              sent: Sent
+            filter_by: Filter by
+            invite_attendee: Invite attendee
+            invites: Invites
+            registrations_disabled: You can't invite an attendee because the registrations are disabled.
+            search: Search
         meeting_closes:
           edit:
-            close: Kapat
-            title: Toplantıyı kapat
+            close: Close
+            title: Close meeting
         meeting_copies:
           form:
-            select_organizer: Organizatör seç
+            select_organizer: Select the organizer
         meetings:
           close:
-            invalid: Bu toplantıyı kapatırken bir sorun oluştu
-            success: Toplantı başarıyla kapatıldı
+            invalid: There's been a problem closing this meeting
+            success: Meeting successfully closed
           create:
-            invalid: Bu toplantıyı oluştururken bir sorun oluştu
-            success: Toplantı başarıyla oluşturuldu
+            invalid: There's been a problem creating this meeting
+            success: Meeting successfully created
           destroy:
-            success: Toplantı başarıyla silindi
+            success: Meeting successfully deleted
           edit:
-            update: Güncelleştirme
+            update: Update
           form:
-            select_organizer: Organizatör seç
+            select_organizer: Select the organizer
           index:
-            title: Toplantılar
+            title: Meetings
           new:
-            create: yaratmak
-            title: Toplantı oluştur
+            create: Create
+            title: Create meeting
           service:
-            description: Açıklama
-            down: Aşağı
-            remove: Kaldır
-            service: Hizmet
-            title: Başlık
-            up: yukarı
+            description: Description
+            down: Down
+            remove: Remove
+            service: Service
+            title: Title
+            up: Up
           services:
-            add_service: Servis ekle
-            services: Hizmetler
+            add_service: Add service
+            services: Services
           update:
-            invalid: Bu toplantı güncellenirken bir sorun oluştu
-            success: Toplantı başarıyla güncellendi
+            invalid: There's been a problem updating this meeting
+            success: Meeting successfully updated
         minutes:
           create:
-            invalid: Bu dakika oluştururken bir sorun oluştu
-            success: Dakika başarıyla oluşturuldu
+            invalid: There's been a problem creating this minutes
+            success: Minutes successfully created
           edit:
-            update: Güncelleştirme
+            update: Update
           new:
-            create: yaratmak
-            title: Dakika oluşturun
+            create: Create
+            title: Create minutes
           update:
-            invalid: Bu dakika güncellenirken bir sorun oluştu
-            success: Dakika başarıyla güncellendi
+            invalid: There's been a problem updating this minutes
+            success: Minutes successfully updated
         models:
           meeting:
-            name: Toplantı
+            name: Meeting
         registrations:
           edit:
-            save: Kayıt etmek
-            validate: onaylamak
-            validate_registration_code: Kayıt kodunu doğrula
+            save: Save
+            validate: Validate
+            validate_registration_code: Validate registration code
           form:
-            available_slots_help: Mevcut sınırsız yuvaya sahipseniz 0'a bırakın.
-            invites: Davetler
-            registration_form: Kayıt formu
+            available_slots_help: Leave it to 0 if you have unlimited slots available.
+            invites: Invites
+            registration_form: Registration form
             registrations_count:
-              one: '%{count} kayıt oldu.'
-              other: '%{count} kayıt var.'
-            reserved_slots_help: Ayrılmış yuvalarınız yoksa 0'a bırakın
-            reserved_slots_less_than: Daha az ya da buna eşit olmalıdır %{count}
+              one: There has been %{count} registration.
+              other: There has been %{count} registrations.
+            reserved_slots_help: Leave it to 0 if you don't have reserved slots
+            reserved_slots_less_than: Must be less than or equal to %{count}
           update:
-            invalid: Kayıt ayarları kaydedilirken bir sorun oluştu.
-            success: Toplantı kayıtları ayarları başarıyla kaydedildi.
+            invalid: There's been a problem saving the registration settings.
+            success: Meeting registrations settings successfully saved.
           validate_registration_code:
-            invalid: Bu kayıt kodu geçersiz.
-            success: Kayıt kodu başarıyla doğrulandı.
+            invalid: This registration code is invalid.
+            success: Registration code successfully validated.
       admin_log:
         invite:
-          create: "%{user_name} davet %{attendee_name} katılmaya %{resource_name} toplantıya %{space_name} uzayda"
-          deleted: "%{user_name} %{space_name} alandaki %{resource_name} toplantıya katılmadan davetsiz %{attendee_name}"
-          update: "%{user_name} davet %{attendee_name} katılmaya %{resource_name} toplantıya %{space_name} uzayda"
+          create: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
+          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
         meeting:
-          close: "%{user_name} %{space_name} uzayda %{resource_name} toplantıyı kapattı"
-          create: "%{user_name} , %{space_name} alanda %{resource_name} toplantıyı oluşturdu"
-          delete: "%{user_name} , %{space_name} alandaki %{resource_name} toplantıyı sildi"
-          export_registrations: "%{user_name} %{resource_name} toplantının kayıtlarını %{space_name} uzayda ihraç etti"
-          update: "%{user_name} , %{space_name} alanda %{resource_name} toplantıyı güncelledi"
+          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} meeting on the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name} space"
+          export_registrations: "%{user_name} exported the registrations of the %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name} space"
           value_types:
             organizer_presenter:
-              not_found: 'Organizatör veritabanında bulunamadı (ID: %{id})'
+              not_found: 'The organizer was not found on the database (ID: %{id})'
         minutes:
-          create: "%{user_name} toplantının tutanağını %{resource_name} %{space_name} uzayda oluşturdu"
-          update: "%{user_name} toplantının tutanaklarını %{resource_name} %{space_name} uzayda güncelledi"
+          create: "%{user_name} created the minutes of the meeting %{resource_name} on the %{space_name} space"
+          update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
       calendar_modal:
-        calendar_url: Takvim URL'si
-        close_window: Pencereyi kapat
-        export_calendar: Takvimi dışa aktar
-      conference_venues: Konferans Mekanları
+        calendar_url: Calendar URL
+        close_window: Close window
+        export_calendar: Export calendar
+      conference_venues: Conference Venues
       content_blocks:
         upcoming_events:
-          name: Yaklaşan Etkinlikler
-          upcoming_events: Yaklaşan toplantılar
-          view_all_events: Hepsini gör
+          name: Upcoming events
+          upcoming_events: Upcoming meetings
+          view_all_events: View all
       directory:
         meetings:
           index:
-            all: Herşey
-            date: tarih
-            meetings: Toplantılar
-            past: geçmiş
-            search: Arama
-            space_type: Katılımcı alan
-            upcoming: Yaklaşan
+            all: All
+            date: Date
+            meetings: Meetings
+            past: Past
+            search: Search
+            space_type: Participatory space
+            upcoming: Upcoming
       last_activity:
-        new_meeting_at_html: "%{link}</span><span>yeni toplantı"
+        new_meeting_at_html: "<span>New meeting at %{link}</span>"
       mailer:
         invite_join_meeting_mailer:
           invite:
-            subject: Bir toplantıya katılma daveti
+            subject: Invitation to join a meeting
         registration_mailer:
           confirmation:
-            subject: Toplantınızın kaydı onaylandı
+            subject: Your meeting's registration has been confirmed
       meeting:
-        not_allowed: Bu toplantıyı göremezsin
+        not_allowed: You are not allowed to view this meeting
       meetings:
         filters:
-          category: Kategori
-          category_prompt: bir kategori seç
-          date: tarih
-          past: geçmiş
-          search: Arama
-          upcoming: Yaklaşan
+          category: Category
+          category_prompt: Select a category
+          date: Date
+          past: Past
+          search: Search
+          upcoming: Upcoming
         filters_small_view:
-          close_modal: Yakın kalıcı
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         meeting_minutes:
-          meeting_minutes: Görüşme süreleri
-          related_information: İlgili bilgi
+          meeting_minutes: Meeting Minutes
+          related_information: Related Information
         meetings:
-          no_meetings_warning: Hiçbir toplantı, arama kriterinizle eşleşmiyor veya planlanmış bir toplantı yok.
-          upcoming_meetings_warning: Şu anda planlanmış bir toplantı yok, ancak burada listelenen tüm geçmiş toplantıları bulabilirsiniz.
+          no_meetings_warning: No meetings match your search criteria or there isn't any meeting scheduled.
+          upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.
         registration_confirm:
-          cancel: İptal etmek
-          confirm: Onaylamak
+          cancel: Cancel
+          confirm: Confirm
         show:
-          attendees: Katılımcı sayısı
-          contributions: Katkı sayımı
-          going: Gidiyor
-          join: Toplantıya katıl
-          meeting_report: Toplantı Raporu
-          no_slots_available: Mevcut yuva yok
-          organizations: Katılan kuruluşlar
-          registration_code_help_text: Kayıt kodunuz
+          attendees: Attendees count
+          contributions: Contributions count
+          going: Going
+          join: Join meeting
+          meeting_report: Meeting report
+          no_slots_available: No slots available
+          organizations: Attending organizations
+          registration_code_help_text: Your registration code
           registration_state:
-            validated: valide
+            validated: VALIDATED
             validation_pending: VALIDATION PENDING
           remaining_slots:
-            one: "%{count} yuva kaldı"
-            other: "%{count} yuva kaldı"
-          view: Görünüm
+            one: "%{count} slot remaining"
+            other: "%{count} slots remaining"
+          view: View
       meetings_map:
-        view_meeting: Toplantıyı görüntüle
+        view_meeting: View meeting
       models:
         invite:
           fields:
-            email: E-posta
-            name: isim
-            sent_at: Adresine gönderildi
-            status: durum
+            email: Email
+            name: Name
+            sent_at: Sent at
+            status: Status
           status:
-            accepted: Kabul edildi (%{at})
-            rejected: Reddedildi (%{at})
-            sent: Gönderilen
+            accepted: Accepted (%{at})
+            rejected: Rejected (%{at})
+            sent: Sent
         meeting:
           fields:
-            closed: Kapalı
-            end_time: Bitiş tarihi
-            map: harita
-            start_time: Başlangıç tarihi
-            title: Başlık
-      read_more: "(daha fazla oku)"
+            closed: Closed
+            end_time: End date
+            map: Map
+            start_time: Start date
+            title: Title
+      read_more: "(read more)"
       registration_mailer:
         confirmation:
-          confirmed_html: Toplantı için kaydınız <a href="%{url}">%{title}</a> onaylandı.
-          details: Toplantı detaylarını ekte bulabilirsiniz.
-          registration_code: Kayıt kodunuz %{code}.
+          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a> has been confirmed.
+          details: You will find the meeting's details in the attachment.
+          registration_code: Your registration code is %{code}.
       registrations:
         create:
-          invalid: Bu toplantıya katılırken bir sorun oluştu.
-          success: Toplantıya başarılı bir şekilde katıldınız.
+          invalid: There's been a problem joining this meeting.
+          success: You have joined the meeting successfully.
         decline_invitation:
-          invalid: Davetin reddedilmesiyle ilgili bir sorun oluştu.
-          success: Davetiyeyi başarıyla reddettiniz.
+          invalid: There's been a problem declining the invitation.
+          success: You have declined the invitation successfully.
         destroy:
-          invalid: Bu buluşmadan bir sorun çıktı.
-          success: Toplantıdan başarıyla ayrıldınız.
+          invalid: There's been a problem leaving this meeting.
+          success: You have left the meeting successfully.
       types:
-        private_meeting: Özel toplantı
-        transparent: Şeffaf
+        private_meeting: Private meeting
+        transparent: Transparent
     metrics:
       meetings:
-        description: Oluşturulan toplantı sayısı
-        object: toplantılar
-        title: Toplantılar
+        description: Number of meetings created
+        object: meetings
+        title: Meetings
     participatory_processes:
       participatory_process_groups:
         highlighted_meetings:
-          past_meetings: Geçmiş toplantılar
-          upcoming_meetings: Yaklaşan toplantılar
+          past_meetings: Past meetings
+          upcoming_meetings: Upcoming meetings
     participatory_spaces:
       highlighted_meetings:
-        past_meetings: Geçmiş toplantılar
-        see_all: Tümünü gör (%{count})
-        upcoming_meetings: Yaklaşan toplantılar
+        past_meetings: Past meetings
+        see_all: See all (%{count})
+        upcoming_meetings: Upcoming meetings
       upcoming_meeting_for_card:
-        upcoming_meeting: Yaklaşan toplantı
+        upcoming_meeting: Upcoming meeting
     resource_links:
       meetings_through_proposals:
-        meeting_result: 'İlgili sonuçlar:'
-        result_meeting: 'İlgili toplantılar:'
+        meeting_result: 'Related results:'
+        result_meeting: 'Related meetings:'
       proposals_from_meeting:
-        meeting_proposal: 'İlgili teklifler:'
-        proposal_meeting: 'İlgili toplantılar:'
+        meeting_proposal: 'Related proposals:'
+        proposal_meeting: 'Related meetings:'
   devise:
     mailer:
       join_meeting:
-        subject: Bir toplantıya katılma daveti
+        subject: Invitation to join a meeting

--- a/decidim-meetings/config/locales/uk.yml
+++ b/decidim-meetings/config/locales/uk.yml
@@ -1,3 +1,4 @@
+---
 uk:
   activemodel:
     attributes:
@@ -22,6 +23,7 @@ uk:
         location_hints: Як дістатися до цього місця
         organizer_id: Організатор
         private_meeting: Приватна зустріч
+        registration_form_enabled: Registration form enabled
         registration_terms: Умови реєстрації
         registrations_enabled: Реєстрацію відкрито
         start_time: Час початку
@@ -53,19 +55,19 @@ uk:
   activerecord:
     models:
       decidim/meetings/meeting:
-        one: Зустріч
         few: Зустрічі
         many: Зустрічей
+        one: Зустріч
         other: Зустрічей
       decidim/meetings/minutes:
-        one: Протокол
         few: Протоколи
         many: Протоколів
+        one: Протокол
         other: Протоколів
       decidim/meetings/registration:
-        one: Зареєстрований
         few: Зареєстрованих
         many: Зареєстрованих
+        one: Зареєстрований
         other: Зареєстрованих
   decidim:
     admin:
@@ -87,6 +89,7 @@ uk:
             announcement: Оголошення
             comments_enabled: Коментарі увімкнено
             default_registration_terms: Умови реєстрації за умовчанням
+            enable_pads_creation: Enable pads creation
             resources_permissions_enabled: Права на дії можна встановити для кожної зустрічі
           step:
             announcement: Оголошення
@@ -95,17 +98,26 @@ uk:
       meetings:
         meeting_closed:
           affected_user:
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
             email_subject: Зустріч "%{resource_title}" було завершено
             notification_title: Зустріч <a href="%{resource_path}">%{resource_title}</a> було завершено.
+          email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_subject: La rencontre "%{resource_title}" est terminée
           follower:
             email_intro: 'Зустріч "%{resource_title}" було завершено. Ви можете ознайомитися з підсумками на сторінці зустрічі:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
             email_subject: Зустріч "%{resource_title}" було завершено
             notification_title: Зустріч <a href="%{resource_path}">%{resource_title}</a> було завершено.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
         meeting_created:
           email_intro: До "%{participatory_space_title}", за яким ви стежите, була додана зустріч "%{resource_title}".
           email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{participatory_space_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: До %{participatory_space_title} додано нову зустріч
           notification_title: До %{participatory_space_title} була додано зустріч <a href="%{resource_path}">%{resource_title}</a>
+        meeting_registration_confirmed:
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
           email_intro: На зустріч "%{resource_title}" зайнято більше %{percentage}% місць.
           email_outro: Ви отримали це сповіщення, оскільки ви адміністратор простору співучасті цієї зустрічі.
@@ -117,7 +129,9 @@ uk:
           email_subject: Зустріч "%{resource_title}" було оновлено
           notification_title: Зустріч <a href="%{resource_path}">%{resource_title}</a> було оновлено.
         registration_code_validated:
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
           email_outro: Ви отримали це повідомлення, оскільки ваш реєстраційний код для зустрічі "%{resource_title}" підтверджено.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
           notification_title: Ваш реєстраційний код "%{registration_code}" для зустрічі <a href="%{resource_path}">%{resource_title}</a> підтверджено.
         registrations_enabled:
           email_intro: 'Розпочалася реєстрація на зустріч "%{resource_title}". Ви можете зареєструватися на сторінці:'
@@ -129,6 +143,17 @@ uk:
           email_outro: Ви отримали це сповіщення, оскільки ви стежите за зустріччю "%{resource_title}". Ви можете припинити стежити за нею, перейшовши за наведеним вище посиланням.
           email_subject: Зустріч "%{resource_title}" розпочнеться менш ніж за 48 годин.
           notification_title: Зустріч <a href="%{resource_path}">%{resource_title}</a> розпочнеться менш ніж за 48 годин.
+    gamification:
+      badges:
+        attended_meetings:
+          conditions: '["Register in the meetings you want to attend"]'
+          description: This badge is granted when you attend several face-to-face meetings.
+          description_another: This user has attended %{score} meetings.
+          description_own: You have attended %{score} meetings.
+          name: Attended meetings
+          next_level_in: Attend %{score} more meetings to reach the next level!
+          unearned_another: This user hasn't attended any meeting yet.
+          unearned_own: You haven't attended any meeting yet.
     meetings:
       actions:
         agenda: Порядок денний
@@ -175,6 +200,7 @@ uk:
             invalid: При спробі оновити цей порядок денний сталася помилка
             success: Порядок денний успішно оновлено
         exports:
+          meetings: Meetings
           registrations: Реєстрації
         invite_join_meeting_mailer:
           invite:
@@ -264,6 +290,10 @@ uk:
           form:
             available_slots_help: Залиште це число нульовим, якщо у вас не обмежена кількість місць.
             invites: Запрошення
+            registration_form: Registration form
+            registrations_count:
+              one: There has been %{count} registration.
+              other: There has been %{count} registrations.
             reserved_slots_help: Залиште його 0, якщо у вас немає заброньованих місць
             reserved_slots_less_than: Має бути меншим або рівним %{count}
           update:
@@ -289,6 +319,28 @@ uk:
         minutes:
           create: "%{user_name} створив протокол зустрічі %{resource_name} у просторі %{space_name}"
           update: "%{user_name} оновив протокол зустрічі %{resource_name} у просторі %{space_name}"
+      calendar_modal:
+        calendar_url: Calendar URL
+        close_window: Close window
+        export_calendar: Export calendar
+      conference_venues: Conference Venues
+      content_blocks:
+        upcoming_events:
+          name: Upcoming events
+          upcoming_events: Upcoming meetings
+          view_all_events: View all
+      directory:
+        meetings:
+          index:
+            all: All
+            date: Date
+            meetings: Meetings
+            past: Past
+            search: Search
+            space_type: Participatory space
+            upcoming: Upcoming
+      last_activity:
+        new_meeting_at_html: "<span>New meeting at %{link}</span>"
       mailer:
         invite_join_meeting_mailer:
           invite:
@@ -328,7 +380,16 @@ uk:
           meeting_report: Звіт про зустріч
           no_slots_available: Не залишилось місць
           organizations: Організації, що приймають участь
+          registration_code_help_text: Your registration code
+          registration_state:
+            validated: VALIDATED
+            validation_pending: VALIDATION PENDING
+          remaining_slots:
+            one: "%{count} slot remaining"
+            other: "%{count} slots remaining"
           view: Переглянути
+      meetings_map:
+        view_meeting: View meeting
       models:
         invite:
           fields:
@@ -366,6 +427,11 @@ uk:
       types:
         private_meeting: Приватна зустріч
         transparent: Прозора
+    metrics:
+      meetings:
+        description: Number of meetings created
+        object: meetings
+        title: Meetings
     participatory_processes:
       participatory_process_groups:
         highlighted_meetings:
@@ -374,6 +440,7 @@ uk:
     participatory_spaces:
       highlighted_meetings:
         past_meetings: Минулі зустрічі
+        see_all: See all (%{count})
         upcoming_meetings: Прийдешні зустрічі
       upcoming_meeting_for_card:
         upcoming_meeting: Прийдешня зустріч

--- a/decidim-pages/config/locales/fi-pl.yml
+++ b/decidim-pages/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activerecord:
     models:

--- a/decidim-pages/config/locales/fr.yml
+++ b/decidim-pages/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activerecord:
     models:

--- a/decidim-pages/config/locales/id-ID.yml
+++ b/decidim-pages/config/locales/id-ID.yml
@@ -1,26 +1,31 @@
-id:
+---
+id-ID:
   activerecord:
     models:
       decidim/pages/page:
-        other: Halaman
+        one: Page
+        other: Pages
   decidim:
     admin_log:
       page:
-        update: "%{user_name} memperbarui %{resource_name} halaman menjadi %{space_name}"
+        update: "%{user_name} updated the %{resource_name} page in %{space_name}"
     components:
       pages:
-        name: Halaman
+        name: Page
         settings:
           global:
-            announcement: Pengumuman
+            announcement: Announcement
           step:
-            announcement: Pengumuman
+            announcement: Announcement
     pages:
       admin:
         models:
           components:
-            body: Tubuh
+            body: Body
         pages:
           edit:
-            save: Memperbarui
-            title: Edit halaman
+            save: Update
+            title: Edit page
+          update:
+            invalid: There's been errors when saving the page.
+            success: Page saved successfully.

--- a/decidim-pages/config/locales/tr-TR.yml
+++ b/decidim-pages/config/locales/tr-TR.yml
@@ -1,30 +1,31 @@
-tr:
+---
+tr-TR:
   activerecord:
     models:
       decidim/pages/page:
-        one: Sayfa
-        other: Sayfalar
+        one: Page
+        other: Pages
   decidim:
     admin_log:
       page:
-        update: "%{user_name} %{resource_name} sayfayı %{space_name}güncelledi"
+        update: "%{user_name} updated the %{resource_name} page in %{space_name}"
     components:
       pages:
-        name: Sayfa
+        name: Page
         settings:
           global:
-            announcement: duyuru
+            announcement: Announcement
           step:
-            announcement: duyuru
+            announcement: Announcement
     pages:
       admin:
         models:
           components:
-            body: Vücut
+            body: Body
         pages:
           edit:
-            save: Güncelleştirme
-            title: Sayfayı düzenle
+            save: Update
+            title: Edit page
           update:
-            invalid: Sayfayı kaydederken hatalar oluştu.
-            success: Sayfa başarıyla kaydedildi.
+            invalid: There's been errors when saving the page.
+            success: Page saved successfully.

--- a/decidim-participatory_processes/config/locales/ca.yml
+++ b/decidim-participatory_processes/config/locales/ca.yml
@@ -19,6 +19,7 @@ ca:
         participatory_process_group_id: Grup de processos
         participatory_scope: El que es decideix
         participatory_structure: Com es decideix
+        private_space: Concertation privée
         promoted: Destacat
         published_at: Publicat el
         scope_id: Àmbit
@@ -71,6 +72,7 @@ ca:
         duplicate: Duplicar
         edit: Editar
         new: New
+        new_process: Yeni süreç
         new_process_group: Nou grup de processos
         new_process_step: Nova fase
         new_process_user_role: Nou usuari del procés

--- a/decidim-participatory_processes/config/locales/de.yml
+++ b/decidim-participatory_processes/config/locales/de.yml
@@ -19,6 +19,7 @@ de:
         participatory_process_group_id: Prozessgruppe
         participatory_scope: Was ist entschieden?
         participatory_structure: Wie ist es entschieden?
+        private_space: Concertation privée
         promoted: Gefördert
         published_at: Veröffentlicht unter
         scope_id: Umfang
@@ -71,6 +72,7 @@ de:
         duplicate: Duplikat
         edit: Bearbeiten
         new: New
+        new_process: Yeni süreç
         new_process_group: Neue Prozessgruppe
         new_process_step: Neuer Schritt
         new_process_user_role: Neuer Prozessbenutzer

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -72,7 +72,6 @@ en:
         duplicate: Duplicate
         edit: Edit
         new: New
-        new_process: Yeni süreç
         new_process_group: New process group
         new_process_step: New step
         new_process_user_role: New process user

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
         participatory_process_group_id: Processes group
         participatory_scope: What is decided
         participatory_structure: How is it decided
+        private_space: Concertation privée
         promoted: Promoted
         published_at: Published at
         scope_id: Scope
@@ -71,6 +72,7 @@ en:
         duplicate: Duplicate
         edit: Edit
         new: New
+        new_process: Yeni süreç
         new_process_group: New process group
         new_process_step: New step
         new_process_user_role: New process user

--- a/decidim-participatory_processes/config/locales/es-PY.yml
+++ b/decidim-participatory_processes/config/locales/es-PY.yml
@@ -19,6 +19,7 @@ es-PY:
         participatory_process_group_id: Grupo de procesos
         participatory_scope: Qué se decide
         participatory_structure: Cómo se decide
+        private_space: Concertation privée
         promoted: Destacado
         published_at: Publicado en
         scope_id: Ámbito
@@ -71,6 +72,7 @@ es-PY:
         duplicate: Duplicar
         edit: Editar
         new: New
+        new_process: Yeni süreç
         new_process_group: Nuevo grupo de procesos
         new_process_step: Nueva fase
         new_process_user_role: Nuevo usuario de proceso

--- a/decidim-participatory_processes/config/locales/es.yml
+++ b/decidim-participatory_processes/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -18,6 +19,7 @@ es:
         participatory_process_group_id: Grupo de procesos
         participatory_scope: Qué se decide
         participatory_structure: Cómo se decide
+        private_space: Concertation privée
         promoted: Destacado
         published_at: Publicado en
         scope_id: Ámbito
@@ -69,9 +71,12 @@ es:
         destroy: Borrar
         duplicate: Duplicar
         edit: Editar
+        new_process: Yeni süreç
         new_process_group: Nuevo grupo de procesos
         new_process_step: Nueva fase
         new_process_user_role: Nuevo usuario de proceso
+        participatory_process:
+          new: New process
         preview: Previsualizar
         publish: Publicar
         resend_invitation: Reenviar invitación
@@ -202,6 +207,9 @@ es:
         index:
           not_published: No publicado
           private: Privado
+          promoted:
+            'false': 'False'
+            'true': 'True'
           public: Público
           published: Publicada
         new:
@@ -257,7 +265,7 @@ es:
         participatory_processes:
           contextual: "<p>Un <strong>proceso participativo</strong> es una secuencia de actividades participativas (p.e. primero rellenar una encuesta, luego realizar propuestas, debatirlas en encuentros presenciales o virtuales, y finalmente priorizarlas) con el objetivo de definir y tomar una decisión sobre un tema específico.</p> <p>Ejemplos de procesos participativos son: un proceso de elección de los miembros de un comité (donde primero se presentan unas candidaturas, luego se debate y finalmente se elige una candidatura), presupuestos participativos (donde se realizan propuestas, se valoran económicamente y se vota con el dinero disponible), un proceso de planificación estratégica, la redacción colaborativa de un reglamento o norma, el diseño de un espacio urbano o la producción de un plan de políticas públicas.</p>\n"
           page: "<p>Un <strong>proceso participativo</strong> es una secuencia de actividades participativas (p.e. primero rellenar una encuesta, luego realizar propuestas, debatirlas en encuentros presenciales o virtuales, y finalmente priorizarlas) con el objetivo de definir y tomar una decisión sobre un tema específico.</p> <p>Ejemplos de procesos participativos son: un proceso de elección de los miembros de un comité (donde primero se presentan unas candidaturas, luego se debate y finalmente se elige una candidatura), presupuestos participativos (donde se realizan propuestas, se valoran económicamente y se vota con el dinero disponible), un proceso de planificación estratégica, la redacción colaborativa de un reglamento o norma, el diseño de un espacio urbano o la producción de un plan de políticas públicas.</p>\n"
-          title: '¿Qué es un proceso participativo?'
+          title: "¿Qué es un proceso participativo?"
     menu:
       processes: Procesos
     metrics:

--- a/decidim-participatory_processes/config/locales/eu.yml
+++ b/decidim-participatory_processes/config/locales/eu.yml
@@ -19,6 +19,7 @@ eu:
         participatory_process_group_id: Prozesu-multzoa
         participatory_scope: Zer erabaki
         participatory_structure: Nola erabakitzen da?
+        private_space: Concertation privée
         promoted: Nabarmendua
         published_at: Argitaratu at
         scope_id: Esparrua
@@ -71,6 +72,7 @@ eu:
         duplicate: Kopiatu
         edit: Editatu
         new: New
+        new_process: Yeni süreç
         new_process_group: Prozesu talde berria
         new_process_step: Urrats berria
         new_process_user_role: Prozesu berria erabiltzailea

--- a/decidim-participatory_processes/config/locales/fi-pl.yml
+++ b/decidim-participatory_processes/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -18,6 +19,7 @@ fi-pl:
         participatory_process_group_id: Prosessiryhmä
         participatory_scope: Mitä päätetään
         participatory_structure: Miten päätetään
+        private_space: Concertation privée
         promoted: Korostettu
         published_at: Julkaisuaika
         scope_id: Teema
@@ -73,6 +75,8 @@ fi-pl:
         new_process_group: Uusi prosessiryhmä
         new_process_step: Uusi vaihe
         new_process_user_role: Uusi prosessikäyttäjä
+        participatory_process:
+          new: New process
         preview: Esikatsele
         publish: Julkaise
         resend_invitation: Lähetä kutsu uudelleen
@@ -203,6 +207,9 @@ fi-pl:
         index:
           not_published: Ei julkaistu
           private: Yksityinen
+          promoted:
+            'false': 'False'
+            'true': 'True'
           public: Julkinen
           published: Julkaistu
         new:

--- a/decidim-participatory_processes/config/locales/fi.yml
+++ b/decidim-participatory_processes/config/locales/fi.yml
@@ -19,6 +19,7 @@ fi:
         participatory_process_group_id: Prosessiryhmä
         participatory_scope: Mitä päätetään
         participatory_structure: Miten päätetään
+        private_space: Concertation privée
         promoted: Korostettu
         published_at: Julkaisuaika
         scope_id: Teema
@@ -71,6 +72,7 @@ fi:
         duplicate: Kopioi
         edit: Muokkaa
         new: New
+        new_process: Yeni süreç
         new_process_group: Uusi prosessiryhmä
         new_process_step: Uusi vaihe
         new_process_user_role: Uusi prosessikäyttäjä

--- a/decidim-participatory_processes/config/locales/fr.yml
+++ b/decidim-participatory_processes/config/locales/fr.yml
@@ -72,6 +72,7 @@ fr:
         duplicate: Dupliquer
         edit: Modifier
         new: Nouveau
+        new_process: Yeni süreç
         new_process_group: Nouveau groupe de concertations
         new_process_step: Nouvelle étape
         new_process_user_role: Nouvel utilisateur de la concertation

--- a/decidim-participatory_processes/config/locales/gl.yml
+++ b/decidim-participatory_processes/config/locales/gl.yml
@@ -19,6 +19,7 @@ gl:
         participatory_process_group_id: Grupo de procesos
         participatory_scope: O que se decide
         participatory_structure: Como se decide
+        private_space: Concertation privée
         promoted: Promocionado
         published_at: Publicado en
         scope_id: Alcance
@@ -71,6 +72,7 @@ gl:
         duplicate: Duplicar
         edit: Editar
         new: New
+        new_process: Yeni süreç
         new_process_group: Novo grupo de procesos
         new_process_step: Novo paso
         new_process_user_role: Novo usuario do proceso

--- a/decidim-participatory_processes/config/locales/hu.yml
+++ b/decidim-participatory_processes/config/locales/hu.yml
@@ -19,6 +19,7 @@ hu:
         participatory_process_group_id: Folyamat csoport
         participatory_scope: Mi a döntés
         participatory_structure: Hogyan döntenek
+        private_space: Concertation privée
         promoted: Támogatott
         published_at: Közzétéve
         scope_id: Hatáskör
@@ -71,6 +72,7 @@ hu:
         duplicate: Duplikálás
         edit: Szerkesztés
         new: New
+        new_process: Yeni süreç
         new_process_group: Új folyamat csoport
         new_process_step: Új lépés
         new_process_user_role: Új folyamat felhasználó

--- a/decidim-participatory_processes/config/locales/id-ID.yml
+++ b/decidim-participatory_processes/config/locales/id-ID.yml
@@ -1,382 +1,403 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       participatory_process:
-        announcement: Pengumuman
-        banner_image: Gambar spanduk
-        copy_categories: Salin kategori
-        copy_components: Salin komponen
-        copy_steps: Salin langkah
-        description: Deskripsi
-        developer_group: Grup promotor
+        announcement: Announcement
+        banner_image: Banner image
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_steps: Copy steps
+        description: Description
+        developer_group: Promoter group
         domain: Domain
-        end_date: Tanggal akhir
-        hashtag: Tanda pagar
-        hero_image: Gambar rumah
-        local_area: Area organisasi
-        meta_scope: Ruang lingkup metadata
-        participatory_process_group_id: Kelompok proses
-        participatory_scope: Apa yang diputuskan
-        participatory_structure: Bagaimana cara memutuskannya
-        promoted: Dipromosikan
-        published_at: Diterbitkan di
-        scope_id: Cakupan
-        scopes_enabled: Lingkup diaktifkan
-        short_description: Deskripsi Singkat
-        show_statistics: Tampilkan statistik
-        slug: Siput URL
-        start_date: Mulai tanggal
+        end_date: End date
+        hashtag: Hashtag
+        hero_image: Home image
+        local_area: Organization area
+        meta_scope: Scope metadata
+        participatory_process_group_id: Processes group
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: Concertation privée
+        promoted: Promoted
+        published_at: Published at
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
+        slug: URL slug
+        start_date: Start date
         subtitle: Subtitle
-        target: Yang berpartisipasi
-        title: Judul
+        target: Who participates
+        title: Title
       participatory_process_group:
-        description: Deskripsi
-        hero_image: Gambar
-        name: Nama
-        participatory_process_ids: Proses terkait
+        description: Description
+        hero_image: Image
+        name: Name
+        participatory_process_ids: Related processes
       participatory_process_step:
         cta_path: Call to Action path
-        cta_text: Teks Ajakan Bertindak
-        description: Deskripsi
-        end_date: Tanggal akhir
-        short_description: Deskripsi Singkat
-        start_date: Mulai tanggal
-        title: Judul
+        cta_text: Call to Action text
+        description: Description
+        end_date: End date
+        short_description: Short description
+        start_date: Start date
+        title: Title
       participatory_process_user_role:
-        email: E-mail
-        name: Nama
-        role: Peran
+        email: Email
+        name: Name
+        role: Role
     models:
-      decidim/participatory_process_step_activated_event: Langkah diaktifkan
-      decidim/participatory_process_step_changed_event: Langkah berubah
+      decidim/participatory_process_step_activated_event: Step activated
+      decidim/participatory_process_step_changed_event: Step changed
   activerecord:
     models:
       decidim/participatory_process:
-        other: Proses partisipatif
+        one: Participatory process
+        other: Participatory processes
       decidim/participatory_process_group:
-        other: Kelompok proses partisipatif
+        one: Participatory process group
+        other: Participatory process groups
       decidim/participatory_process_step:
-        other: Tangga
+        one: Step
+        other: Steps
   decidim:
     admin:
       actions:
-        activate: Mengaktifkan
-        configure: Konfigurasikan
-        confirm_destroy: Konfirmasikan penghapusan
-        destroy: Menghapus
-        duplicate: Duplikat
+        activate: Activate
+        configure: Configure
+        confirm_destroy: Confirm delete
+        destroy: Delete
+        duplicate: Duplicate
         edit: Edit
-        new_process: Proses baru
-        new_process_group: Grup proses baru
-        new_process_step: Langkah baru
-        new_process_user_role: Pengguna proses baru
+        new: New
+        new_process: Yeni süreç
+        new_process_group: New process group
+        new_process_step: New step
+        new_process_user_role: New process user
+        participatory_process:
+          new: New process
         preview: Preview
-        publish: Menerbitkan
-        resend_invitation: Mengirim kembali undangan
-        unpublish: Batalkan publikasi
+        publish: Publish
+        resend_invitation: Resend invitation
+        unpublish: Unpublish
       menu:
-        participatory_process_groups: Kelompok proses
-        participatory_processes: Proses
+        participatory_process_groups: Process groups
+        participatory_processes: Processes
         participatory_processes_submenu:
-          attachment_collections: Folder
-          attachment_files: File
-          attachments: Lampiran
-          categories: Kategori
-          components: Komponen
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
           info: Info
-          moderations: Moderasi
-          private_users: Pengguna Pribadi
-          process_admins: Memproses pengguna
-          steps: Tangga
+          moderations: Moderations
+          private_users: Private Users
+          process_admins: Process users
+          steps: Steps
       models:
         participatory_process:
           fields:
-            created_at: Dibuat di
-            private: Pribadi
-            promoted: Disorot
-            published: Diterbitkan
-            title: Judul
-          name: Proses partisipatif
+            created_at: Created at
+            private: Private
+            promoted: Highlighted
+            published: Published
+            title: Title
+          name: Participatory process
         participatory_process_group:
           fields:
-            name: Nama
-          name: Kelompok proses
+            name: Name
+          name: Process group
         participatory_process_step:
           fields:
-            end_date: Tanggal akhir
-            start_date: Mulai tanggal
-            title: Judul
-          name: Langkah proses partisipatif
+            end_date: End date
+            start_date: Start date
+            title: Title
+          name: Participatory process step
         participatory_process_user_role:
           fields:
-            email: E-mail
-            name: Nama
-            role: Peran
-          name: Pengguna proses partisipatif
+            email: Email
+            name: Name
+            role: Role
+          name: Participatory process user
           roles:
             admin: Administrator
-            collaborator: Kolaborator
+            collaborator: Collaborator
             moderator: Moderator
         user:
           fields:
-            invitation_accepted_at: Undangan diterima di
-            invitation_sent_at: Undangan dikirim pada
+            invitation_accepted_at: Invitation accepted at
+            invitation_sent_at: Invitation sent at
       participatory_process_copies:
         new:
-          copy: Salinan
-          select: Pilih data mana yang ingin Anda gandakan
-          title: Proses partisipatif duplikat
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate participatory process
       participatory_process_groups:
         destroy:
-          success: Kelompok proses partisipatif berhasil dihapus.
+          success: Participatory process group deleted successfully.
         edit:
-          title: Edit grup proses
-          update: Memperbarui
+          title: Edit process group
+          update: Update
         new:
-          create: Membuat
-          title: Grup proses baru
+          create: Create
+          title: New process group
         update:
-          error: Terjadi kesalahan saat memutakhirkan grup proses partisipatif ini.
-          success: Kelompok proses partisipatif berhasil diperbarui.
+          error: There was en error updating this participatory process group.
+          success: Participatory process group updated successfully.
       participatory_process_publications:
         create:
-          error: Terjadi kesalahan saat mempublikasikan proses partisipatif ini.
-          success: Proses partisipatif berhasil diterbitkan.
+          error: There was an error publishing this participatory process.
+          success: Participatory process published successfully.
         destroy:
-          error: Terjadi kesalahan saat membatalkan publikasi proses partisipatif ini.
-          success: Proses partisipatif tidak berhasil dipublikasikan.
+          error: There was an error unpublishing this participatory process.
+          success: Participatory process unpublished successfully.
       participatory_process_step_activations:
         create:
-          error: Terjadi kesalahan saat mengaktifkan langkah proses partisipatif ini.
-          success: Langkah proses partisipatif berhasil diaktifkan.
+          error: There was an error activating this participatory process step.
+          success: Participatory process step activated successfully.
       participatory_process_steps:
         create:
-          error: Terjadi kesalahan saat membuat langkah proses partisipatif baru.
-          success: Langkah proses partisipatif berhasil dibuat.
-        default_title: pengantar
+          error: There was an error creating a new participatory process step.
+          success: Participatory process step created successfully.
+        default_title: Introduction
         destroy:
           error:
-            active_step: Tidak dapat menghapus langkah aktif.
-            last_step: Tidak dapat menghapus langkah terakhir dari suatu proses.
-          success: Langkah proses partisipatif berhasil dihapus.
+            active_step: Can't delete the active step.
+            last_step: Can't delete the last step of a process.
+          success: Participatory process step deleted successfully.
         edit:
-          title: Edit langkah proses partisipatif
-          update: Memperbarui
+          title: Edit participatory process step
+          update: Update
         index:
-          steps_title: Tangga
+          steps_title: Steps
         new:
-          create: Membuat
-          title: Langkah proses partisipatif baru
+          create: Create
+          title: New participatory process step
         ordering:
-          error: Ada kesalahan saat menata ulang langkah-langkah proses partisipatif ini.
+          error: There was an error when reordering this participatory process steps.
         update:
-          error: Ada kesalahan saat memperbarui langkah proses partisipatif ini.
-          success: Langkah proses partisipatif berhasil diperbarui.
+          error: There was an error when updating this participatory process step.
+          success: Participatory process step updated successfully.
       participatory_process_user_roles:
         create:
-          error: Terjadi kesalahan saat menambahkan pengguna untuk proses partisipatif ini.
-          success: Pengguna berhasil ditambahkan ke proses partisipatif ini.
+          error: There was an error adding a user for this participatory process.
+          success: User added successfully to this participatory process.
         destroy:
-          success: Pengguna berhasil dihapus dari proses partisipatif ini.
+          success: User removed successfully from this participatory process.
         edit:
-          title: Perbarui pengguna proses partisipatif.
-          update: Memperbarui
+          title: Update participatory process user.
+          update: Update
         index:
-          process_admins_title: Pengguna proses partisipatif
+          process_admins_title: Participatory process users
         new:
-          create: Membuat
-          title: Pengguna proses partisipatif baru.
+          create: Create
+          title: New participatory process user.
         update:
-          error: Terjadi kesalahan saat memperbarui pengguna untuk proses partisipatif ini.
-          success: Pengguna berhasil diperbarui untuk proses partisipatif ini.
+          error: There was an error updated a user for this participatory process.
+          success: User updated successfully for this participatory process.
       participatory_processes:
         create:
-          error: Terjadi kesalahan saat membuat proses partisipatif baru.
-          success: Proses partisipatif berhasil dibuat. Konfigurasikan sekarang langkahnya.
+          error: There was an error creating a new participatory process.
+          success: Participatory process created successfully. Configure now its steps.
         edit:
-          update: Memperbarui
+          update: Update
         form:
-          title: Informasi Umum
+          title: General Information
         index:
-          not_published: Tidak diterbitkan
-          private: Pribadi
-          public: Publik
-          published: Diterbitkan
+          not_published: Not published
+          private: Private
+          promoted:
+            'false': 'False'
+            'true': 'True'
+          public: Public
+          published: Published
         new:
-          create: Membuat
-          title: Proses partisipatif baru
+          create: Create
+          title: New participatory process
         update:
-          error: Ada kesalahan saat memperbarui proses partisipatif ini.
-          success: Proses partisipatif berhasil diperbarui.
+          error: There was an error when updating this participatory process.
+          success: Participatory process updated successfully.
       participatory_processes_copies:
         create:
-          error: Ada kesalahan saat menduplikasi proses partisipatif ini.
-          success: Proses partisipatif berhasil digandakan.
+          error: There was an error when duplicating this participatory process.
+          success: Participatory process duplicated successfully.
       participatory_processes_group:
         create:
-          error: Terjadi kesalahan saat membuat grup proses partisipatif baru.
-          success: Kelompok proses partisipatif berhasil dibuat.
+          error: There was an error creating a new participatory process group.
+          success: Participatory process group created successfully.
       titles:
-        participatory_process_groups: Kelompok proses partisipatif
-        participatory_processes: Proses partisipatif
+        participatory_process_groups: Participatory process groups
+        participatory_processes: Participatory processes
       users:
         resend_invitation:
-          error: Terjadi kesalahan saat mengirim ulang undangan.
-          success: Undangan berhasil dikirim.
+          error: There was an error resending the invitation.
+          success: Invitation resent successfully.
     admin_log:
       participatory_process:
-        create: "%{user_name} membuat proses %{resource_name} partisipatif"
-        publish: "%{user_name} mempublikasikan %{resource_name} proses partisipatif"
-        unpublish: "%{user_name} tidak mempublikasi %{resource_name} proses partisipatif"
-        update: "%{user_name} memperbarui %{resource_name} proses partisipatif"
+        create: "%{user_name} created the %{resource_name} participatory process"
+        publish: "%{user_name} published the %{resource_name} participatory process"
+        unpublish: "%{user_name} unpublished the %{resource_name} participatory process"
+        update: "%{user_name} updated the %{resource_name} participatory process"
       participatory_process_step:
-        activate: "%{user_name} mengaktifkan %{resource_name} langkah dalam %{space_name} proses partisipatif"
-        create: "%{user_name} membuat %{resource_name} langkah dalam %{space_name} proses partisipatif"
-        delete: "%{user_name} menghapus %{resource_name} langkah dalam %{space_name} proses partisipatif"
-        update: "%{user_name} memperbarui %{resource_name} langkah dalam %{space_name} proses partisipatif"
+        activate: "%{user_name} activated the %{resource_name} step in the %{space_name} participatory process"
+        create: "%{user_name} created the %{resource_name} step in the %{space_name} participatory process"
+        delete: "%{user_name} deleted the %{resource_name} step in the %{space_name} participatory process"
+        update: "%{user_name} updated the %{resource_name} step in the %{space_name} participatory process"
       participatory_process_user_role:
-        create: "%{user_name} mengundang pengguna %{resource_name} ke %{space_name} proses partisipatif"
-        delete: "%{user_name} mengeluarkan pengguna %{resource_name} dari %{space_name} proses partisipatif"
-        update: "%{user_name} mengubah peran pengguna %{resource_name} dalam %{space_name} proses partisipatif"
+        create: "%{user_name} invited the user %{resource_name} to the %{space_name} participatory process"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} participatory process"
+        update: "%{user_name} changed the role of the user %{resource_name} in the %{space_name} participatory process"
     events:
       participatory_process:
         step_activated:
-          email_intro: 'Langkah %{resource_title} sekarang aktif untuk %{participatory_space_title}. Anda dapat melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Pembaruan ke %{participatory_space_title}
-          notification_title: Langkah %{resource_title} sekarang aktif untuk <a href="%{resource_path}">%{participatory_space_title}</a>
+          email_intro: 'The %{resource_title} step is now active for %{participatory_space_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The %{resource_title} step is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
         step_changed:
-          email_intro: 'Tanggal untuk %{resource_title} langkah pada %{participatory_space_title} telah diperbarui. Anda dapat melihatnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Pembaruan ke %{participatory_space_title}
-          notification_title: Tanggal untuk langkah <a href="%{resource_path}">%{resource_title}</a> pada <a href="%{participatory_space_url}">%{participatory_space_title}</a> telah diperbarui.
+          email_intro: 'The dates for the %{resource_title} step at %{participatory_space_title} have been updated. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The dates for the <a href="%{resource_path}">%{resource_title}</a> step at <a href="%{participatory_space_url}">%{participatory_space_title}</a> have been updated.
     help:
       participatory_spaces:
         participatory_processes:
-          contextual: "<p>A <strong>proses partisipatif</strong> adalah urutan kegiatan partisipatif (misalnya pertama mengisi survei, kemudian membuat proposal, mendiskusikannya dalam pertemuan tatap muka atau virtual, dan akhirnya memprioritaskan mereka) dengan tujuan mendefinisikan dan membuat keputusan pada topik tertentu.</p> <p>Contoh proses partisipatif adalah: proses pemilihan anggota komite (di mana pencalonan pertama kali disajikan, kemudian diperdebatkan dan akhirnya terpilih sebagai kandidat), anggaran partisipatif (di mana proposal dibuat, dihargai secara ekonomi dan dipilih dengan uang yang tersedia), proses perencanaan strategis, penyusunan kolaboratif peraturan atau norma, desain ruang kota atau produksi rencana kebijakan publik.</p>\n"
-          page: "<p>A <strong>proses partisipatif</strong> adalah urutan kegiatan partisipatif (misalnya pertama mengisi survei, kemudian membuat proposal, mendiskusikannya dalam pertemuan tatap muka atau virtual, dan akhirnya memprioritaskan mereka) dengan tujuan mendefinisikan dan membuat keputusan pada topik tertentu.</p> <p>Contoh proses partisipatif adalah: proses pemilihan anggota komite (di mana pencalonan pertama kali disajikan, kemudian diperdebatkan dan akhirnya terpilih sebagai kandidat), anggaran partisipatif (di mana proposal dibuat, dihargai secara ekonomi dan dipilih dengan uang yang tersedia), proses perencanaan strategis, penyusunan kolaboratif peraturan atau norma, desain ruang kota atau produksi rencana kebijakan publik.</p>\n"
-          title: Apa itu proses partisipatif?
+          contextual: "<p>A <strong>participatory process</strong> is a sequence of participatory activities (e.g. first filling out a survey, then making proposals, discussing them in face-to-face or virtual meetings, and finally prioritizing them) with the aim of defining and making a decision on a specific topic.</p> <p>Examples of participatory processes are: a process of electing committee members (where candidatures are first presented, then debated and finally a candidacy is chosen), participatory budgets (where proposals are made, valued economically and voted on with the money available), a strategic planning process, the collaborative drafting of a regulation or norm, the design of an urban space or the production of a public policy plan.</p>\n"
+          page: "<p>A <strong>participatory process</strong> is a sequence of participatory activities (e.g. first filling out a survey, then making proposals, discussing them in face-to-face or virtual meetings, and finally prioritizing them) with the aim of defining and making a decision on a specific topic.</p> <p>Examples of participatory processes are: a process of electing committee members (where candidatures are first presented, then debated and finally a candidacy is chosen), participatory budgets (where proposals are made, valued economically and voted on with the money available), a strategic planning process, the collaborative drafting of a regulation or norm, the design of an urban space or the production of a public policy plan.</p>\n"
+          title: What is a participatory process?
     menu:
-      processes: Proses
+      processes: Processes
     metrics:
       participatory_processes:
-        description: Jumlah proses partisipatif dalam organisasi ini
-        object: proses partisipatif
-        title: Proses partisipatif
+        description: Number of participatory processes in this organization
+        object: participatory processes
+        title: Participatory processes
+    pages:
+      participatory_space:
+        metrics:
+          headline: Participation in figures
+          link: Show all statistics
     participatory_process_groups:
       show:
         group_participatory_processes:
-          other: "%{count} proses untuk %{group}"
-        title: Kelompok proses partisipatif
+          one: 1 processes for %{group}
+          other: "%{count} processes for %{group}"
+        title: Participatory process groups
     participatory_process_steps:
       index:
-        process_steps: Langkah-langkah proses
-        title: Langkah-langkah proses partisipatif
+        process_steps: Process steps
+        title: Participatory process steps
     participatory_processes:
       admin:
         content_blocks:
           highlighted_processes:
-            max_results: Jumlah maksimum elemen untuk ditampilkan
+            max_results: Maximum amount of elements to show
         participatory_process_copies:
           form:
-            slug_help: 'Slug URL digunakan untuk menghasilkan URL yang mengarah ke proses ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         participatory_process_steps:
           form:
-            cta_path_help: 'Gunakan jalur parsial, bukan URL lengkap di sini. Menerima surat, angka, tanda pisah dan garis miring, dan harus dimulai dengan huruf. Jika tidak disetel, tombol tidak akan ditampilkan. Contoh: %{url}'
-            cta_text_help: Jika tidak disetel, tombol tidak akan ditampilkan.
+            cta_path_help: 'Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. If not set, the button will not be shown. Example: %{url}'
+            cta_text_help: If not set, the button will not be shown.
         participatory_processes:
           form:
-            announcement_help: Teks yang Anda masukkan di sini akan ditampilkan kepada pengguna tepat di bawah informasi proses.
-            slug_help: 'Slug URL digunakan untuk menghasilkan URL yang mengarah ke proses ini. Hanya menerima huruf, angka, dan tanda hubung, dan harus dimulai dengan huruf. Contoh: %{url}'
+            announcement_help: The text you enter here will be shown to the user right below the process information.
+            slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
       content_blocks:
         highlighted_processes:
-          name: Proses yang disorot
+          name: Highlighted processes
       index:
-        title: Proses partisipatif
+        title: Participatory processes
       last_activity:
-        new_participatory_process: Proses partisipatif baru
+        new_participatory_process: New participatory process
       pages:
         home:
           highlighted_processes:
-            active_processes: Proses aktif
-            active_step: Langkah aktif
-            more_information: Informasi lebih lanjut
-            participate: Ikut
-            see_all_processes: Lihat semua proses
+            active_processes: Active processes
+            active_step: Active step
+            more_information: More information
+            participate: Participate
+            see_all_processes: See all processes
       participatory_process_groups:
-        none: Tidak ada
+        none: None
       participatory_processes:
         filters:
           counters:
             active:
-              other: "%{count} proses aktif"
+              one: 1 active process
+              other: "%{count} active processes"
             all:
-              other: "%{count} proses"
+              one: 1 process
+              other: "%{count} processes"
             past:
-              other: "%{count} proses sebelumnya"
+              one: 1 past process
+              other: "%{count} past processes"
             upcoming:
-              other: "%{count} proses yang akan datang"
+              one: 1 upcoming process
+              other: "%{count} upcoming processes"
           explanations:
-            no_active: Tidak ada proses aktif
-            no_active_nor_upcoming: Tidak ada proses aktif atau yang akan datang
-            no_active_nor_upcoming_callout: Tidak ada proses aktif atau yang akan datang. Berikut ini daftar daftar yang lalu.
+            no_active: No active processes
+            no_active_nor_upcoming: No active nor upcoming processes
+            no_active_nor_upcoming_callout: There are no active nor upcoming processes. Here is a list of the past ones.
           names:
-            active: Aktif
-            all: Semua
-            past: Lalu
-            upcoming: Mendatang
-          see: Lihat
+            active: Active
+            all: All
+            past: Past
+            upcoming: Upcoming
+          see: See
         index:
-          loading: Memuat hasil ...
+          loading: Loading results...
       show:
-        developer_group: Grup promotor
-        end_date: Tanggal akhir
-        local_area: Wilayah Organisasi
-        participatory_scope: Apa yang diputuskan
-        participatory_structure: Bagaimana cara memutuskannya
-        private_space: Ini adalah proses pribadi
-        scope: Cakupan
-        start_date: Mulai tanggal
-        target: Yang berpartisipasi
-        unspecified: Tidak ditentukan
+        developer_group: Promoter group
+        end_date: End date
+        local_area: Organization Area
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: This is a private process
+        scope: Scope
+        start_date: Start date
+        target: Who participates
+        unspecified: Not specified
       statistics:
-        answers_count: Jawaban
-        comments_count: Komentar
-        debates_count: Perdebatan
-        endorsements_count: Endorsemen
-        headline: Aktivitas
-        meetings_count: Rapat
-        orders_count: Suara
-        pages_count: Halaman
-        processes_count: Proses
-        projects_count: Proyek
-        proposals_count: Proposal
-        results_count: Hasil
-        surveys_count: Survei
-        users_count: Peserta
-        votes_count: Suara
+        answers_count: Answers
+        comments_count: Comments
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        processes_count: Processes
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
   layouts:
     decidim:
       participatory_process_groups:
         participatory_process_group:
-          browse: Jelajahi
-          processes_count: 'Proses:'
+          browse: Browse
+          processes_count: 'Processes:'
       participatory_process_widgets:
         show:
-          active_step: Langkah aktif
-          take_part: Ambil bagian
+          active_step: Active step
+          take_part: Take part
       participatory_processes:
         index:
-          promoted_processes: Proses yang disorot
+          promoted_processes: Highlighted processes
         participatory_process:
-          active_step: 'Langkah saat ini:'
-          take_part: Ambil bagian
+          active_step: 'Current step:'
+          take_part: Take part
         promoted_process:
-          active_step: 'Langkah saat ini:'
-          more_info: Info lebih lanjut
-          take_part: Ambil bagian
+          active_step: 'Current step:'
+          more_info: More info
+          take_part: Take part
       process_header_steps:
-        step: Langkah %{current} dari %{total}
-        view_steps: Lihat langkah
+        step: Step %{current} of %{total}
+        view_steps: View steps
       process_navigation:
-        process_menu_item: Proses
+        process_menu_item: The process

--- a/decidim-participatory_processes/config/locales/it.yml
+++ b/decidim-participatory_processes/config/locales/it.yml
@@ -19,6 +19,7 @@ it:
         participatory_process_group_id: Gruppo di processi
         participatory_scope: Cosa è deciso
         participatory_structure: Come è deciso?
+        private_space: Concertation privée
         promoted: Promossa
         published_at: Pubblicato a
         scope_id: Objetivos
@@ -71,6 +72,7 @@ it:
         duplicate: Duplica
         edit: Modifica
         new: New
+        new_process: Yeni süreç
         new_process_group: Nuovo gruppo di processi
         new_process_step: Nuovo passo
         new_process_user_role: Nuovo utente del processo

--- a/decidim-participatory_processes/config/locales/nl.yml
+++ b/decidim-participatory_processes/config/locales/nl.yml
@@ -19,6 +19,7 @@ nl:
         participatory_process_group_id: Groep thema's
         participatory_scope: Wat wordt besloten
         participatory_structure: Hoe is het besloten
+        private_space: Concertation privée
         promoted: Gepromoveerd
         published_at: Gepubliceerd op
         scope_id: Scope
@@ -71,6 +72,7 @@ nl:
         duplicate: Dupliceren
         edit: Bewerken
         new: New
+        new_process: Yeni süreç
         new_process_group: Nieuwe procesgroep
         new_process_step: Nieuwe stap
         new_process_user_role: Nieuwe procesgebruiker

--- a/decidim-participatory_processes/config/locales/pl.yml
+++ b/decidim-participatory_processes/config/locales/pl.yml
@@ -19,6 +19,7 @@ pl:
         participatory_process_group_id: Grupa procesów
         participatory_scope: Co postanowiono
         participatory_structure: Jak to się decyduje
+        private_space: Concertation privée
         promoted: Lansowany
         published_at: Opublikowano na
         scope_id: Zakres
@@ -77,6 +78,7 @@ pl:
         duplicate: Duplikat
         edit: Edytuj
         new: New
+        new_process: Yeni süreç
         new_process_group: Nowa grupa procesów
         new_process_step: Nowy krok
         new_process_user_role: Nowy użytkownik procesu

--- a/decidim-participatory_processes/config/locales/pt-BR.yml
+++ b/decidim-participatory_processes/config/locales/pt-BR.yml
@@ -19,6 +19,7 @@ pt-BR:
         participatory_process_group_id: Grupo de processos
         participatory_scope: O que é decidido
         participatory_structure: Como é decidido
+        private_space: Concertation privée
         promoted: Destacado
         published_at: Publicado em
         scope_id: Âmbito
@@ -71,6 +72,7 @@ pt-BR:
         duplicate: Duplicar
         edit: Editar
         new: New
+        new_process: Yeni süreç
         new_process_group: Novo grupo de processos
         new_process_step: Novo passo
         new_process_user_role: Novo usuário do processo

--- a/decidim-participatory_processes/config/locales/pt.yml
+++ b/decidim-participatory_processes/config/locales/pt.yml
@@ -19,6 +19,7 @@ pt:
         participatory_process_group_id: Grupo de processos
         participatory_scope: O que é decidido
         participatory_structure: Como é decidido
+        private_space: Concertation privée
         promoted: Destacado
         published_at: Publicado em
         scope_id: Âmbito
@@ -71,6 +72,7 @@ pt:
         duplicate: Duplicar
         edit: Editar
         new: New
+        new_process: Yeni süreç
         new_process_group: Novo grupo de processos
         new_process_step: Novo passo
         new_process_user_role: Novo usuário do processo

--- a/decidim-participatory_processes/config/locales/ru.yml
+++ b/decidim-participatory_processes/config/locales/ru.yml
@@ -19,6 +19,7 @@ ru:
         participatory_process_group_id: Группа движений
         participatory_scope: Что решается
         participatory_structure: Как это решается
+        private_space: Concertation privée
         promoted: Рекомендуется
         published_at: 'Обнародовано:'
         scope_id: Охват
@@ -77,6 +78,7 @@ ru:
         duplicate: Создать копию
         edit: Редактировать
         new: New
+        new_process: Yeni süreç
         new_process_group: Создать группу движений
         new_process_step: Новый шаг
         new_process_user_role: Добавить участника движения

--- a/decidim-participatory_processes/config/locales/sv.yml
+++ b/decidim-participatory_processes/config/locales/sv.yml
@@ -19,6 +19,7 @@ sv:
         participatory_process_group_id: Processgrupp
         participatory_scope: Vad som bestäms
         participatory_structure: Hur det bestäms
+        private_space: Concertation privée
         promoted: Främjad
         published_at: Publicerad vid
         scope_id: Omfattning
@@ -71,6 +72,7 @@ sv:
         duplicate: Duplicera
         edit: Redigera
         new: New
+        new_process: Yeni süreç
         new_process_group: Ny processgrupp
         new_process_step: Nytt steg
         new_process_user_role: Ny processanvändare

--- a/decidim-participatory_processes/config/locales/tr-TR.yml
+++ b/decidim-participatory_processes/config/locales/tr-TR.yml
@@ -1,390 +1,403 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       participatory_process:
-        announcement: duyuru
-        banner_image: Banner resmi
-        copy_categories: Kategorileri kopyala
-        copy_components: Bileşenleri kopyala
-        copy_steps: Adımları kopyala
-        description: Açıklama
-        developer_group: Tanıtım grubu
-        domain: domain
-        end_date: Bitiş tarihi
-        hashtag: Başlık etiketi
-        hero_image: Ana resim
-        local_area: Organizasyon alanı
-        meta_scope: Kapsam meta verileri
-        participatory_process_group_id: Süreçleri grubu
-        participatory_scope: Karar nedir
-        participatory_structure: Nasıl karar verilir
-        promoted: Tanıtılan
-        published_at: Yayınlandı
-        scope_id: kapsam
-        scopes_enabled: Kapsamlar etkin
-        short_description: Kısa Açıklama
-        show_statistics: İstatistikleri göster
-        slug: URL sümüklü böcek
-        start_date: Başlangıç tarihi
-        subtitle: Alt yazı
-        target: Kimler katılır
-        title: Başlık
+        announcement: Announcement
+        banner_image: Banner image
+        copy_categories: Copy categories
+        copy_components: Copy components
+        copy_steps: Copy steps
+        description: Description
+        developer_group: Promoter group
+        domain: Domain
+        end_date: End date
+        hashtag: Hashtag
+        hero_image: Home image
+        local_area: Organization area
+        meta_scope: Scope metadata
+        participatory_process_group_id: Processes group
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: Concertation privée
+        promoted: Promoted
+        published_at: Published at
+        scope_id: Scope
+        scopes_enabled: Scopes enabled
+        short_description: Short description
+        show_statistics: Show statistics
+        slug: URL slug
+        start_date: Start date
+        subtitle: Subtitle
+        target: Who participates
+        title: Title
       participatory_process_group:
-        description: Açıklama
-        hero_image: görüntü
-        name: isim
-        participatory_process_ids: İlgili süreçler
+        description: Description
+        hero_image: Image
+        name: Name
+        participatory_process_ids: Related processes
       participatory_process_step:
-        cta_path: Eylem yolunu çağır
-        cta_text: Harekete Geçirici Mesaj metni
-        description: Açıklama
-        end_date: Bitiş tarihi
-        short_description: Kısa Açıklama
-        start_date: Başlangıç tarihi
-        title: Başlık
+        cta_path: Call to Action path
+        cta_text: Call to Action text
+        description: Description
+        end_date: End date
+        short_description: Short description
+        start_date: Start date
+        title: Title
       participatory_process_user_role:
-        email: E-posta
-        name: isim
-        role: rol
+        email: Email
+        name: Name
+        role: Role
     models:
-      decidim/participatory_process_step_activated_event: Adım aktif
-      decidim/participatory_process_step_changed_event: Adım değişti
+      decidim/participatory_process_step_activated_event: Step activated
+      decidim/participatory_process_step_changed_event: Step changed
   activerecord:
     models:
       decidim/participatory_process:
-        one: Katılımcı süreç
-        other: Katılımcı süreçler
+        one: Participatory process
+        other: Participatory processes
       decidim/participatory_process_group:
-        one: Katılımcı süreç grubu
-        other: Katılımcı süreç grupları
+        one: Participatory process group
+        other: Participatory process groups
       decidim/participatory_process_step:
-        one: Adım
-        other: adımlar
+        one: Step
+        other: Steps
   decidim:
     admin:
       actions:
-        activate: etkinleştirmek
-        configure: Yapılandır
-        confirm_destroy: Silmeyi onayla
-        destroy: silmek
-        duplicate: Çift
-        edit: Düzenle
+        activate: Activate
+        configure: Configure
+        confirm_destroy: Confirm delete
+        destroy: Delete
+        duplicate: Duplicate
+        edit: Edit
+        new: New
         new_process: Yeni süreç
-        new_process_group: Yeni işlem grubu
-        new_process_step: Yeni adım
-        new_process_user_role: Yeni işlem kullanıcısı
-        preview: Ön izleme
-        publish: Yayınla
-        resend_invitation: Yeniden gönderme daveti
-        unpublish: Yayından Kaldır
+        new_process_group: New process group
+        new_process_step: New step
+        new_process_user_role: New process user
+        participatory_process:
+          new: New process
+        preview: Preview
+        publish: Publish
+        resend_invitation: Resend invitation
+        unpublish: Unpublish
       menu:
-        participatory_process_groups: Süreç grupları
-        participatory_processes: Süreçler
+        participatory_process_groups: Process groups
+        participatory_processes: Processes
         participatory_processes_submenu:
-          attachment_collections: Klasörler
-          attachment_files: Dosyalar
-          attachments: Ekler
-          categories: Kategoriler
-          components: Bileşenler
-          info: Bilgi
-          moderations: Denetimler
-          private_users: Özel Kullanıcılar
-          process_admins: İşlemi gerçekleştiren kullanıcılar
-          steps: adımlar
+          attachment_collections: Folders
+          attachment_files: Files
+          attachments: Attachments
+          categories: Categories
+          components: Components
+          info: Info
+          moderations: Moderations
+          private_users: Private Users
+          process_admins: Process users
+          steps: Steps
       models:
         participatory_process:
           fields:
-            created_at: Düzenlendi
-            private: Özel
-            promoted: Vurgulanan
-            published: Yayınlanan
-            title: Başlık
-          name: Katılımcı süreç
+            created_at: Created at
+            private: Private
+            promoted: Highlighted
+            published: Published
+            title: Title
+          name: Participatory process
         participatory_process_group:
           fields:
-            name: isim
-          name: İşlem grubu
+            name: Name
+          name: Process group
         participatory_process_step:
           fields:
-            end_date: Bitiş tarihi
-            start_date: Başlangıç tarihi
-            title: Başlık
-          name: Katılımcı süreç adımı
+            end_date: End date
+            start_date: Start date
+            title: Title
+          name: Participatory process step
         participatory_process_user_role:
           fields:
-            email: E-posta
-            name: isim
-            role: rol
-          name: Katılımcı işlem kullanıcısı
+            email: Email
+            name: Name
+            role: Role
+          name: Participatory process user
           roles:
-            admin: yönetici
-            collaborator: işbirlikçi
-            moderator: arabulucu
+            admin: Administrator
+            collaborator: Collaborator
+            moderator: Moderator
         user:
           fields:
-            invitation_accepted_at: Davet kabul edildi
-            invitation_sent_at: Davetiye gönderildi
+            invitation_accepted_at: Invitation accepted at
+            invitation_sent_at: Invitation sent at
       participatory_process_copies:
         new:
-          copy: kopya
-          select: Çoğaltmak istediğiniz verileri seçin
-          title: Yinelenen katılımcı süreç
+          copy: Copy
+          select: Select which data you would like to duplicate
+          title: Duplicate participatory process
       participatory_process_groups:
         destroy:
-          success: Katılımcı süreç grubu başarıyla silindi.
+          success: Participatory process group deleted successfully.
         edit:
-          title: İşlem grubunu düzenle
-          update: Güncelleştirme
+          title: Edit process group
+          update: Update
         new:
-          create: yaratmak
-          title: Yeni işlem grubu
+          create: Create
+          title: New process group
         update:
-          error: Bu katılımcı süreç grubunu güncellemede hata oluştu.
-          success: Katılımcı süreç grubu başarıyla güncellendi.
+          error: There was en error updating this participatory process group.
+          success: Participatory process group updated successfully.
       participatory_process_publications:
         create:
-          error: Bu katılımcı süreci yayınlayan bir hata oluştu.
-          success: Katılımcı süreç başarıyla yayınlandı.
+          error: There was an error publishing this participatory process.
+          success: Participatory process published successfully.
         destroy:
-          error: Bu katılımcı süreci yayından kaldırmada bir hata oluştu.
-          success: Katılımcı süreç başarıyla yayından kaldırıldı.
+          error: There was an error unpublishing this participatory process.
+          success: Participatory process unpublished successfully.
       participatory_process_step_activations:
         create:
-          error: Bu katılımcı süreç adımı etkinleştirilirken bir hata oluştu.
-          success: Katılımcı süreç adımı başarıyla etkinleştirildi.
+          error: There was an error activating this participatory process step.
+          success: Participatory process step activated successfully.
       participatory_process_steps:
         create:
-          error: Yeni bir katılımcı süreç adımı oluştururken bir hata oluştu.
-          success: Katılımcı süreç adımı başarıyla oluşturuldu.
-        default_title: Giriş
+          error: There was an error creating a new participatory process step.
+          success: Participatory process step created successfully.
+        default_title: Introduction
         destroy:
           error:
-            active_step: Aktif adımı silemiyorum.
-            last_step: Bir işlemin son adımı silinemiyor.
-          success: Katılımcı süreç adımı başarıyla silindi.
+            active_step: Can't delete the active step.
+            last_step: Can't delete the last step of a process.
+          success: Participatory process step deleted successfully.
         edit:
-          title: Katılımcı süreç adımını düzenle
-          update: Güncelleştirme
+          title: Edit participatory process step
+          update: Update
         index:
-          steps_title: adımlar
+          steps_title: Steps
         new:
-          create: yaratmak
-          title: Yeni katılımcı süreç adımı
+          create: Create
+          title: New participatory process step
         ordering:
-          error: Bu katılımcı süreç adımlarını yeniden sıralarken bir hata oluştu.
+          error: There was an error when reordering this participatory process steps.
         update:
-          error: Bu katılımcı süreç adımı güncellenirken bir hata oluştu.
-          success: Katılımcı süreç adımı başarıyla güncellendi.
+          error: There was an error when updating this participatory process step.
+          success: Participatory process step updated successfully.
       participatory_process_user_roles:
         create:
-          error: Bu katılımcı süreç için bir kullanıcı eklenirken bir hata oluştu.
-          success: Kullanıcı bu katılımcı sürece başarıyla eklendi.
+          error: There was an error adding a user for this participatory process.
+          success: User added successfully to this participatory process.
         destroy:
-          success: Kullanıcı bu katılımcı işlemden başarıyla kaldırıldı.
+          success: User removed successfully from this participatory process.
         edit:
-          title: Katılımcı süreç kullanıcısını güncelleyin.
-          update: Güncelleştirme
+          title: Update participatory process user.
+          update: Update
         index:
-          process_admins_title: Katılımcı süreç kullanıcıları
+          process_admins_title: Participatory process users
         new:
-          create: yaratmak
-          title: Yeni katılımcı süreç kullanıcısı.
+          create: Create
+          title: New participatory process user.
         update:
-          error: Bu katılımcı işlem için bir kullanıcı güncellendi bir hata oluştu.
-          success: Kullanıcı bu katılımcı süreç için başarıyla güncellendi.
+          error: There was an error updated a user for this participatory process.
+          success: User updated successfully for this participatory process.
       participatory_processes:
         create:
-          error: Yeni bir katılımcı süreci oluştururken bir hata oluştu.
-          success: Katılımcı süreç başarıyla oluşturuldu. Şimdi adımlarını yapılandırın.
+          error: There was an error creating a new participatory process.
+          success: Participatory process created successfully. Configure now its steps.
         edit:
-          update: Güncelleştirme
+          update: Update
         form:
-          title: Genel bilgi
+          title: General Information
         index:
-          not_published: Yayınlanmadı
-          private: Özel
-          public: halka açık
-          published: Yayınlanan
+          not_published: Not published
+          private: Private
+          promoted:
+            'false': 'False'
+            'true': 'True'
+          public: Public
+          published: Published
         new:
-          create: yaratmak
-          title: Yeni katılımcı süreç
+          create: Create
+          title: New participatory process
         update:
-          error: Bu katılımcı süreci güncellerken bir hata oluştu.
-          success: Katılımcı süreç başarıyla güncellendi.
+          error: There was an error when updating this participatory process.
+          success: Participatory process updated successfully.
       participatory_processes_copies:
         create:
-          error: Bu katılımcı süreci çoğaltırken bir hata oluştu.
-          success: Katılımcı süreç başarıyla kopyalandı.
+          error: There was an error when duplicating this participatory process.
+          success: Participatory process duplicated successfully.
       participatory_processes_group:
         create:
-          error: Yeni bir katılımcı süreç grubu oluştururken bir hata oluştu.
-          success: Katılımcı süreç grubu başarıyla oluşturuldu.
+          error: There was an error creating a new participatory process group.
+          success: Participatory process group created successfully.
       titles:
-        participatory_process_groups: Katılımcı süreç grupları
-        participatory_processes: Katılımcı süreçler
+        participatory_process_groups: Participatory process groups
+        participatory_processes: Participatory processes
       users:
         resend_invitation:
-          error: Davetiye yeniden gönderilirken bir hata oluştu.
-          success: Davetiye başarıyla gönderilir.
+          error: There was an error resending the invitation.
+          success: Invitation resent successfully.
     admin_log:
       participatory_process:
-        create: "%{user_name} , %{resource_name} katılımcı süreci oluşturdu"
-        publish: "%{user_name} %{resource_name} katılımcı süreci yayınladı"
-        unpublish: "%{user_name} %{resource_name} katılımcı süreci yayından kaldırıldı"
-        update: "%{user_name} katılımcı %{resource_name} süreci güncelledi"
+        create: "%{user_name} created the %{resource_name} participatory process"
+        publish: "%{user_name} published the %{resource_name} participatory process"
+        unpublish: "%{user_name} unpublished the %{resource_name} participatory process"
+        update: "%{user_name} updated the %{resource_name} participatory process"
       participatory_process_step:
-        activate: "%{user_name} , %{space_name} katılımcı süreçte %{resource_name} adımı aktifleştirdi"
-        create: "%{user_name} , %{space_name} katılımcı süreçte %{resource_name} adımı oluşturdu"
-        delete: "%{user_name} , %{space_name} katılımcı süreçte %{resource_name} adımı sildi"
-        update: "%{user_name} , %{space_name} katılımcı süreçte %{resource_name} adımı güncelledi"
+        activate: "%{user_name} activated the %{resource_name} step in the %{space_name} participatory process"
+        create: "%{user_name} created the %{resource_name} step in the %{space_name} participatory process"
+        delete: "%{user_name} deleted the %{resource_name} step in the %{space_name} participatory process"
+        update: "%{user_name} updated the %{resource_name} step in the %{space_name} participatory process"
       participatory_process_user_role:
-        create: "%{user_name} kullanıcı %{resource_name} %{space_name} katılımcı sürece davet etti"
-        delete: "%{user_name} kullanıcı uzaklaştırıldı %{resource_name} den %{space_name} katılımcı bir süreç"
-        update: "%{user_name} , %{space_name} katılımcı sürecindeki kullanıcı %{resource_name} rolünü değiştirdi"
+        create: "%{user_name} invited the user %{resource_name} to the %{space_name} participatory process"
+        delete: "%{user_name} removed the user %{resource_name} from the %{space_name} participatory process"
+        update: "%{user_name} changed the role of the user %{resource_name} in the %{space_name} participatory process"
     events:
       participatory_process:
         step_activated:
-          email_intro: '%{resource_title} adım şimdi %{participatory_space_title}için aktif. Bu sayfadan görebilirsiniz:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{participatory_space_title}bir güncelleme'
-          notification_title: '%{resource_title} adım şimdi <a href="%{resource_path}">%{participatory_space_title}</a>için aktif'
+          email_intro: 'The %{resource_title} step is now active for %{participatory_space_title}. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The %{resource_title} step is now active for <a href="%{resource_path}">%{participatory_space_title}</a>
         step_changed:
-          email_intro: '%{participatory_space_title} %{resource_title} adımın tarihleri güncellendi. Bu sayfadan görebilirsiniz:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{participatory_space_title}bir güncelleme'
-          notification_title: <a href="%{participatory_space_url}">%{participatory_space_title}</a> de <a href="%{resource_path}">%{resource_title}</a> adım için tarihler güncellendi.
+          email_intro: 'The dates for the %{resource_title} step at %{participatory_space_title} have been updated. You can see it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: An update to %{participatory_space_title}
+          notification_title: The dates for the <a href="%{resource_path}">%{resource_title}</a> step at <a href="%{participatory_space_url}">%{participatory_space_title}</a> have been updated.
     help:
       participatory_spaces:
         participatory_processes:
-          contextual: "<p>A <strong>katılımcı süreç</strong> tanımlanması ve karar verme amacıyla katılımcı faaliyetlerin bir dizi (örneğin, önce onları öncelik son olarak yüz-yüze ya da sanal toplantılar bunları tartışırken, teklif verme, sonra bir anket doldurarak ve benzeri) olduğu belirli bir konuda.</p> <p>Katılımcı süreçlerin örnekleri şunlardır: (adayların ilk sunulduğu, daha sonra tartışıldığı ve sonunda bir adaylığın seçildiği) komite üyelerini seçme süreci, katılımcı bütçeler (tekliflerin yapıldığı, ekonomik olarak değerlendirildiği ve mevcut para ile oy verildiğinde), Bir stratejik planlama süreci, bir yönetmeliğin veya kuralın işbirlikçi taslağının hazırlanması, bir kentsel alanın tasarımı veya bir kamu politikası planının üretilmesi.</p>\n"
-          page: "<p>A <strong>katılımcı süreç</strong> tanımlanması ve karar verme amacıyla katılımcı faaliyetlerin bir dizi (örneğin, önce onları öncelik son olarak yüz-yüze ya da sanal toplantılar bunları tartışırken, teklif verme, sonra bir anket doldurarak ve benzeri) olduğu belirli bir konuda.</p> <p>Katılımcı süreçlerin örnekleri şunlardır: (adayların ilk sunulduğu, daha sonra tartışıldığı ve sonunda bir adaylığın seçildiği) komite üyelerini seçme süreci, katılımcı bütçeler (tekliflerin yapıldığı, ekonomik olarak değerlendirildiği ve mevcut para ile oy verildiğinde), Bir stratejik planlama süreci, bir yönetmeliğin veya kuralın işbirlikçi taslağının hazırlanması, bir kentsel alanın tasarımı veya bir kamu politikası planının üretilmesi.</p>\n"
-          title: Katılımcı bir süreç nedir?
+          contextual: "<p>A <strong>participatory process</strong> is a sequence of participatory activities (e.g. first filling out a survey, then making proposals, discussing them in face-to-face or virtual meetings, and finally prioritizing them) with the aim of defining and making a decision on a specific topic.</p> <p>Examples of participatory processes are: a process of electing committee members (where candidatures are first presented, then debated and finally a candidacy is chosen), participatory budgets (where proposals are made, valued economically and voted on with the money available), a strategic planning process, the collaborative drafting of a regulation or norm, the design of an urban space or the production of a public policy plan.</p>\n"
+          page: "<p>A <strong>participatory process</strong> is a sequence of participatory activities (e.g. first filling out a survey, then making proposals, discussing them in face-to-face or virtual meetings, and finally prioritizing them) with the aim of defining and making a decision on a specific topic.</p> <p>Examples of participatory processes are: a process of electing committee members (where candidatures are first presented, then debated and finally a candidacy is chosen), participatory budgets (where proposals are made, valued economically and voted on with the money available), a strategic planning process, the collaborative drafting of a regulation or norm, the design of an urban space or the production of a public policy plan.</p>\n"
+          title: What is a participatory process?
     menu:
-      processes: Süreçler
+      processes: Processes
     metrics:
       participatory_processes:
-        description: Bu kuruluştaki katılımcı süreçlerin sayısı
-        object: katılımcı süreçler
-        title: Katılımcı süreçler
+        description: Number of participatory processes in this organization
+        object: participatory processes
+        title: Participatory processes
+    pages:
+      participatory_space:
+        metrics:
+          headline: Participation in figures
+          link: Show all statistics
     participatory_process_groups:
       show:
         group_participatory_processes:
-          one: '%{group}için 1 süreç'
-          other: "%{count} için işlemler %{group}"
-        title: Katılımcı süreç grupları
+          one: 1 processes for %{group}
+          other: "%{count} processes for %{group}"
+        title: Participatory process groups
     participatory_process_steps:
       index:
-        process_steps: Süreç adımları
-        title: Katılımcı süreç adımları
+        process_steps: Process steps
+        title: Participatory process steps
     participatory_processes:
       admin:
         content_blocks:
           highlighted_processes:
-            max_results: Gösterilecek maksimum öğe miktarı
+            max_results: Maximum amount of elements to show
         participatory_process_copies:
           form:
-            slug_help: 'URL sümükleri, bu işleme işaret eden URL''leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
+            slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         participatory_process_steps:
           form:
-            cta_path_help: 'Tam URL’leri değil kısmi yolları kullanın. Harfleri, sayıları, kısa çizgileri ve eğik çizgileri kabul eder ve bir harfle başlamalıdır. Ayarlanmazsa, düğme gösterilmeyecektir. Örnek: %{url}'
-            cta_text_help: Ayarlanmazsa, düğme gösterilmeyecektir.
+            cta_path_help: 'Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. If not set, the button will not be shown. Example: %{url}'
+            cta_text_help: If not set, the button will not be shown.
         participatory_processes:
           form:
-            announcement_help: Buraya girdiğiniz metin, işlem bilgilerinin hemen altındaki kullanıcıya gösterilecektir.
-            slug_help: 'URL sümükleri, bu işleme işaret eden URL''leri oluşturmak için kullanılır. Sadece harfleri, sayıları ve kısa çizgileri kabul eder ve bir harfle başlamalıdır. Örnek: %{url}'
+            announcement_help: The text you enter here will be shown to the user right below the process information.
+            slug_help: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
       content_blocks:
         highlighted_processes:
-          name: Vurgulanan süreçler
+          name: Highlighted processes
       index:
-        title: Katılımcı süreçler
+        title: Participatory processes
       last_activity:
-        new_participatory_process: Yeni katılımcı süreç
+        new_participatory_process: New participatory process
       pages:
         home:
           highlighted_processes:
-            active_processes: Aktif süreçler
-            active_step: Aktif adım
-            more_information: Daha fazla bilgi
-            participate: Katıl
-            see_all_processes: Tüm süreçleri gör
+            active_processes: Active processes
+            active_step: Active step
+            more_information: More information
+            participate: Participate
+            see_all_processes: See all processes
       participatory_process_groups:
-        none: Yok
+        none: None
       participatory_processes:
         filters:
           counters:
             active:
-              one: 1 aktif süreç
-              other: "%{count} aktif süreç"
+              one: 1 active process
+              other: "%{count} active processes"
             all:
-              one: 1 işlem
-              other: "%{count} süreç"
+              one: 1 process
+              other: "%{count} processes"
             past:
-              one: 1 geçmiş süreç
-              other: "%{count} geçmiş süreç"
+              one: 1 past process
+              other: "%{count} past processes"
             upcoming:
-              one: 1 yaklaşan süreç
-              other: "%{count} gelecek süreç"
+              one: 1 upcoming process
+              other: "%{count} upcoming processes"
           explanations:
-            no_active: Etkin işlem yok
-            no_active_nor_upcoming: Etkin ve yaklaşan süreç yok
-            no_active_nor_upcoming_callout: Etkin ve yaklaşan süreçler yoktur. İşte geçmiş olanların listesi.
+            no_active: No active processes
+            no_active_nor_upcoming: No active nor upcoming processes
+            no_active_nor_upcoming_callout: There are no active nor upcoming processes. Here is a list of the past ones.
           names:
-            active: Aktif
-            all: Herşey
-            past: geçmiş
-            upcoming: Yaklaşan
-          see: Görmek
+            active: Active
+            all: All
+            past: Past
+            upcoming: Upcoming
+          see: See
         index:
-          loading: Sonuçlar yükleniyor ...
+          loading: Loading results...
       show:
-        developer_group: Tanıtım grubu
-        end_date: Bitiş tarihi
-        local_area: Organizasyon Alanı
-        participatory_scope: Karar nedir
-        participatory_structure: Nasıl karar verilir
-        private_space: Bu özel bir süreç
-        scope: kapsam
-        start_date: Başlangıç tarihi
-        target: Kimler katılır
-        unspecified: Belirtilmemiş
+        developer_group: Promoter group
+        end_date: End date
+        local_area: Organization Area
+        participatory_scope: What is decided
+        participatory_structure: How is it decided
+        private_space: This is a private process
+        scope: Scope
+        start_date: Start date
+        target: Who participates
+        unspecified: Not specified
       statistics:
-        answers_count: Cevaplar
-        comments_count: Yorumlar
-        debates_count: Tartışmalar
-        endorsements_count: Cirolar
-        headline: Aktivite
-        meetings_count: Toplantılar
-        orders_count: oy
-        pages_count: Sayfalar
-        processes_count: Süreçler
-        projects_count: Projeler
-        proposals_count: Teklif
-        results_count: Sonuçlar
-        surveys_count: Anketler
-        users_count: Katılımcılar
-        votes_count: oy
+        answers_count: Answers
+        comments_count: Comments
+        debates_count: Debates
+        endorsements_count: Endorsements
+        headline: Activity
+        meetings_count: Meetings
+        orders_count: Votes
+        pages_count: Pages
+        processes_count: Processes
+        projects_count: Projects
+        proposals_count: Proposals
+        results_count: Results
+        surveys_count: Surveys
+        users_count: Participants
+        votes_count: Votes
   layouts:
     decidim:
       participatory_process_groups:
         participatory_process_group:
-          browse: Araştır
-          processes_count: 'Süreçler:'
+          browse: Browse
+          processes_count: 'Processes:'
       participatory_process_widgets:
         show:
-          active_step: Aktif adım
-          take_part: Yer almak
+          active_step: Active step
+          take_part: Take part
       participatory_processes:
         index:
-          promoted_processes: Vurgulanan süreçler
+          promoted_processes: Highlighted processes
         participatory_process:
-          active_step: 'Mevcut adım:'
-          take_part: Yer almak
+          active_step: 'Current step:'
+          take_part: Take part
         promoted_process:
-          active_step: 'Mevcut adım:'
-          more_info: Daha fazla bilgi
-          take_part: Yer almak
+          active_step: 'Current step:'
+          more_info: More info
+          take_part: Take part
       process_header_steps:
-        step: '%{total}adımdan %{current}'
-        view_steps: Adımları göster
+        step: Step %{current} of %{total}
+        view_steps: View steps
       process_navigation:
-        process_menu_item: Süreç
+        process_menu_item: The process

--- a/decidim-participatory_processes/config/locales/uk.yml
+++ b/decidim-participatory_processes/config/locales/uk.yml
@@ -19,6 +19,7 @@ uk:
         participatory_process_group_id: Сукупність рухів
         participatory_scope: Що вирішується
         participatory_structure: Як це вирішується
+        private_space: Concertation privée
         promoted: Висвітлено
         published_at: 'Оприлюднено:'
         scope_id: Обсяг
@@ -77,6 +78,7 @@ uk:
         duplicate: Створити копію
         edit: Редагувати
         new: New
+        new_process: Yeni süreç
         new_process_group: Створити сукупність рухів
         new_process_step: Додати крок
         new_process_user_role: Додати учасника руху

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ ca:
         title: Títol
         user_group_id: Crea un esborrany de col·laboració com a
       proposal:
+        address: Address
         answer: Resposta
         answered_at: Respost el
         automatic_hashtags: Etiquetes afegides automàticament
@@ -105,17 +107,26 @@ ca:
             votes_blocked: Suports deshabilitats
             votes_enabled: Recollida de suport habilitada
             votes_hidden: Suports ocults (si els suports estan habilitats, marcant aquesta opció amagarà el nombre de suports)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: 'S''ha acceptat %{requester_name} per accedir com a contribuidor de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
+          email_intro: S'ha acceptat %{requester_name} per accedir com a contribuidor de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
           email_outro: Has rebut aquesta notificació perquè ets un contribuidor de <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "S'ha acceptat %{requester_name} per accedir com a contribuidor del %{resource_title}."
+          email_subject: S'ha acceptat %{requester_name} per accedir com a contribuidor del %{resource_title}.
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> ha estat <strong>acceptat per accedir com a contribuidor</strong> de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_rejected:
-          email_intro: 'S''ha rebutjat %{requester_name} per accedir com a contribuidor de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
+          email_intro: S'ha rebutjat %{requester_name} per accedir com a contribuidor de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
           email_outro: Has rebut aquesta notificació perquè ets un contribuidor de <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "S'ha rebutjat %{requester_name} per accedir com a col·laborador de l'esborrany col·lanoratiu %{resource_title}."
+          email_subject: S'ha rebutjat %{requester_name} per accedir com a col·laborador de l'esborrany col·lanoratiu %{resource_title}.
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a><strong> ha estat rebutjat per accedir com a contribuïdor</strong> de l'esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_requested:
           email_intro: '%{requester_name} ha sol·licitat accés com a contribuïdor. Pots <strong>acceptar o rebutjar la sol·licitud</strong> de l''esborrany col·laboratiu <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ ca:
             email_outro: Has rebut aquesta notificació perquè ets autor/a de "%{resource_title}".
             email_subject: S'ha acceptat la teva proposta
             notification_title: S'ha acceptat la teva proposta <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'S''ha acceptat la proposta "%{resource_title}". Pots llegir la resposta des d''aquesta pàgina:'
             email_outro: Has rebut aquesta notificació perquè que segueixes "%{resource_title}". El pots deixar de seguir al link anterior.
             email_subject: Una proposta que segueixes ha estat acceptada
             notification_title: S'ha acceptat la proposta <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, a qui segueixes, acaba d''aprovar la proposta "%{resource_title}" i creiem que pot ser interessant per tu. Consulta i contribueix:'
           email_outro: Has rebut aquesta notificació perquè estàs seguint a %{endorser_nickname}. Pots deixar de rebre notificacions seguint l'enllaç anterior.
@@ -169,11 +184,15 @@ ca:
             email_outro: Has rebut aquesta notificació perquè ets autor/a de "%{resource_title}".
             email_subject: S'està avaluant la teva proposta
             notification_title: S'està avaluant la teva proposta <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'La proposta "%{resource_title}" s''està avaluant actualment. Pots consultar una resposta en aquesta pàgina:'
             email_outro: Has rebut aquesta notificació perquè que segueixes "%{resource_title}". El pots deixar de seguir al link anterior.
             email_subject: S'està avaluant una proposta que segueixes
             notification_title: S'ha avaluat la proposta <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: La teva proposta "%{mentioned_proposal_title}" ha estat esmentada <a href="%{resource_path}">en aquest espai</a> als comentaris.
           email_outro: Has rebut aquesta notificació perquè ets autor/a de "%{resource_title}".
@@ -195,11 +214,15 @@ ca:
             email_outro: Has rebut aquesta notificació perquè ets autor/a de "%{resource_title}".
             email_subject: La teva proposta ha estat rebutjada
             notification_title: La teva proposta <a href="%{resource_path}">%{resource_title}</a> ha estat rebutjada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'La proposta "%{resource_title}" ha estat rebutjada. Pots llegir la resposta des d''aquesta pàgina:'
             email_outro: Has rebut aquesta notificació perquè que segueixes "%{resource_title}". El pots deixar de seguir al link anterior.
             email_subject: S'ha rebutjat una proposta que segueixes
             notification_title: S'ha rebutjat la proposta <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Un administrador ha actualitzat la categoria de la teva proposta "%{resource_title}", fes-hi una ullada:'
           email_outro: Has rebut aquesta notificació perquè ets l'autor de la proposta.
@@ -214,8 +237,8 @@ ca:
       badges:
         accepted_proposals:
           conditions:
-            - Tria l'espai de participació del teu interès amb la creació de propostes activada
-            - Intenta fer propostes que es puguin dur a terme. D'aquesta manera és més probable que s'acceptin.
+          - Tria l'espai de participació del teu interès amb la creació de propostes activada
+          - Intenta fer propostes que es puguin dur a terme. D'aquesta manera és més probable que s'acceptin.
           description: Aquest distintiu es concedeix quan participes activament amb noves propostes i s'accepten.
           description_another: Aquest usuari ha aconseguit tenir %{score} propostes acceptades.
           description_own: Has aconseguit que s'acceptin %{score} de les teves propostes.
@@ -225,8 +248,8 @@ ca:
           unearned_own: Cap de les teves propostes encara no ha estat acceptada.
         proposal_votes:
           conditions:
-            - Navega i passa un temps llegint les propostes d'altres persones
-            - Dóna suport a les propostes que desitgis o troba'n d'interessants
+          - Navega i passa un temps llegint les propostes d'altres persones
+          - Dóna suport a les propostes que desitgis o troba'n d'interessants
           description: Aquest distintiu es concedeix quan dones suport a propostes d'altres persones.
           description_another: Aquest usuari ha donat suport a %{score} propostes.
           description_own: Has donat suport a %{score} propostes.
@@ -236,8 +259,8 @@ ca:
           unearned_own: Encara no has donat suport a cap proposta.
         proposals:
           conditions:
-            - Tria un espai de participació del teu interès amb la creació de propostes activada
-            - Crea una proposta nova
+          - Tria un espai de participació del teu interès amb la creació de propostes activada
+          - Crea una proposta nova
           description: Aquest distintiu es concedeix quan participes activament amb noves propostes.
           description_another: Aquest usuari ha creat %{score} propostes.
           description_own: Has creat %{score} propostes.
@@ -290,8 +313,10 @@ ca:
         participatory_texts:
           bulk-actions:
             are_you_sure: Segur que vols descartar l'esborrany sencer de text participatiu?
-            import_doc: Importar document
             discard_all: Descarta'l sencer
+            import_doc: Importar document
+          discard:
+            success: S'han descartat tots els esborranys de text participatius.
           import:
             invalid: El formulari no és vàlid!
             success: Enhorabona, les seccions següents s'han analitzat del document importat, i s'han convertit en propostes. Ara pots revisar-les i ajustar el que necessitis abans de publicar.
@@ -308,8 +333,6 @@ ca:
           publish:
             invalid: No s'han pogut publicar propostes
             success: S'han publicat totes les propostes
-          discard:
-            success: S'han descartat tots els esborranys de text participatius.
           sections:
             article: "<em>Article</em>"
             section: "<em>Secció:</em> <strong>%{title}</strong>"
@@ -488,7 +511,7 @@ ca:
         requests:
           accepted_request:
             error: No s'ha pogut acceptar com a contribuïdor, torna-ho a provar més tard.
-            success: "S'ha acceptat amb èxit @%{user} com a contribuïdor"
+            success: S'ha acceptat amb èxit @%{user} com a contribuïdor
           access_requested:
             error: No s'ha pogut completar la teva sol·licitud, torna-ho a provar més tard.
             success: La teva sol·licitud de contribució s'ha enviat correctament
@@ -587,6 +610,7 @@ ca:
           error: Hi ha hagut errors en donar suport a la proposta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: La meva proposta és diferent
           no_similars_found: Ben fet! No s'han trobat propostes semblants
           title: Propostes similars
@@ -597,9 +621,14 @@ ca:
           proposals_count:
             one: "%{count} proposta"
             other: "%{count} propostes"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Afegiu un fitxer adjunt"
           back: Enrere
+          not_geocoded: Not geocoded
           select_a_category: Si us plau, selecciona una categoria
           send: Enviar
           title: Editar proposta
@@ -614,6 +643,7 @@ ca:
           comments: Comentaris
         filters:
           activity: Activitat
+          amendment_type: Escriu
           category: Categoria
           category_prompt: Selecciona una categoria
           origin: Origen
@@ -621,7 +651,6 @@ ca:
           search: Cerca
           state: Estat
           voted: Has donat suport
-          amendment_type: Escriu
         filters_small_view:
           close_modal: Tancar finestra
           filter: Filtra
@@ -649,13 +678,18 @@ ca:
             document_index: Índex del document
           view_index:
             see_index: Veure índex
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modifica la proposta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Podràs editar aquesta proposta durant el primer minut després de publicar la proposta. Un cop passada aquesta finestra de temps, no podràs editar la proposta.
             other: Podràs editar aquesta proposta durant els primers %{count} minuts després de la publicació de la proposta. Un cop passada aquesta finestra de temps, no podràs editar la proposta.
           publish: Publica
           title: Publica la teva proposta
+          update_pos: Update the position
         proposal:
           creation_date: 'Creació: %{date}'
           view_proposal: Veure proposta
@@ -685,12 +719,18 @@ ca:
           no_votes_remaining: No hi ha suports restants
           vote: Donar suport
           votes_blocked: Recollida de suports desactivada
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: SUPORT
             other: SUPORTS
           most_popular_proposal: Proposta més popular
           need_more_votes: Necessita més vots
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada proposta pot acumular més de %{limit} suports

--- a/decidim-proposals/config/locales/de.yml
+++ b/decidim-proposals/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ de:
         title: Titel
         user_group_id: Erstellen Sie einen gemeinsamen Entwurf als
       proposal:
+        address: Address
         answer: Antworten
         answered_at: Beantwortet bei
         automatic_hashtags: Hashtags werden automatisch hinzugefügt
@@ -105,7 +107,16 @@ de:
             votes_blocked: Abstimmung blockiert
             votes_enabled: Abstimmung aktiviert
             votes_hidden: Abstimmungen ausgeblendet (wenn Abstimmungen aktiviert sind, wird dies die Anzahl der Abstimmungen verbergen)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} wurde als Beitrag zum <a href="%{resource_path}">%{resource_title}</a> Verbundentwurf akzeptiert.'
@@ -153,11 +164,15 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von "%{resource_title}" sind.
             email_subject: Ihr Vorschlag wurde angenommen
             notification_title: Ihr Vorschlag <a href="%{resource_path}">%{resource_title}</a> wurde angenommen.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Der Vorschlag "%{resource_title}" wurde akzeptiert. Sie können die Antwort auf dieser Seite lesen:'
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie "%{resource_title}" folgen. Sie können es aus dem vorherigen Link aufheben.
             email_subject: Ein Vorschlag, dem Sie folgen, wurde akzeptiert
             notification_title: Der <a href="%{resource_path}">%{resource_title}</a> Vorschlag wurde angenommen.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, dem Sie folgen, hat gerade den Vorschlag "%{resource_title}" befürwortet, und wir denken, er könnte für Sie interessant sein. Überprüfen Sie es und tragen Sie bei:'
           email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie %{endorser_nickname}. Sie können nach dem vorherigen Link keine Benachrichtigungen mehr erhalten.
@@ -169,11 +184,15 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von "%{resource_title}" sind.
             email_subject: Ihr Vorschlag wird geprüft
             notification_title: Ihr Vorschlag <a href="%{resource_path}">%{resource_title}</a> wird geprüft.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Der Vorschlag "%{resource_title}" wird gerade ausgewertet. Sie können auf dieser Seite nach einer Antwort suchen:'
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie "%{resource_title}" folgen. Sie können es aus dem vorherigen Link aufheben.
             email_subject: Ein Vorschlag, dem Sie folgen, wird evaluiert
             notification_title: Der <a href="%{resource_path}">%{resource_title}</a> Vorschlag wird evaluiert.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Ihr Vorschlag „%{mentioned_proposal_title}“ erwähnt <a href="%{resource_path}">in diesem Raum</a> in den Kommentaren.
           email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von "%{resource_title}" sind.
@@ -195,11 +214,15 @@ de:
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie ein Autor von "%{resource_title}" sind.
             email_subject: Ihr Vorschlag wurde abgelehnt
             notification_title: Ihr Vorschlag <a href="%{resource_path}">%{resource_title}</a> wurde abgelehnt.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Der Vorschlag "%{resource_title}" wurde abgelehnt. Sie können die Antwort auf dieser Seite lesen:'
             email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie "%{resource_title}" folgen. Sie können es aus dem vorherigen Link aufheben.
             email_subject: Ein Vorschlag, dem Sie folgen, wurde abgelehnt
             notification_title: Der <a href="%{resource_path}">%{resource_title}</a> Vorschlag wurde abgelehnt.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Ein Administrator hat die Kategorie Ihres Angebots "%{resource_title}" aktualisiert, sehen Sie es sich an:'
           email_outro: Sie haben diese Benachrichtigung erhalten, weil Sie der Autor des Angebots sind.
@@ -214,8 +237,8 @@ de:
       badges:
         accepted_proposals:
           conditions:
-            - Wählen Sie den Bereich für die Teilnahme Ihrer Interessen mit der Einreichung von Vorschlägen aktiviert
-            - Versuchen Sie Vorschläge zu machen, die ausgeführt werden können. Auf diese Weise werden sie eher akzeptiert.
+          - Wählen Sie den Bereich für die Teilnahme Ihrer Interessen mit der Einreichung von Vorschlägen aktiviert
+          - Versuchen Sie Vorschläge zu machen, die ausgeführt werden können. Auf diese Weise werden sie eher akzeptiert.
           description: Dieses Abzeichen wird gewährt, wenn Sie aktiv an neuen Angeboten teilnehmen und diese angenommen werden.
           description_another: Dieser Benutzer hat %{score} Vorschläge akzeptiert.
           description_own: Sie haben %{score} Vorschläge angenommen.
@@ -225,8 +248,8 @@ de:
           unearned_own: Sie haben noch keine Vorschläge erhalten.
         proposal_votes:
           conditions:
-            - Stöbern Sie und verbringen Sie etwas Zeit, die Vorschläge anderer Leute zu lesen
-            - Unterstützen Sie die Vorschläge, die Sie mögen oder interessant finden
+          - Stöbern Sie und verbringen Sie etwas Zeit, die Vorschläge anderer Leute zu lesen
+          - Unterstützen Sie die Vorschläge, die Sie mögen oder interessant finden
           description: Dieses Abzeichen wird gewährt, wenn Sie Vorschläge anderer Personen unterstützen.
           description_another: Dieser Benutzer hat %{score} Vorschläge unterstützt.
           description_own: Sie haben %{score} Vorschläge unterstützt.
@@ -236,8 +259,8 @@ de:
           unearned_own: Sie haben noch keine Vorschläge unterstützt.
         proposals:
           conditions:
-            - Wählen Sie den Bereich für die Teilnahme Ihrer Interessen mit der Einreichung von Vorschlägen aktiviert
-            - Erstellen Sie einen neuen Vorschlag
+          - Wählen Sie den Bereich für die Teilnahme Ihrer Interessen mit der Einreichung von Vorschlägen aktiviert
+          - Erstellen Sie einen neuen Vorschlag
           description: Dieses Abzeichen wird gewährt, wenn Sie aktiv an neuen Vorschlägen teilnehmen.
           description_another: Dieser Benutzer hat %{score} Vorschläge erstellt.
           description_own: Sie haben %{score} Vorschläge erstellt.
@@ -266,6 +289,9 @@ de:
       participatory_process_groups:
         highlighted_proposals:
           proposals: Vorschläge
+    participatory_spaces:
+      highlighted_proposals:
+        see_all: See all (%{count})
     proposals:
       actions:
         answer: Antworten
@@ -287,8 +313,10 @@ de:
         participatory_texts:
           bulk-actions:
             are_you_sure: Sind Sie sicher, den gesamten Entwurf des partizipativen Textes zu verwerfen?
-            import_doc: Dokument importieren
             discard_all: Alle verwerfen
+            import_doc: Dokument importieren
+          discard:
+            success: Alle Mitentscheidungsentwürfe wurden verworfen.
           import:
             invalid: Das Formular ist ungültig!
             success: Herzlichen Glückwunsch, die folgenden Abschnitte wurden aus dem importierten Dokument analysiert, sie wurden in Vorschläge konvertiert. Jetzt können Sie alles überprüfen und anpassen, bevor Sie es veröffentlichen.
@@ -305,8 +333,6 @@ de:
           publish:
             invalid: Vorschläge konnten nicht veröffentlicht werden
             success: Alle Vorschläge wurden veröffentlicht
-          discard:
-            success: Alle Mitentscheidungsentwürfe wurden verworfen.
           sections:
             article: "<em>Artikel</em>"
             section: "<em>Abschnitt:</em> <strong>%{title}</strong>"
@@ -584,6 +610,7 @@ de:
           error: Es gab Fehler bei der Abstimmung des Vorschlags.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Mein Vorschlag ist anders
           no_similars_found: Gut gemacht! Keine ähnlichen Vorschläge gefunden
           title: Ähnliche Vorschläge
@@ -594,9 +621,14 @@ de:
           proposals_count:
             one: "%{count} Vorschlag"
             other: "%{count} Vorschläge"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Optional) Fügen Sie einen Anhang hinzu"
           back: Zurück
+          not_geocoded: Not geocoded
           select_a_category: Bitte wählen sie eine Kategorie
           send: Senden
           title: Angebot bearbeiten
@@ -611,6 +643,7 @@ de:
           comments: Bemerkungen
         filters:
           activity: Aktivität
+          amendment_type: Art
           category: Kategorie
           category_prompt: Wählen Sie eine Kategorie
           origin: Ursprung
@@ -618,7 +651,6 @@ de:
           search: Suche
           state: Zustand
           voted: Gewählt
-          amendment_type: Art
         filters_small_view:
           close_modal: Modal schließen
           filter: Filter
@@ -646,13 +678,18 @@ de:
             document_index: Dokumentenindex
           view_index:
             see_index: Siehe Index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Ändern Sie den Vorschlag
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Sie können diesen Vorschlag in der ersten Minute nach der Veröffentlichung des Vorschlags bearbeiten. Nach Ablauf dieses Zeitfensters können Sie das Angebot nicht mehr bearbeiten.
             other: Sie können dieses Angebot in den ersten %{count} Minuten nach der Veröffentlichung des Angebots bearbeiten. Nach Ablauf dieses Zeitfensters können Sie das Angebot nicht mehr bearbeiten.
           publish: Veröffentlichen
           title: Veröffentlichen Sie Ihren Vorschlag
+          update_pos: Update the position
         proposal:
           creation_date: 'Erstellung: %{date}'
           view_proposal: Angebot anzeigen
@@ -682,12 +719,18 @@ de:
           no_votes_remaining: Keine verbleibenden Stimmen
           vote: Abstimmung
           votes_blocked: Abstimmung deaktiviert
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: ABSTIMMUNG
             other: ABSTIMMUNGEN
           most_popular_proposal: Beliebtester Vorschlag
           need_more_votes: Brauche mehr Stimmen
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Jeder Vorschlag kann mehr als %{limit} Unterstützungen sammeln

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -611,7 +611,6 @@ en:
       proposals:
         compare:
           continue: Continue
-          mine_is_different: Моя пропозиція інша
           no_similars_found: Well done! No similar proposals found
           title: Similar Proposals
         complete:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -611,6 +611,7 @@ en:
       proposals:
         compare:
           continue: Continue
+          mine_is_different: Моя пропозиція інша
           no_similars_found: Well done! No similar proposals found
           title: Similar Proposals
         complete:

--- a/decidim-proposals/config/locales/es-PY.yml
+++ b/decidim-proposals/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ es-PY:
         title: Título
         user_group_id: Crear borrador colaborativo como
       proposal:
+        address: Address
         answer: Respuesta
         answered_at: Respondido
         automatic_hashtags: Hashtags añadidos automáticamente
@@ -105,7 +107,16 @@ es-PY:
             votes_blocked: Votación bloqueada
             votes_enabled: Votación habilitada
             votes_hidden: Votos ocultos (si los votos están habilitados, marcar esto ocultará el número de votos)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} ha sido aceptado para acceder como contribuidor del borrador colaborativo de <a href="%{resource_path}">%{resource_title}</a>.'
@@ -138,12 +149,12 @@ es-PY:
           email_subject: "%{author_name} %{author_nickname} ha retirado el borrador colaborativo %{resource_title}."
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>ha retirado</strong> el borrador colaborativo <a href="%{resource_path}">%{resource_title}</a>.
         creation_enabled:
-          email_intro: '¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Comienza a participar en esta página:'
+          email_intro: "¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Comienza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: Propuestas ahora disponibles en %{participatory_space_title}
           notification_title: Ahora puedes presentar <a href="%{resource_path}">nuevas propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: '¡Puedes adherirte a propuestas en %{participatory_space_title}! Comienza a participar en esta página:'
+          email_intro: "¡Puedes adherirte a propuestas en %{participatory_space_title}! Comienza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La adhesión de propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ahora puedes comenzar a <a href="%{resource_path}">adherirte propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -153,11 +164,15 @@ es-PY:
             email_outro: Has recibido esta notificación porque eres autor de "%{resource_title}".
             email_subject: Su propuesta ha sido aceptada.
             notification_title: Su propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido aceptada.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'La propuesta "%{resource_title}" ha sido aceptada. Puedes leer la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo ha sido aceptada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido aceptada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, a quien está siguiendo, acaba de respaldar la propuesta "%{resource_title}" y creemos que puede ser interesante para usted. Échale un vistazo y contribuye:'
           email_outro: Recibió esta notificación porque está siguiendo %{endorser_nickname}. Puede dejar de recibir notificaciones siguiendo el enlace anterior.
@@ -169,11 +184,15 @@ es-PY:
             email_outro: Has recibido esta notificación porque eres autor de "%{resource_title}".
             email_subject: Tu propuesta esta siendo evaluada
             notification_title: Su propuesta <a href="%{resource_path}">%{resource_title}</a> está siendo evaluada.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'La propuesta "%{resource_title}" se está evaluando actualmente. Puedes encontrar la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo está siendo evaluada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> está siendo evaluada.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Su propuesta "%{mentioned_proposal_title}" se ha mencionado <a href="%{resource_path}">en este espacio</a> en los comentarios.
           email_outro: Has recibido esta notificación porque eres autor de "%{resource_title}".
@@ -195,18 +214,22 @@ es-PY:
             email_outro: Has recibido esta notificación porque eres autor de "%{resource_title}".
             email_subject: Su propuesta ha sido rechazada
             notification_title: Su propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido rechazada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'La propuesta "%{resource_title}" ha sido rechazada. Puedes leer la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo ha sido rechazada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido rechazada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Un/a administrador/a ha actualizado la categoría de tu propuesta "%{resource_title}", compruébalo:'
           email_outro: Recibiste esta notificación porque eres autor/a de la propuesta.
           email_subject: La categoría de la propuesta %{resource_title} ha sido actualizada
           notification_title: La categoría de la propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido actualizada por un/a administrador/a.
         voting_enabled:
-          email_intro: '¡Puedes votar propuestas en %{participatory_space_title}! Comienza a participar en esta página:'
+          email_intro: "¡Puedes votar propuestas en %{participatory_space_title}! Comienza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La posibilidad de dar apoyo a las propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ahora puedes comenzar <a href="%{resource_path}">apoyar propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -214,35 +237,35 @@ es-PY:
       badges:
         accepted_proposals:
           conditions:
-            - Elija el espacio de participación de su interés con la presentación de propuestas habilitada.
-            - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptados.
+          - Elija el espacio de participación de su interés con la presentación de propuestas habilitada.
+          - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptados.
           description: Este distintivo se otorga cuando usted participa activamente con nuevas propuestas y se aceptan.
-          description_another: '%{score} propuestas de este usuario han sido aceptadas.'
-          description_own: '%{score} de tus propuestas han sido aceptadas.'
+          description_another: "%{score} propuestas de este usuario han sido aceptadas."
+          description_own: "%{score} de tus propuestas han sido aceptadas."
           name: Propuestas aceptadas
-          next_level_in: '¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha conseguido ninguna propuesta aceptada.
           unearned_own: Aún no tienes ninguna propuesta aceptada.
         proposal_votes:
           conditions:
-            - Navega y pasa un tiempo leyendo las propuestas de otras personas.
-            - Da soporte a las propuestas que te gusten o encuentres interesantes.
+          - Navega y pasa un tiempo leyendo las propuestas de otras personas.
+          - Da soporte a las propuestas que te gusten o encuentres interesantes.
           description: Este distintivo se otorga cuando apoyas las propuestas de otras personas.
           description_another: Este usuario ha dado soporte a %{score} propuestas.
           description_own: Has dado soporte a %{score} propuestas.
           name: Apoyos a propuestas
-          next_level_in: '¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha dado apoyo a ninguna propuesta.
           unearned_own: Todavía no has dado apoyo a ninguna propuesta.
         proposals:
           conditions:
-            - Elija el espacio de participación de su interés con la presentación de propuestas habilitada.
-            - Crear una nueva propuesta
+          - Elija el espacio de participación de su interés con la presentación de propuestas habilitada.
+          - Crear una nueva propuesta
           description: Este distintivo se otorga cuando participas activamente con nuevas propuestas.
           description_another: Este usuario ha creado %{score} propuestas.
           description_own: Has creado %{score} propuestas.
           name: Propuestas
-          next_level_in: '¡Crea %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Crea %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario no ha creado ninguna propuesta todavía.
           unearned_own: Aún no has creado propuestas.
     metrics:
@@ -289,9 +312,11 @@ es-PY:
             name: Propuesta
         participatory_texts:
           bulk-actions:
-            are_you_sure: '¿Estás seguro de descartar todo el borrador del texto participativo?'
-            import_doc: Importar documento
+            are_you_sure: "¿Estás seguro de descartar todo el borrador del texto participativo?"
             discard_all: Descartar todo
+            import_doc: Importar documento
+          discard:
+            success: Todos los borradores de textos participativos han sido descartados.
           import:
             invalid: El formulario no es válido!
             success: Enhorabuena, las siguientes secciones se analizaron en el documento importado y se convirtieron en propuestas. Ahora puedes revisar y ajustar lo que necesites antes de publicar.
@@ -308,8 +333,6 @@ es-PY:
           publish:
             invalid: No se pudieron publicar propuestas.
             success: Todas las propuestas han sido publicadas.
-          discard:
-            success: Todos los borradores de textos participativos han sido descartados.
           sections:
             article: "<em>Artículo</em>"
             section: "<em>Sección:</em> <strong>%{title}</strong>"
@@ -441,7 +464,7 @@ es-PY:
             success: Borrador colaborativo retirado con éxito.
         compare:
           mine_is_different: Mi borrador colaborativo es diferente
-          no_similars_found: '¡Enhorabuena! No se encontraron borradores colaborativos similares'
+          no_similars_found: "¡Enhorabuena! No se encontraron borradores colaborativos similares"
           title: Borradores colaborativos similares
         complete:
           send: Enviar
@@ -587,8 +610,9 @@ es-PY:
           error: Ha habido errores al votar la propuesta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Mi propuesta es diferente
-          no_similars_found: '¡Bien hecho! No se encontraron propuestas similares'
+          no_similars_found: "¡Bien hecho! No se encontraron propuestas similares"
           title: Propuestas similares
         complete:
           send: Enviar
@@ -597,15 +621,20 @@ es-PY:
           proposals_count:
             one: "%{count} propuesta"
             other: "%{count} propuestas"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Agregar un archivo adjunto"
           back: Volver
+          not_geocoded: Not geocoded
           select_a_category: Por favor, seleccione una categoría
           send: Enviar
           title: Editar propuesta
         edit_draft:
           discard: Descartar este borrador
-          discard_confirmation: '¿Estás seguro que quieres descartar este borrador de propuesta?'
+          discard_confirmation: "¿Estás seguro que quieres descartar este borrador de propuesta?"
           send: Previsualizar
           title: Editar borrador de propuesta
         endorsement_identities_cabin:
@@ -614,6 +643,7 @@ es-PY:
           comments: Comentarios
         filters:
           activity: Actividad
+          amendment_type: Tipo
           category: Categoría
           category_prompt: Selecciona una categoría
           origin: Origen
@@ -621,7 +651,6 @@ es-PY:
           search: Buscar
           state: Estado
           voted: Votado
-          amendment_type: Tipo
         filters_small_view:
           close_modal: Cerrar ventana
           filter: Filtrar
@@ -649,13 +678,18 @@ es-PY:
             document_index: Índice de documentos
           view_index:
             see_index: Ver índice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modificar la propuesta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Podrás editar esta propuesta durante el primer minuto posterior a la publicación de la misma. Una vez que pase este tiempo, ya no podrás editarla.
             other: Podrás editar esta propuesta durante los primeros %{count} minutos después de que se publique. Una vez que pase este tiempo, no podrás editar la propuesta.
           publish: Publicar
           title: Publica tu propuesta
+          update_pos: Update the position
         proposal:
           creation_date: 'Creación: %{date}'
           view_proposal: Ver propuesta
@@ -673,7 +707,7 @@ es-PY:
           proposal_rejected_reason: 'Esta propuesta ha sido rechazada porque:'
           report: Denunciar
           withdraw_btn_hint: Puedes retirar tu propuesta si cambias de opinión, siempre que no haya recibido ningún soporte. La propuesta no se elimina, aparecerá en la lista de propuestas retiradas.
-          withdraw_confirmation: '¿Seguro que quieres retirar esta propuesta?'
+          withdraw_confirmation: "¿Seguro que quieres retirar esta propuesta?"
           withdraw_proposal: Retirar propuesta
         tags:
           changed_from: "(cambiado desde <u>%{previous_category}</u> por un administrador)"
@@ -685,12 +719,18 @@ es-PY:
           no_votes_remaining: No hay votos restantes
           vote: Dar apoyo
           votes_blocked: Votación desactivada
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: APOYO
             other: APOYOS
           most_popular_proposal: La propuesta más popular
           need_more_votes: Necesita más votos
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada propuesta puede acumular más de %{limit} apoyos

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ es:
         title: Título
         user_group_id: Crear borrador colaborativo como
       proposal:
+        address: Address
         answer: Respuesta
         answered_at: Respondido en
         automatic_hashtags: Hashtags añadidos automáticamente
@@ -72,7 +74,9 @@ es:
         settings:
           global:
             amendments_enabled: Enmiendas habilitadas
-            announcement: "Aviso\n"
+            announcement: 'Aviso
+
+'
             attachments_allowed: Permitir archivos adjuntos
             can_accumulate_supports_beyond_threshold: Puede acumular apoyos más allá del umbral
             collaborative_drafts_enabled: Habilitar borradores colaborativos
@@ -105,7 +109,16 @@ es:
             votes_blocked: Votación deshabilitada
             votes_enabled: Votación habilitada
             votes_hidden: Votos ocultos (si los votos están habilitados, marcando esta opción ocultará el número de votos)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} ha sido aceptado para acceder como contribuidor del borrador colaborativo de <a href="%{resource_path}">%{resource_title}</a>.'
@@ -138,12 +151,12 @@ es:
           email_subject: "%{author_name} %{author_nickname} ha retirado el borrador colaborativo %{resource_title}."
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>ha retirado</strong> el borrador colaborativo <a href="%{resource_path}">%{resource_title}</a>.
         creation_enabled:
-          email_intro: '¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
+          email_intro: "¡Ahora puedes crear nuevas propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: Propuestas ahora disponibles en %{participatory_space_title}
           notification_title: Ahora puedes presentar <a href="%{resource_path}">nuevas propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: '¡Puedes adherirte a propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
+          email_intro: "¡Puedes adherirte a propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La adhesión de propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ahora puedes empezar a <a href="%{resource_path}">adherirte propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -153,11 +166,15 @@ es:
             email_outro: Has recibido esta notificación porque eres autora de "%{resource_title}".
             email_subject: Tu propuesta ha sido aceptada
             notification_title: Tu propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido aceptada.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'La propuesta "%{resource_title}" ha sido aceptada. Puedes leer la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo ha sido aceptada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido aceptada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, a quien estás siguiendo, acaba de adherirse a la propuesta "%{resource_title}" y creemos que puede ser interesante para ti. Échale un vistazo y contribuye:'
           email_outro: Has recibido esta notificación porque estás siguiendo %{endorser_nickname}. Puedes dejar de recibir notificaciones a través del enlace anterior.
@@ -169,11 +186,15 @@ es:
             email_outro: Has recibido esta notificación porque eres autora de "%{resource_title}".
             email_subject: Tu propuesta esta siendo evaluada
             notification_title: Tu propuesta <a href="%{resource_path}">%{resource_title}</a> está siendo evaluada.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'La propuesta "%{resource_title}" se está evaluando actualmente. Puedes encontrar la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo está siendo evaluada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> está siendo evaluada.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Tu propuesta "%{mentioned_proposal_title}" se ha mencionado <a href="%{resource_path}">en este espacio</a> en los comentarios.
           email_outro: Has recibido esta notificación porque eres autora de "%{resource_title}".
@@ -195,18 +216,22 @@ es:
             email_outro: Has recibido esta notificación porque eres autora de "%{resource_title}".
             email_subject: Tu propuesta ha sido rechazada
             notification_title: Tu propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido rechazada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'La propuesta "%{resource_title}" ha sido rechazada. Puedes leer la respuesta en esta página:'
             email_outro: Has recibido esta notificación porque sigues "%{resource_title}". Puedes dejar de seguirlo en el enlace anterior.
             email_subject: Una propuesta que estás siguiendo ha sido rechazada
             notification_title: La propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido rechazada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Un/a administrador/a ha actualizado la categoría de tu propuesta "%{resource_title}", compruébalo:'
           email_outro: Recibiste esta notificación porque eres autor/a de la propuesta.
           email_subject: La categoría de la propuesta %{resource_title} ha sido actualizada
           notification_title: La categoría de la propuesta <a href="%{resource_path}">%{resource_title}</a> ha sido actualizada por un/a administrador/a.
         voting_enabled:
-          email_intro: '¡Puedes votar propuestas en %{participatory_space_title}! Empieza a participar en esta página:'
+          email_intro: "¡Puedes votar propuestas en %{participatory_space_title}! Empieza a participar en esta página:"
           email_outro: Recibiste esta notificación porque estás siguiendo %{participatory_space_title}. Puedes dejar de recibir notificaciones siguiendo el enlace anterior.
           email_subject: La posibilidad de dar apoyo a las propuestas ha comenzado para %{participatory_space_title}
           notification_title: Ya puedes empezar a <a href="%{resource_path}">apoyar propuestas</a> en <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -214,35 +239,35 @@ es:
       badges:
         accepted_proposals:
           conditions:
-            - Elige el espacio de participación con la creación de propuestas habilitada de tu interés
-            - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptadas.
+          - Elige el espacio de participación con la creación de propuestas habilitada de tu interés
+          - Intenta hacer propuestas que se puedan realizar. De esta manera es más probable que sean aceptadas.
           description: Este distintivo se otorga cuando participes activamente con nuevas propuestas y estas sean aceptadas.
-          description_another: '%{score} propuestas de este usuario han sido aceptadas.'
-          description_own: '%{score} de tus propuestas han sido aceptadas.'
+          description_another: "%{score} propuestas de este usuario han sido aceptadas."
+          description_own: "%{score} de tus propuestas han sido aceptadas."
           name: Propuestas aceptadas
-          next_level_in: '¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Consigue que se aprueben %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha conseguido ninguna propuesta aceptada.
           unearned_own: Aún no tienes ninguna propuesta aceptada.
         proposal_votes:
           conditions:
-            - Navega y dedica un tiempo leyendo las propuestas de otras personas
-            - Da apoyo a las propuestas con las que estés de acuerdo o encuentres interesantes
+          - Navega y dedica un tiempo leyendo las propuestas de otras personas
+          - Da apoyo a las propuestas con las que estés de acuerdo o encuentres interesantes
           description: Este distintivo se otorga cuando apoyas propuestas de otras personas.
           description_another: Este usuario ha dado soporte a %{score} propuestas.
           description_own: Has dado soporte a %{score} propuestas.
           name: Apoyos a propuestas
-          next_level_in: '¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Apoya %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario aún no ha dado apoyo a ninguna propuesta.
           unearned_own: Todavía no has dado apoyo a ninguna propuesta.
         proposals:
           conditions:
-            - Elige el espacio de participación con la creación de propuestas habilitada que sea de tu interés
-            - Crear una nueva propuesta
+          - Elige el espacio de participación con la creación de propuestas habilitada que sea de tu interés
+          - Crear una nueva propuesta
           description: Este distintivo se otorga cuando participas activamente con nuevas propuestas.
           description_another: Este usuario ha creado %{score} propuestas.
           description_own: Has creado %{score} propuestas.
           name: Propuestas
-          next_level_in: '¡Crea %{score} propuestas más para alcanzar el siguiente nivel!'
+          next_level_in: "¡Crea %{score} propuestas más para alcanzar el siguiente nivel!"
           unearned_another: Este usuario no ha creado ninguna propuesta todavía.
           unearned_own: Aún no has creado propuestas.
     metrics:
@@ -289,11 +314,13 @@ es:
             name: Propuesta
         participatory_texts:
           bulk-actions:
-            are_you_sure: '¿Seguro que quieres descartar todo el borrador de texto participativo?'
-            import_doc: Importar documento
+            are_you_sure: "¿Seguro que quieres descartar todo el borrador de texto participativo?"
             discard_all: Descartar todo
+            import_doc: Importar documento
+          discard:
+            success: Todos los borradores de textos participativos han sido descartados.
           import:
-            invalid: '¡El formulario no es válido!'
+            invalid: "¡El formulario no es válido!"
             success: Enhorabuena, los párrafos y secciones del documento importado se han convertido correctamente en propuestas. Ahora puedes revisarlas y ajustar las que necesites antes de publicar.
           index:
             info_1: Los párrafos y secciones del documento importado se han convertido correctamente en propuestas. Ahora puedes revisarlas y ajustar las que necesites antes de publicar.
@@ -308,8 +335,6 @@ es:
           publish:
             invalid: No se pudieron publicar las propuestas
             success: Todas las propuestas han sido publicadas
-          discard:
-            success: Todos los borradores de textos participativos han sido descartados.
           sections:
             article: "<em>Artículo</em>"
             section: "<em>Sección:</em> <strong>%{title}</strong>"
@@ -441,7 +466,7 @@ es:
             success: Borrador colaborativo retirado con éxito.
         compare:
           mine_is_different: Mi borrador colaborativo es diferente
-          no_similars_found: '¡Enhorabuena! No se encontraron borradores colaborativos similares'
+          no_similars_found: "¡Enhorabuena! No se encontraron borradores colaborativos similares"
           title: Borradores colaborativos similares
         complete:
           send: Enviar
@@ -587,8 +612,9 @@ es:
           error: Ha habido errores al apoyar la propuesta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Mi propuesta es diferente
-          no_similars_found: '¡Bien hecho! No se encontraron propuestas similares'
+          no_similars_found: "¡Bien hecho! No se encontraron propuestas similares"
           title: Propuestas similares
         complete:
           send: Enviar
@@ -597,15 +623,20 @@ es:
           proposals_count:
             one: "%{count} propuesta"
             other: "%{count} propuestas"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Agregar un archivo adjunto"
           back: Atrás
+          not_geocoded: Not geocoded
           select_a_category: Por favor, selecciona una categoría
           send: Enviar
           title: Editar propuesta
         edit_draft:
           discard: Descartar este borrador
-          discard_confirmation: '¿Estás seguro que quieres descartar este borrador de propuesta?'
+          discard_confirmation: "¿Estás seguro que quieres descartar este borrador de propuesta?"
           send: Previsualizar
           title: Editar el borrador de la propuesta
         endorsement_identities_cabin:
@@ -614,6 +645,7 @@ es:
           comments: Comentarios
         filters:
           activity: Actividad
+          amendment_type: Tipo
           category: Categoría
           category_prompt: Selecciona una categoría
           origin: Origen
@@ -621,7 +653,6 @@ es:
           search: Buscar
           state: Estado
           voted: Apoyadas
-          amendment_type: Tipo
         filters_small_view:
           close_modal: Cerrar ventana
           filter: Filtrar
@@ -649,13 +680,18 @@ es:
             document_index: Índice del documento
           view_index:
             see_index: Ver índice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modificar la propuesta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Podrás editar esta propuesta durante el primer minuto posterior a la publicación de la misma. Una vez que pase este tiempo, ya no podrás editarla.
             other: Podrás editar esta propuesta durante los primeros %{count} minutos después que se publique. Una vez que pase este tiempo, no podrás editar la propuesta.
           publish: Publicar
           title: Publica tu propuesta
+          update_pos: Update the position
         proposal:
           creation_date: 'Fecha de creación: %{date}'
           view_proposal: Ver propuesta
@@ -673,7 +709,7 @@ es:
           proposal_rejected_reason: 'Esta propuesta ha sido rechazada porque:'
           report: Denunciar
           withdraw_btn_hint: Puedes retirar tu propuesta si cambias de opinión, siempre que no haya recibido ningún soporte. La propuesta no se eliminará, aparecerá en la lista de propuestas retiradas.
-          withdraw_confirmation: '¿Estás seguro de retirar esta propuesta?'
+          withdraw_confirmation: "¿Estás seguro de retirar esta propuesta?"
           withdraw_proposal: Retirar propuesta
         tags:
           changed_from: "(cambiado desde <u>%{previous_category}</u> por un administrador)"
@@ -685,12 +721,18 @@ es:
           no_votes_remaining: No hay votos restantes
           vote: Dar apoyo
           votes_blocked: Apoyos desactivados
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: APOYO
             other: APOYOS
           most_popular_proposal: Propuestas más populares
           need_more_votes: Necesita más apoyos
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada propuesta puede acumular más de %{limit} apoyos

--- a/decidim-proposals/config/locales/eu.yml
+++ b/decidim-proposals/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ eu:
         title: Izenburua
         user_group_id: Lankidetza zirriborroa sortu
       proposal:
+        address: Address
         answer: Erantzuna
         answered_at: Erantzuna at
         automatic_hashtags: Hashtags automatikoki gehitu da
@@ -105,7 +107,16 @@ eu:
             votes_blocked: Botoak blokeatuta
             votes_enabled: Botoak gaituta
             votes_hidden: Botoiak ezkutatuta (botoak gaituta badago, hau egiaztatuz boto kopurua ezkutatuko da)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} onartu da <a href="%{resource_path}">%{resource_title}</a> lankidetza proiektuaren laguntzaile gisa sartzeko.'
@@ -125,7 +136,7 @@ eu:
         collaborative_draft_access_requester_accepted:
           email_intro: <a href="%{resource_path}">%{resource_title}</a> lankidetza zirriborroaren laguntzaile gisa sartzeko onartu duzu.
           email_outro: Jakinarazpen hau jaso duzu, <a href="%{resource_path}">%{resource_title}</a>laguntzaile izateko eskatu zenuen.
-          email_subject: '%{resource_title}laguntzaile gisa onartzen duzu.'
+          email_subject: "%{resource_title}laguntzaile gisa onartzen duzu."
           notification_title: Izan zara <strong>onartu laguntzaile gisa sartzeko</strong> de <a href="%{resource_path}">%{resource_title}</a> elkarlanerako zirriborroa.
         collaborative_draft_access_requester_rejected:
           email_intro: Baztertu egin zaituzte <a href="%{resource_path}">%{resource_title}</a> lankidetza proiektuaren laguntzaile gisa sartzeko.
@@ -143,7 +154,7 @@ eu:
           email_subject: Proposamenak orain eskuragarri %{participatory_space_title}
           notification_title: Orain jarri ahal Aurrera <a href="%{resource_path}">proposamen berriak</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: '%{participatory_space_title}proposamenak onartu ditzakezu! Hasi orri honetan parte hartzea:'
+          email_intro: "%{participatory_space_title}proposamenak onartu ditzakezu! Hasi orri honetan parte hartzea:"
           email_outro: Jakinarazpena jaso duzu %{participatory_space_title}jarraituz gero. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
           email_subject: Onarpen proposamenak %{participatory_space_title}-ra hasi dira
           notification_title: Oraingo <a href="%{resource_path}"></a> babes-proposamenak hasi ditzakezu <a href="%{participatory_space_url}">%{participatory_space_title}</a>
@@ -153,11 +164,15 @@ eu:
             email_outro: Jakinarazpen hau jaso duzu "%{resource_title}" egilearena delako.
             email_subject: Zure proposamena onartu da
             notification_title: Zure proposamena <a href="%{resource_path}">%{resource_title}</a> onartu da.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: '"%{resource_title}" proposamena onartu da. Orri honetan erantzun dezakezu:'
             email_outro: Jakinarazpena jaso duzu "%{resource_title}" jarraitzen ari zarenagatik. Aurreko esteka estekan jarrai dezakezu.
             email_subject: Ondorengo proposamen bat onartu da
             notification_title: <a href="%{resource_path}">%{resource_title}</a> proposamena onartu da.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, jarraitzen ari zarenak, "%{resource_title}" proposamena onartu du eta uste duzu zure interesgarria dela. Begiratu eta lagundu:'
           email_outro: Jakinarazpena jaso duzu %{endorser_nickname}jarraituz gero. Aurreko esteka jarraituz jakinarazpenak jasotzeari uztea erabaki dezakezu.
@@ -169,11 +184,15 @@ eu:
             email_outro: Jakinarazpen hau jaso duzu "%{resource_title}" egilearena delako.
             email_subject: Zure proposamena ebaluatzen ari da
             notification_title: Zure proposamena <a href="%{resource_path}">%{resource_title}</a> ebaluatzen ari da.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: '"%{resource_title}" proposamena ebaluatzen ari da. Orri honetan erantzun dezakezu:'
             email_outro: Jakinarazpena jaso duzu "%{resource_title}" jarraitzen ari zarenagatik. Aurreko esteka estekan jarrai dezakezu.
             email_subject: Jarraitzen ari zaren proposamena ebaluatzen ari da
             notification_title: <a href="%{resource_path}">%{resource_title}</a> proposamena ebaluatzen ari da.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: '"%{mentioned_proposal_title}" zure proposamena <a href="%{resource_path}"></a> espazio honetan aipatu da iruzkinetan.'
           email_outro: Jakinarazpen hau jaso duzu "%{resource_title}" egilearena delako.
@@ -195,15 +214,19 @@ eu:
             email_outro: Jakinarazpen hau jaso duzu "%{resource_title}" egilearena delako.
             email_subject: Zure proposamena baztertu da
             notification_title: Zure proposamena <a href="%{resource_path}">%{resource_title}</a> baztertu egin da.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: '"%{resource_title}" proposamena baztertu egin da. Orri honetan erantzun dezakezu:'
             email_outro: Jakinarazpena jaso duzu "%{resource_title}" jarraitzen ari zarenagatik. Aurreko esteka estekan jarrai dezakezu.
             email_subject: Ondorengo proposamen bat baztertu egin da
             notification_title: <a href="%{resource_path}">%{resource_title}</a> proposamena baztertu da.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Administratzaileak "%{resource_title}" proposamenaren kategoria eguneratu du, check it out:'
           email_outro: Jakinarazpen hau jaso duzu proposamenaren egilea delako.
-          email_subject: '%{resource_title} Proposamenaren kategoria eguneratu da'
+          email_subject: "%{resource_title} Proposamenaren kategoria eguneratu da"
           notification_title: <a href="%{resource_path}">%{resource_title}</a> proposamenaren kategoria administratzaile batek eguneratu du.
         voting_enabled:
           email_intro: 'Proposamenak bozkatu ditzakezu %{participatory_space_title}-n! Hasi orri honetan parte hartzea:'
@@ -214,33 +237,33 @@ eu:
       badges:
         accepted_proposals:
           conditions:
-            - Aukeratu zure intereseko partaidetza espazioa proposamenak bidaltzeko
-            - Saiatu egin daitezkeen proposamenak egitea. Horrela onartuko lirateke gehiago.
+          - Aukeratu zure intereseko partaidetza espazioa proposamenak bidaltzeko
+          - Saiatu egin daitezkeen proposamenak egitea. Horrela onartuko lirateke gehiago.
           description: Idazmahaia proposamen berriekin modu aktiboan parte hartzen duzunean onartuko zaituzte eta onartzen dira.
           description_another: Erabiltzaile honek %{score} proposamen jaso ditu.
-          description_own: '%{score} proposamen onartu dituzu.'
+          description_own: "%{score} proposamen onartu dituzu."
           name: Onartutako proposamenak
           next_level_in: Talde %{score} proposamen gehiago hurrengo mailara iristeko onartu!
           unearned_another: Erabiltzaile honek oraindik ez ditu onartutako proposamenik.
           unearned_own: Oraindik ez duzu onartutako proposamenik.
         proposal_votes:
           conditions:
-            - Arakatu eta beste pertsona batzuen proposamenak irakurtzen
-            - Eman gustuko dituzun proposamenei edo interesgarria iruditu
+          - Arakatu eta beste pertsona batzuen proposamenak irakurtzen
+          - Eman gustuko dituzun proposamenei edo interesgarria iruditu
           description: Idazmahaia beste pertsonen proposamenak onartzen dituzunean onartzen da.
           description_another: Erabiltzaile honek %{score} proposamen onartzen ditu.
-          description_own: '%{score} proposamenei laguntza eman diezu.'
+          description_own: "%{score} proposamenei laguntza eman diezu."
           name: Proposamenak onartzen ditu
           next_level_in: Eman laguntza %{score} proposamen gehiago hurrengo mailara iristea!
           unearned_another: Erabiltzaile honek oraindik ez du proposamenik onartzen.
           unearned_own: Ez duzu proposamenik onartzen oraindik.
         proposals:
           conditions:
-            - Aukeratu zure intereseko partaidetza espazioa proposamenak bidaltzeko
-            - Proposamen berri bat sortu
+          - Aukeratu zure intereseko partaidetza espazioa proposamenak bidaltzeko
+          - Proposamen berri bat sortu
           description: Txartela hau proposamen berriekin parte hartzera gonbidatzen zaituztegu.
           description_another: Erabiltzaile honek %{score} proposamen sortu ditu.
-          description_own: '%{score} proposamen sortu dituzu.'
+          description_own: "%{score} proposamen sortu dituzu."
           name: proposamenak
           next_level_in: Sortu %{score} proposamen gehiago hurrengo mailara iristeko!
           unearned_another: Erabiltzaile honek oraindik ez du proposamenik sortu.
@@ -290,8 +313,10 @@ eu:
         participatory_texts:
           bulk-actions:
             are_you_sure: Ziur al zaude parte hartzailearen testu-zirriborroa baztertu nahi duzula?
-            import_doc: Inportatu dokumentua
             discard_all: Baztertu guztiak
+            import_doc: Inportatu dokumentua
+          discard:
+            success: Parte-hartzaileen testu-zirriborro guztiak baztertu egin dira.
           import:
             invalid: Inprimakia baliogabea da!
             success: Zorionak, ondorengo atalak inportatutako dokumentutik aztertu dira, proposamen bihurtu dira. Orain argitalpenaren aurretik behar duzun guztia berrikusi eta egokitu dezakezu.
@@ -308,8 +333,6 @@ eu:
           publish:
             invalid: Ezin izan dira proposamenik argitaratu
             success: Proposamen guztiak argitaratu dira
-          discard:
-            success: Parte-hartzaileen testu-zirriborro guztiak baztertu egin dira.
           sections:
             article: "<em>artikuluaren</em>"
             section: "<em>Artikulua:</em> <strong>%{title}</strong>"
@@ -515,7 +538,7 @@ eu:
           request_access: Eskatu sarbidea
           requested_access: Eskatutako sarbidea
           see_other_versions: ikusi beste bertsio batzuk
-          version: '%{number}bertsioa'
+          version: "%{number}bertsioa"
           version_history: ikusi bertsioaren historia proposamen honetarako
           withdraw: kendu zirriborroa
         states:
@@ -587,6 +610,7 @@ eu:
           error: Erroreak gertatu dira proposamena bozkatzean.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Nire proposamena desberdina da
           no_similars_found: Ongi egina! Ez da antzeko proposamenik aurkitu
           title: Proposamen antzekoak
@@ -597,9 +621,14 @@ eu:
           proposals_count:
             one: "%{count} proposamen"
             other: "%{count} proposamen"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Aukerakoa) Gehitu eranskina"
           back: Back
+          not_geocoded: Not geocoded
           select_a_category: Hautatu kategoria bat
           send: Bidali
           title: Editatu proposamena
@@ -614,6 +643,7 @@ eu:
           comments: Oharrak
         filters:
           activity: Jarduera
+          amendment_type: Mota
           category: Kategoria
           category_prompt: Aukeratu kategoria bat
           origin: Jatorria
@@ -621,7 +651,6 @@ eu:
           search: Bilatu
           state: Estatu
           voted: Bozkatuta
-          amendment_type: Mota
         filters_small_view:
           close_modal: Itxi leihoa
           filter: Iragazi
@@ -649,13 +678,18 @@ eu:
             document_index: Dokumentuaren indizea
           view_index:
             see_index: Ikusi indizea
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Aldatu proposamena
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Proposamen hau argitaratu ondoren, lehenengo proposamena editatu ahal izango duzu. Behin leiho hau igarotzen denean, ezingo duzu proposamen hori editatu.
             other: Proposamen hau editatu ahal izango duzu lehenengo %{count} Proposamenaren ondoren argitaratutako minutuak. Behin leiho hau igarotzen denean, ezingo duzu proposamen hori editatu.
           publish: Argitaratu
           title: Argitaratu zure proposamena
+          update_pos: Update the position
         proposal:
           creation_date: 'Sorkuntza: %{date}'
           view_proposal: Ikusi proposamena
@@ -685,26 +719,32 @@ eu:
           no_votes_remaining: Ez da gelditzen botorik
           vote: Proiektuaren alde egin
           votes_blocked: Bozketa desaktibatu da
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: SOSTENGU
             other: SOSTENGU
           most_popular_proposal: Proposamenrik ezagunena
           need_more_votes: Botoak gehiago behar dituzu
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Proposamen bakoitza %{limit} euskarri baino gehiagotan pilatu daiteke
           minimum_votes_per_user:
             description: Gutxienez %{votes} boto eman behar dituzu proposamen desberdinen artean.
             given_enough_votes: Onartutako euskarri guztiak eman dituzu.
-            supports_remaining: '%{remaining_votes} boto gehiago proposatu behar dituzu zure botoak kontuan hartzeko.'
+            supports_remaining: "%{remaining_votes} boto gehiago proposatu behar dituzu zure botoak kontuan hartzeko."
           proposal_limit:
-            description: '%{limit} proposamen sortu ditzakezu.'
+            description: "%{limit} proposamen sortu ditzakezu."
           threshold_per_proposal:
             description: Onartutako proposamenak %{limit} euskarri behar ditu
           title: 'Botoak honako arauak ditu:'
           vote_limit:
-            description: '%{limit} proposamenari bozkatu ahal zaizkio.'
+            description: "%{limit} proposamenari bozkatu ahal zaizkio."
             left: Emateke
             votes: Euskarriak
         wizard_aside:
@@ -740,7 +780,7 @@ eu:
           version_number: Bertsio zenbakia
           version_number_out_of_total: "%{current_version} out of %{total_count}"
         version:
-          version_index: '%{index}bertsioa'
+          version_index: "%{index}bertsioa"
     resource_links:
       copied_from_component:
         proposal_proposal: Lotutako proposamenak

--- a/decidim-proposals/config/locales/fi-pl.yml
+++ b/decidim-proposals/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ fi-pl:
         title: Ehdotuksen nimi
         user_group_id: Luo yhteistyöluonnos nimellä
       proposal:
+        address: Address
         answer: Vastaus
         answered_at: Vastattu osoitteessa
         automatic_hashtags: Hashtagit lisätty automaattisesti
@@ -105,7 +107,16 @@ fi-pl:
             votes_blocked: Äänestys estetty
             votes_enabled: Äänestys käytössä
             votes_hidden: Piilotetut äänet (jos äänet ovat käytössä, tämä valitseminen piilottaa äänimäärän)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} on annettu käyttöoikeus yhteistyöluonnokseen <a href="%{resource_path}">%{resource_title}</a> osallistujana.'
@@ -113,7 +124,7 @@ fi-pl:
           email_subject: "%{requester_name} on hyväksytty osallistujaksi kohtaan %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> on <strong>hyväksytty osallistujaksi</strong> yheistyöluonnokseen <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_rejected:
-          email_intro: 'Käyttäjän %{requester_name} osallistuminen kohteeseen <a href="%{resource_path}">%{resource_title} </a>on estetty.'
+          email_intro: Käyttäjän %{requester_name} osallistuminen kohteeseen <a href="%{resource_path}">%{resource_title} </a>on estetty.
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet osallistuja kohteessa <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} on hylätty, jotta hän voi osallistua %{resource_title} yhteistyöhankkeeseen."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> <strong>avustajaoikeudet on hylätty</strong> yhteistyöluonnoksesta <a href="%{resource_path}">%{resource_title}</a>.
@@ -153,11 +164,15 @@ fi-pl:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi on hyväksytty
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> on hyväksytty.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Ehdotus "%{resource_title}" on hyväksytty. Voit lukea vastauksen täältä:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on hyväksytty
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on hyväksytty.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, jota seuraat, on juuri suositellut ehdotusta "%{resource_title}" ja uskomme, että tämä voi kiinnostaa sinua. Tutustu ehdotukseen ja osallistu:'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet seuraat %{endorser_nickname}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
@@ -169,11 +184,15 @@ fi-pl:
             email_outro: Saat tämän ilmoituksen, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi arvioidaan
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> arvioidaan.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Ehdotusta "%{resource_title}" arvioidaan parhaillaan. Voit tarkistaa vastauksen tältä sivulla:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on arvioitavana
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on arvioitavana.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Ehdotuksesi "%{mentioned_proposal_title}" on mainittu <a href="%{resource_path}">tässä tilassa</a> kommentissa.
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
@@ -195,11 +214,15 @@ fi-pl:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi hylättiin
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> on hylätty.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Ehdotus "%{resource_title}" on hylätty. Voit lukea vastauksen tällä sivulla:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on hylätty
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on hylätty.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Järjestelmänvalvoja on päivittänyt ehdotuksesi aihepiiriin "%{resource_title}", tarkista se:'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet ehdotuksen tekijä.
@@ -214,8 +237,8 @@ fi-pl:
       badges:
         accepted_proposals:
           conditions:
-            - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
-            - Yritä luoda ehdotuksia, jotka voidaan toteuttaa. Tällä tavoin ne todennäköisesti hyväksytään.
+          - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
+          - Yritä luoda ehdotuksia, jotka voidaan toteuttaa. Tällä tavoin ne todennäköisesti hyväksytään.
           description: Tämä kunniamerkki myönnetään, kun luot aktiivisesti uusia ehdotuksia ja ne hyväksytään.
           description_another: Tämä käyttäjä on saanut %{score} ehdotusta hyväksytyksi.
           description_own: Olet saanut %{score} ehdotusta hyväksyksi.
@@ -225,8 +248,8 @@ fi-pl:
           unearned_own: Sinulla ei ole vielä hyväksyttyjä ehdotuksia.
         proposal_votes:
           conditions:
-            - Selaa muiden ihmisten ehdotuksia ja käytä aikaa tutustumalla niihin
-            - Tue ehdotuksia, joita pidät tai jotka kiinnostavat sinua
+          - Selaa muiden ihmisten ehdotuksia ja käytä aikaa tutustumalla niihin
+          - Tue ehdotuksia, joita pidät tai jotka kiinnostavat sinua
           description: Tämä kunniamerkki myönnetään, kun tuet muiden ihmisten ehdotuksia.
           description_another: Tämä käyttäjä on kannattanut %{score} ehdotusta.
           description_own: Olet kannattanut %{score} ehdotusta.
@@ -236,8 +259,8 @@ fi-pl:
           unearned_own: Et ole vielä kannattanut ehdotuksia.
         proposals:
           conditions:
-            - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
-            - Luo uusi ehdotus
+          - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
+          - Luo uusi ehdotus
           description: Tämä kunniamerkki myönnetään, kun luot aktiivisesti uusia ehdotuksia.
           description_another: Tämä käyttäjä on luonut %{score} ehdotusta.
           description_own: Olet luonut %{score} ehdotusta.
@@ -290,8 +313,10 @@ fi-pl:
         participatory_texts:
           bulk-actions:
             are_you_sure: Haluatko varmasti hylätä koko ehdotusaineiston luonnoksen?
-            import_doc: Tuo aineisto
             discard_all: Hylkää kaikki
+            import_doc: Tuo aineisto
+          discard:
+            success: Kaikki ehdotusaineistojen luonnokset on hylätty.
           import:
             invalid: Lomake on virheellinen!
             success: Onnittelut, seuraavat osat on tuotu aineistosta ja ne on muunnettu ehdotuksiksi. Voit tarkistaa ja muuttaa mitä haluat ennen julkaisua.
@@ -308,8 +333,6 @@ fi-pl:
           publish:
             invalid: Ehdotuksia ei voitu julkaista
             success: Kaikki ehdotukset on julkaistu
-          discard:
-            success: Kaikki ehdotusaineistojen luonnokset on hylätty.
           sections:
             article: "<em>Kappalesisältö</em>"
             section: "<em>Osio:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ fi-pl:
           error: Äänestettäessä ehdotusta tapahtui virhe.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Ehdotukseni on erilainen
           no_similars_found: Hyvin tehty! Vastaavia ehdotuksia ei löytynyt
           title: Vastaavat ehdotukset
@@ -597,9 +621,14 @@ fi-pl:
           proposals_count:
             one: "%{count} ehdotus"
             other: "%{count} ehdotusta"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Valinnainen) Lisää liite"
           back: Takaisin
+          not_geocoded: Not geocoded
           select_a_category: Valitse aihepiiri
           send: Lähetä
           title: Muokkaa ehdotusta
@@ -614,6 +643,7 @@ fi-pl:
           comments: Kommentit
         filters:
           activity: Aktiivisuus
+          amendment_type: Tyyppi
           category: Aihepiiri
           category_prompt: Valitse aihepiiri
           origin: Alkuperä
@@ -621,7 +651,6 @@ fi-pl:
           search: Haku
           state: Tila
           voted: Äänestetty
-          amendment_type: Tyyppi
         filters_small_view:
           close_modal: Sulje ikkuna
           filter: Suodata
@@ -649,13 +678,18 @@ fi-pl:
             document_index: Asiakirjan hakemisto
           view_index:
             see_index: Näytä hakemisto
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Muokkaa ehdotusta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Voit muokata tätä ehdotusta ensimmäisen minuutin kuluttua ehdotuksen julkaisemisesta. Kun tämä aikaikkuna sulkeutuu, et pysty muokkaamaan ehdotusta.
             other: Voit muokata tätä ehdotusta ensimmäisten %{count} minuutin aikana ehdotuksen julkaisemisesta. Kun tämä aikaikkuna sulkeutuu, et pysty muokkaamaan ehdotusta.
           publish: Julkaise
           title: Julkaise ehdotuksesi
+          update_pos: Update the position
         proposal:
           creation_date: 'Luontiaika: %{date}'
           view_proposal: Näytä ehdotus
@@ -685,12 +719,18 @@ fi-pl:
           no_votes_remaining: Ei ääniä jäljellä
           vote: Äänestä
           votes_blocked: Äänestys estetty
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: ÄÄNI
             other: ÄÄNTÄ
           most_popular_proposal: Suosituin ehdotus
           need_more_votes: Tarvitsee enemmän ääniä
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Jokainen ehdotus voi kerätä yli %{limit} kannatusta

--- a/decidim-proposals/config/locales/fi.yml
+++ b/decidim-proposals/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ fi:
         title: Ehdotuksen nimi
         user_group_id: Luo yhteistyöluonnos nimellä
       proposal:
+        address: Address
         answer: Vastaus
         answered_at: Vastattu osoitteessa
         automatic_hashtags: Hashtagit lisätty automaattisesti
@@ -105,7 +107,16 @@ fi:
             votes_blocked: Äänestys estetty
             votes_enabled: Äänestys käytössä
             votes_hidden: Piilotetut äänet (jos äänet ovat käytössä, tämä valitseminen piilottaa äänimäärän)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} on annettu käyttöoikeus yhteistyöluonnokseen <a href="%{resource_path}">%{resource_title}</a> osallistujana.'
@@ -113,7 +124,7 @@ fi:
           email_subject: "%{requester_name} on hyväksytty osallistujaksi kohtaan %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> on <strong>hyväksytty osallistujaksi</strong> yheistyöluonnokseen <a href="%{resource_path}">%{resource_title}</a>.
         collaborative_draft_access_rejected:
-          email_intro: 'Käyttäjän %{requester_name} osallistuminen kohteeseen <a href="%{resource_path}">%{resource_title} </a>on estetty.'
+          email_intro: Käyttäjän %{requester_name} osallistuminen kohteeseen <a href="%{resource_path}">%{resource_title} </a>on estetty.
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet osallistuja kohteessa <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} on hylätty, jotta hän voi osallistua %{resource_title} yhteistyöhankkeeseen."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> <strong>avustajaoikeudet on hylätty</strong> yhteistyöluonnoksesta <a href="%{resource_path}">%{resource_title}</a>.
@@ -153,11 +164,15 @@ fi:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi on hyväksytty
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> on hyväksytty.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Ehdotus "%{resource_title}" on hyväksytty. Voit lukea vastauksen täältä:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on hyväksytty
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on hyväksytty.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, jota seuraat, on juuri suositellut ehdotusta "%{resource_title}" ja uskomme, että tämä voi kiinnostaa sinua. Tutustu ehdotukseen ja osallistu:'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet seuraat %{endorser_nickname}. Voit lopettaa ilmoitusten vastaanottamisen edellä esitetyn linkin kautta.
@@ -169,11 +184,15 @@ fi:
             email_outro: Saat tämän ilmoituksen, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi arvioidaan
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> arvioidaan.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Ehdotusta "%{resource_title}" arvioidaan parhaillaan. Voit tarkistaa vastauksen tältä sivulla:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on arvioitavana
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on arvioitavana.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Ehdotuksesi "%{mentioned_proposal_title}" on mainittu <a href="%{resource_path}">tässä tilassa</a> kommentissa.
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
@@ -195,11 +214,15 @@ fi:
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet luonut kohteen "%{resource_title}".
             email_subject: Ehdotuksesi hylättiin
             notification_title: Ehdotuksesi <a href="%{resource_path}">%{resource_title}</a> on hylätty.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Ehdotus "%{resource_title}" on hylätty. Voit lukea vastauksen tällä sivulla:'
             email_outro: Tämä ilmoitus on lähetetty sinulle, koska seuraat "%{resource_title}". Voit lopettaa sen seuraamisen edellä esitetyn linkin kautta.
             email_subject: Seuraamasi ehdotus on hylätty
             notification_title: Ehdotus <a href="%{resource_path}">%{resource_title}</a> on hylätty.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Järjestelmänvalvoja on päivittänyt ehdotuksesi aihepiiriin "%{resource_title}", tarkista se:'
           email_outro: Tämä ilmoitus on lähetetty sinulle, koska olet ehdotuksen tekijä.
@@ -214,8 +237,8 @@ fi:
       badges:
         accepted_proposals:
           conditions:
-            - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
-            - Yritä luoda ehdotuksia, jotka voidaan toteuttaa. Tällä tavoin ne todennäköisesti hyväksytään.
+          - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
+          - Yritä luoda ehdotuksia, jotka voidaan toteuttaa. Tällä tavoin ne todennäköisesti hyväksytään.
           description: Tämä kunniamerkki myönnetään, kun luot aktiivisesti uusia ehdotuksia ja ne hyväksytään.
           description_another: Tämä käyttäjä on saanut %{score} ehdotusta hyväksytyksi.
           description_own: Olet saanut %{score} ehdotusta hyväksyksi.
@@ -225,8 +248,8 @@ fi:
           unearned_own: Sinulla ei ole vielä hyväksyttyjä ehdotuksia.
         proposal_votes:
           conditions:
-            - Selaa muiden ihmisten ehdotuksia ja käytä aikaa tutustumalla niihin
-            - Tue ehdotuksia, joita pidät tai jotka kiinnostavat sinua
+          - Selaa muiden ihmisten ehdotuksia ja käytä aikaa tutustumalla niihin
+          - Tue ehdotuksia, joita pidät tai jotka kiinnostavat sinua
           description: Tämä kunniamerkki myönnetään, kun tuet muiden ihmisten ehdotuksia.
           description_another: Tämä käyttäjä on kannattanut %{score} ehdotusta.
           description_own: Olet kannattanut %{score} ehdotusta.
@@ -236,8 +259,8 @@ fi:
           unearned_own: Et ole vielä kannattanut ehdotuksia.
         proposals:
           conditions:
-            - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
-            - Luo uusi ehdotus
+          - Valitse kiinnostuksesi mukaan osallisuustila, jossa ehdotusten jättäminen on mahdollista
+          - Luo uusi ehdotus
           description: Tämä kunniamerkki myönnetään, kun luot aktiivisesti uusia ehdotuksia.
           description_another: Tämä käyttäjä on luonut %{score} ehdotusta.
           description_own: Olet luonut %{score} ehdotusta.
@@ -290,8 +313,10 @@ fi:
         participatory_texts:
           bulk-actions:
             are_you_sure: Haluatko varmasti hylätä koko ehdotusaineiston luonnoksen?
-            import_doc: Tuo aineisto
             discard_all: Hylkää kaikki
+            import_doc: Tuo aineisto
+          discard:
+            success: Kaikki ehdotusaineistojen luonnokset on hylätty.
           import:
             invalid: Lomake on virheellinen!
             success: Onnittelut, seuraavat osat on tuotu aineistosta ja ne on muunnettu ehdotuksiksi. Voit tarkistaa ja muuttaa mitä haluat ennen julkaisua.
@@ -308,8 +333,6 @@ fi:
           publish:
             invalid: Ehdotuksia ei voitu julkaista
             success: Kaikki ehdotukset on julkaistu
-          discard:
-            success: Kaikki ehdotusaineistojen luonnokset on hylätty.
           sections:
             article: "<em>Kappalesisältö</em>"
             section: "<em>Osio:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ fi:
           error: Äänestettäessä ehdotusta tapahtui virhe.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Ehdotukseni on erilainen
           no_similars_found: Hyvin tehty! Vastaavia ehdotuksia ei löytynyt
           title: Vastaavat ehdotukset
@@ -597,9 +621,14 @@ fi:
           proposals_count:
             one: "%{count} ehdotus"
             other: "%{count} ehdotusta"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Valinnainen) Lisää liite"
           back: Takaisin
+          not_geocoded: Not geocoded
           select_a_category: Valitse aihepiiri
           send: Lähetä
           title: Muokkaa ehdotusta
@@ -614,6 +643,7 @@ fi:
           comments: Kommentit
         filters:
           activity: Aktiivisuus
+          amendment_type: Tyyppi
           category: Aihepiiri
           category_prompt: Valitse aihepiiri
           origin: Alkuperä
@@ -621,7 +651,6 @@ fi:
           search: Haku
           state: Tila
           voted: Äänestetty
-          amendment_type: Tyyppi
         filters_small_view:
           close_modal: Sulje ikkuna
           filter: Suodata
@@ -649,13 +678,18 @@ fi:
             document_index: Asiakirjan hakemisto
           view_index:
             see_index: Näytä hakemisto
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Muokkaa ehdotusta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Voit muokata tätä ehdotusta ensimmäisen minuutin kuluttua ehdotuksen julkaisemisesta. Kun tämä aikaikkuna sulkeutuu, et pysty muokkaamaan ehdotusta.
             other: Voit muokata tätä ehdotusta ensimmäisten %{count} minuutin aikana ehdotuksen julkaisemisesta. Kun tämä aikaikkuna sulkeutuu, et pysty muokkaamaan ehdotusta.
           publish: Julkaise
           title: Julkaise ehdotuksesi
+          update_pos: Update the position
         proposal:
           creation_date: 'Luontiaika: %{date}'
           view_proposal: Näytä ehdotus
@@ -685,12 +719,18 @@ fi:
           no_votes_remaining: Ei ääniä jäljellä
           vote: Äänestä
           votes_blocked: Äänestys estetty
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: ÄÄNI
             other: ÄÄNTÄ
           most_popular_proposal: Suosituin ehdotus
           need_more_votes: Tarvitsee enemmän ääniä
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Jokainen ehdotus voi kerätä yli %{limit} kannatusta

--- a/decidim-proposals/config/locales/fr.yml
+++ b/decidim-proposals/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -173,7 +174,7 @@ fr:
             notification_title: La proposition <a href="%{resource_path}">%{resource_title}</a> est acceptée.
           notification_title: La proposition <a href="%{resource_path}">%{resource_title}</a> a été acceptée.
         proposal_endorsed:
-          email_intro: '%{endorser_name} %{endorser_nickname}, que vous suivez, vient de soutenir une proposition qui pourrait vous intéresser, consultez-la et contribuez :'
+          email_intro: "%{endorser_name} %{endorser_nickname}, que vous suivez, vient de soutenir une proposition qui pourrait vous intéresser, consultez-la et contribuez :"
           email_outro: Vous avez reçu cette notification parce que vous suivez %{endorser_nickname}. Vous pouvez arrêter de recevoir des notifications en cliquant sur ce dernier lien.
           email_subject: "%{endorser_nickname} a soutenu une nouvelle proposition"
           notification_title: La proposition <a href="%{resource_path}">%{resource_title}</a> a été soutenue par <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
@@ -198,7 +199,7 @@ fr:
           email_subject: Votre proposition "%{mentioned_proposal_title}" a été mentionnée
           notification_title: Votre proposition "%{mentioned_proposal_title}" a été mentionnée <a href="%{resource_path}">dans les commentaires de cet espace</a>.
         proposal_published:
-          email_intro: '%{author_name} %{author_nickname}, que vous suivez, a publié une nouvelle proposition. Découvrez-la et contribuez :'
+          email_intro: "%{author_name} %{author_nickname}, que vous suivez, a publié une nouvelle proposition. Découvrez-la et contribuez :"
           email_outro: Vous avez reçu cette notification car vous suivez %{author_nickname}. Vous pouvez cesser de recevoir des notifications en suivant le lien précédent.
           email_subject: Nouvelle proposition de %{author_nickname}
           notification_title: La proposition <a href="%{resource_path}">%{resource_title}</a> a été publiée par <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
@@ -236,19 +237,19 @@ fr:
       badges:
         accepted_proposals:
           conditions:
-            - Choisissez l'espace de participation qui vous intéresse avec la soumission des propositions activée
-            - Essayez de faire des propositions qui peuvent être réalisées. De cette façon, ils sont plus susceptibles d'être acceptés.
+          - Choisissez l'espace de participation qui vous intéresse avec la soumission des propositions activée
+          - Essayez de faire des propositions qui peuvent être réalisées. De cette façon, ils sont plus susceptibles d'être acceptés.
           description: Ce badge est attribué lorsque vous participez activement à de nouvelles propositions et que celles-ci sont acceptées.
-          description_another: '%{score} des propositions de cet utilisateur ont été acceptées.'
-          description_own: '%{score} de vos propositions ont été acceptées.'
+          description_another: "%{score} des propositions de cet utilisateur ont été acceptées."
+          description_own: "%{score} de vos propositions ont été acceptées."
           name: Propositions acceptées
           next_level_in: Vous atteindrez le niveau suivant lorsque %{score} propositions supplémentaires seront acceptés !
           unearned_another: Aucune proposition de cet auteur n'a encore été acceptée.
           unearned_own: Aucune de vos propositions n'a encore été acceptée.
         proposal_votes:
           conditions:
-            - Parcourir et passer du temps à lire les propositions d'autres personnes
-            - Soutenez les propositions que vous aimez ou trouvez intéressantes
+          - Parcourir et passer du temps à lire les propositions d'autres personnes
+          - Soutenez les propositions que vous aimez ou trouvez intéressantes
           description: Ce badge est attribué lorsque vous soutenez les propositions d'autres personnes.
           description_another: Cet utilisateur a soutenu %{score} propositions.
           description_own: Vous avez soutenu %{score} propositions.
@@ -258,8 +259,8 @@ fr:
           unearned_own: Vous n'avez soutenu aucune proposition pour le moment.
         proposals:
           conditions:
-            - Choisissez l'espace de participation qui vous intéresse avec la soumission des propositions activée
-            - Créer une nouvelle proposition
+          - Choisissez l'espace de participation qui vous intéresse avec la soumission des propositions activée
+          - Créer une nouvelle proposition
           description: Ce badge est attribué lorsque vous participez activement à de nouvelles propositions.
           description_another: Cet utilisateur a créé %{score} propositions.
           description_own: Vous avez créé %{score} propositions.
@@ -610,6 +611,7 @@ fr:
       proposals:
         compare:
           continue: Continuer
+          mine_is_different: Моя пропозиція інша
           no_similars_found: Bien joué ! Aucune proposition similaire n'a été trouvée
           title: Propositions similaires
         complete:
@@ -617,7 +619,7 @@ fr:
           title: Complétez votre proposition
         count:
           proposals_count:
-            one: "1 proposition"
+            one: 1 proposition
             other: "%{count} propositions"
         dynamic_map_instructions:
           primary: Vous pouvez déplacer le point sur la carte.

--- a/decidim-proposals/config/locales/gl.yml
+++ b/decidim-proposals/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ gl:
         title: Título
         user_group_id: Crear un borrador colaborativo como
       proposal:
+        address: Address
         answer: Resposta
         answered_at: Respondeu en
         automatic_hashtags: Engadíronse automaticamente os hexágonos
@@ -105,7 +107,16 @@ gl:
             votes_blocked: Voto bloqueado
             votes_enabled: Votación habilitada
             votes_hidden: Votos ocultos (se os votos están habilitados, a comprobación ocultará o número de votos)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} foi aceptado para acceder como colaborador do borrador colaborativo <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ gl:
             email_outro: Recibiches esta notificación porque es un autor de "%{resource_title}".
             email_subject: A túa proposta foi aceptada
             notification_title: A túa proposta <a href="%{resource_path}">%{resource_title}</a> foi aceptada.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'A proposta "%{resource_title}" foi aceptada. Podes ler a resposta nesta páxina:'
             email_outro: Recibiches esta notificación porque estás seguindo "%{resource_title}". Podes deixar de seguir desde a ligazón anterior.
             email_subject: Aceptouse unha proposta que estás seguindo
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi aceptada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, quen está seguindo, acaba de aprobar a proposta "%{resource_title}" e pensamos que pode ser interesante para ti. Consulte e contribúa:'
           email_outro: Recibiches esta notificación porque estás seguindo %{endorser_nickname}. Podes deixar de recibir notificacións seguindo a ligazón anterior.
@@ -169,11 +184,15 @@ gl:
             email_outro: Recibiches esta notificación porque es un autor de "%{resource_title}".
             email_subject: A túa proposta está a ser avaliada
             notification_title: A súa proposta <a href="%{resource_path}">%{resource_title}</a> está sendo avaliada.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'A proposta "%{resource_title}" está a ser avaliada. Podes consultar unha resposta nesta páxina:'
             email_outro: Recibiches esta notificación porque estás seguindo "%{resource_title}". Podes deixar de seguir desde a ligazón anterior.
             email_subject: Estase evaluando unha proposta que estás seguindo
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> está a ser avaliada.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: A túa proposta "%{mentioned_proposal_title}" foi mencionada <a href="%{resource_path}">neste espazo</a> nos comentarios.
           email_outro: Recibiches esta notificación porque es un autor de "%{resource_title}".
@@ -195,11 +214,15 @@ gl:
             email_outro: Recibiches esta notificación porque es un autor de "%{resource_title}".
             email_subject: A túa proposta foi rexeitada
             notification_title: A túa proposta <a href="%{resource_path}">%{resource_title}</a> foi rexeitada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'A proposta "%{resource_title}" foi rexeitada. Podes ler a resposta nesta páxina:'
             email_outro: Recibiches esta notificación porque estás seguindo "%{resource_title}". Podes deixar de seguir desde a ligazón anterior.
             email_subject: A proposta que segues foi rexeitada
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi rexeitada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Un administrador actualizou a categoría da túa proposta "%{resource_title}", comproba isto:'
           email_outro: Recibiches esta notificación porque es o autor da proposta.
@@ -214,8 +237,8 @@ gl:
       badges:
         accepted_proposals:
           conditions:
-            - Escolle o espazo de participación do teu interese coa presentación de propostas habilitadas
-            - Intente facer propostas que se poidan realizar. Deste xeito son máis propensos a ser aceptados.
+          - Escolle o espazo de participación do teu interese coa presentación de propostas habilitadas
+          - Intente facer propostas que se poidan realizar. Deste xeito son máis propensos a ser aceptados.
           description: Este distintivo concedeuse cando participas activamente con novas propostas e estas son aceptadas.
           description_another: Este usuario obtivo %{score} propostas aceptadas.
           description_own: Recibiches %{score} propostas.
@@ -225,8 +248,8 @@ gl:
           unearned_own: Aínda non recibiu propostas.
         proposal_votes:
           conditions:
-            - Busque e pase un tempo a ler as propostas doutras persoas
-            - Dea soporte ás propostas que che gustan ou que che resulten interesantes
+          - Busque e pase un tempo a ler as propostas doutras persoas
+          - Dea soporte ás propostas que che gustan ou que che resulten interesantes
           description: Este distintivo concedeuse cando apoias as propostas doutras persoas.
           description_another: Este usuario deu soporte a %{score} propostas.
           description_own: Vostede deu apoio a %{score} propostas.
@@ -236,8 +259,8 @@ gl:
           unearned_own: Xa deu soporte a ningunha proposta aínda.
         proposals:
           conditions:
-            - Escolle o espazo de participación do teu interese coa presentación de propostas habilitadas
-            - Crea unha nova proposta
+          - Escolle o espazo de participación do teu interese coa presentación de propostas habilitadas
+          - Crea unha nova proposta
           description: Este distintivo é concedido cando participas activamente con novas propostas.
           description_another: Este usuario creou %{score} propostas.
           description_own: Creaches %{score} propostas.
@@ -289,9 +312,11 @@ gl:
             name: Proposta
         participatory_texts:
           bulk-actions:
-            are_you_sure: '¿Está seguro de descartar o borrador de texto participativo enteiro?'
-            import_doc: Importar documento
+            are_you_sure: "¿Está seguro de descartar o borrador de texto participativo enteiro?"
             discard_all: Descartar todo
+            import_doc: Importar documento
+          discard:
+            success: Todos os borradores de texto participativos foron descartados.
           import:
             invalid: O formulario non é válido.
             success: Parabéns, foron analizadas as seguintes seccións do documento importado, convertéronse en propostas. Agora podes revisar e axustar o que necesites antes de publicar.
@@ -308,8 +333,6 @@ gl:
           publish:
             invalid: Non se puideron publicar propostas
             success: Todas as propostas foron publicadas
-          discard:
-            success: Todos os borradores de texto participativos foron descartados.
           sections:
             article: "<em>artigo</em>"
             section: "<em>Sección:</em> <strong>%{title}</strong>"
@@ -498,7 +521,7 @@ gl:
             title: Solicitudes de colaboración
           rejected_request:
             error: Non se puido rexeitar como colaborador, téntao de novo máis tarde.
-            success: "O @%{user} foi rexeitado correctamente como colaborador"
+            success: O @%{user} foi rexeitado correctamente como colaborador
         show:
           back: De volta
           edit: Editar borrador colaborativo
@@ -587,6 +610,7 @@ gl:
           error: Houbo erros ao votar a proposta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: A miña proposta é diferente
           no_similars_found: Ben feito! Non se atoparon propostas similares
           title: Propostas similares
@@ -597,15 +621,20 @@ gl:
           proposals_count:
             one: "%{count} proposta"
             other: "%{count} propostas"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Engada un anexo"
           back: De volta
+          not_geocoded: Not geocoded
           select_a_category: Selecciona unha categoría
           send: Enviar
           title: Editar proposta
         edit_draft:
           discard: Descarta este borrador
-          discard_confirmation: '¿Estás seguro de que desexas descartar este borrador de proposta?'
+          discard_confirmation: "¿Estás seguro de que desexas descartar este borrador de proposta?"
           send: Vista previa
           title: Editar borrador de proposta
         endorsement_identities_cabin:
@@ -614,6 +643,7 @@ gl:
           comments: Comentarios
         filters:
           activity: Actividade
+          amendment_type: Tipo
           category: Categoría
           category_prompt: Selecciona unha categoría
           origin: Orixe
@@ -621,7 +651,6 @@ gl:
           search: Busca
           state: Estado
           voted: Votado
-          amendment_type: Tipo
         filters_small_view:
           close_modal: Pechar modal
           filter: Filtro
@@ -649,13 +678,18 @@ gl:
             document_index: Índice do documento
           view_index:
             see_index: Ver índice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modificar a proposta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Poderá editar esta proposta durante o primeiro minuto despois de que a proposta se publique. Unha vez que pase esta xanela de tempo, non poderás editar a proposta.
             other: Poderás editar esta proposta durante o primeiro %{count} minutos despois da publicación da proposta. Unha vez que pase esta xanela de tempo, non poderás editar a proposta.
           publish: Publicar
           title: Publica a túa proposta
+          update_pos: Update the position
         proposal:
           creation_date: 'Creación: %{date}'
           view_proposal: Ver proposta
@@ -673,7 +707,7 @@ gl:
           proposal_rejected_reason: 'Esta proposta foi rexeitada porque:'
           report: Informe
           withdraw_btn_hint: Pode retirar a súa proposta se cambia de opinión, sempre que non teña recibido ningún apoio. A proposta non se elimina, aparecerá na lista de propostas retiradas.
-          withdraw_confirmation: '¿Estás seguro de retirar esta proposta?'
+          withdraw_confirmation: "¿Estás seguro de retirar esta proposta?"
           withdraw_proposal: Retire a proposta
         tags:
           changed_from: "(cambiado de <u>%{previous_category}</u> por un administrador)"
@@ -685,12 +719,18 @@ gl:
           no_votes_remaining: Non hai votos restantes
           vote: Vota
           votes_blocked: Votación desactivada
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: VOTAR
             other: VOTOS
           most_popular_proposal: A proposta máis popular
           need_more_votes: Necesita máis votos
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada proposta pode acumular máis de %{limit} apoios

--- a/decidim-proposals/config/locales/hu.yml
+++ b/decidim-proposals/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ hu:
         title: Cím
         user_group_id: Közösen szerkesztett vázlat
       proposal:
+        address: Address
         answer: Válasz
         answered_at: 'Megválaszolva:'
         automatic_hashtags: Hashtagek automatikusan hozzáadva
@@ -105,7 +107,16 @@ hu:
             votes_blocked: Szavazás letiltva
             votes_enabled: Szavazás engedélyezve
             votes_hidden: Szavazatok elrejtése (ha a szavazás engedélyezett, ez elrejti a szavazatok számát)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} jóváhagyva, mint közreműködő ebben a közösen szerkesztett vázlatban: <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ hu:
             email_outro: Ezt az értesítést megkapta, mert a "%{resource_title}" szerzője.
             email_subject: A javaslatodat elfogadták
             notification_title: Javaslata <a href="%{resource_path}">%{resource_title}</a> elfogadva.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'A(z) "%{resource_title}" című javaslat elfogadva. További részletek a következő oldalon:'
             email_outro: 'Ezt az értesítést azért kaptad, mert ezt követed: "%{resource_title}". Leiratkozás az előző link segítségével.'
             email_subject: A követett javaslatot elfogadták
             notification_title: A <a href="%{resource_path}">%{resource_title}</a> című javaslatot elfogadták.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, akit követel, épp most fogadta el a "%{resource_title}" javaslatot, és úgy gondoljuk, hogy érdekes lehet. Nézze meg és járuljon hozzá:'
           email_outro: 'Ezt az értesítést azért kaptad, mert őt követed: "%{endorser_nickname}". Az értesítéseket a következő linkre kattintva kapcsolhatod ki.'
@@ -169,11 +184,15 @@ hu:
             email_outro: Ezt az értesítést megkapta, mert a "%{resource_title}" szerzője.
             email_subject: A javaslat értékelése folyamatban van
             notification_title: Javaslata <a href="%{resource_path}">%{resource_title}</a> értékelődik.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'A(z) "%{resource_title}" című javaslatot éppen értékelik. További részletek a következő oldalon:'
             email_outro: 'Ezt az értesítést azért kaptad, mert ezt követed: "%{resource_title}". Leiratkozás az előző link segítségével.'
             email_subject: A követett javaslat értékelése folyamatban van
             notification_title: A(z) <a href="%{resource_path}">%{resource_title}</a> javaslat értékelése folyamatban.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: '"%{mentioned_proposal_title}" című javaslatodat említette valaki <a href="%{resource_path}">egy megjegyzésben</a>.'
           email_outro: Ezt az értesítést megkapta, mert a "%{resource_title}" szerzője.
@@ -195,11 +214,15 @@ hu:
             email_outro: Ezt az értesítést megkapta, mert a "%{resource_title}" szerzője.
             email_subject: Javaslata elutasításra került
             notification_title: Javaslata <a href="%{resource_path}">%{resource_title}</a> elutasításra került.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'A(z) "%{resource_title}" című javaslat elutasítva. További részletek a következő oldalon:'
             email_outro: 'Ezt az értesítést azért kaptad, mert ezt követed: "%{resource_title}". Leiratkozás az előző link segítségével.'
             email_subject: A követett javaslatot elutasították
             notification_title: A(z) <a href="%{resource_path}">%{resource_title}</a> című javaslatot elutasították.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Az admin frissítette a(z) "%{resource_title}" című javaslatod kategóriáját, ellenőrizd:'
           email_outro: Ezt az értesítést kaptad, mert te vagy a javaslat szerzője.
@@ -214,19 +237,19 @@ hu:
       badges:
         accepted_proposals:
           conditions:
-            - Válassza ki az Ön érdeklődési körének részvételi területét a beküldött pályázati ajánlatokkal
-            - Próbáljon javaslatokat tenni, amelyeket végre lehet hajtani. Így nagyobb valószínűséggel fogadják el őket.
+          - Válassza ki az Ön érdeklődési körének részvételi területét a beküldött pályázati ajánlatokkal
+          - Próbáljon javaslatokat tenni, amelyeket végre lehet hajtani. Így nagyobb valószínűséggel fogadják el őket.
           description: Ezt a jelvényt akkor kapja meg, ha aktívan részt vesz új javaslatokkal, és ezeket elfogadják.
           description_another: A felhasználó %{score} javaslatait elfogadták.
-          description_own: '%{score} ajánlatodat fogadták el.'
+          description_own: "%{score} ajánlatodat fogadták el."
           name: Elfogadott javaslatok
           next_level_in: Szerezz még több %{score} elfogadott ajánlatot, hogy eljuss a következő szintre!
           unearned_another: A felhasználónak még nincsenek elfogadott javaslatai.
           unearned_own: Még nincs elfogadott javaslatod.
         proposal_votes:
           conditions:
-            - Böngésszen és töltsön el egy ideig mások javaslatainak olvasását
-            - Támogatja a kedvelt javaslatokat, vagy érdekesnek találja azokat
+          - Böngésszen és töltsön el egy ideig mások javaslatainak olvasását
+          - Támogatja a kedvelt javaslatokat, vagy érdekesnek találja azokat
           description: Ezt a jelvényt akkor kapja meg, ha más emberek javaslatait támogatja.
           description_another: A felhasználó %{score} javaslatot támogatott.
           description_own: Eddig %{score} javaslatot támogattál.
@@ -236,8 +259,8 @@ hu:
           unearned_own: Még nem támogattál egyetlen javaslatot sem.
         proposals:
           conditions:
-            - Válassza ki az Ön érdeklődési körének részvételi területét a beküldött pályázati ajánlatokkal
-            - Hozzon létre egy új javaslatot
+          - Válassza ki az Ön érdeklődési körének részvételi területét a beküldött pályázati ajánlatokkal
+          - Hozzon létre egy új javaslatot
           description: Ezt a jelvényt akkor kapja meg, ha aktívan részt vesz új javaslatokkal.
           description_another: A felhasználó %{score} javaslatot hozott létre.
           description_own: Eddig %{score} javaslatot hoztál létre.
@@ -290,8 +313,10 @@ hu:
         participatory_texts:
           bulk-actions:
             are_you_sure: Biztos, hogy elveti az egész részvételi szöveg tervezet?
-            import_doc: Dokumentum importálása
             discard_all: Összes elvetése
+            import_doc: Dokumentum importálása
+          discard:
+            success: Az összes résztvevő szövegtervezetet elvetették.
           import:
             invalid: Az űrlap érvénytelen!
             success: Gratulálunk, az alábbi szakaszokat elemeztük az importált dokumentumból, és átkerültek javaslatokká. Mostantól megtekintheti és módosíthatja, amire szüksége van a közzététel előtt.
@@ -308,8 +333,6 @@ hu:
           publish:
             invalid: Nem sikerült közzé tenni a javaslatokat
             success: Minden pályázat megjelent
-          discard:
-            success: Az összes résztvevő szövegtervezetet elvetették.
           sections:
             article: "<em>Cikk</em>"
             section: "<em>szakasz:</em> <strong>%{title}</strong>"
@@ -515,7 +538,7 @@ hu:
           request_access: Hozzáférés kérése
           requested_access: Hozzáférés megkérve
           see_other_versions: más verziók
-          version: '%{number} verzió'
+          version: "%{number} verzió"
           version_history: nézd meg a javaslat verziótörténetét
           withdraw: tervezet visszavonása
         states:
@@ -533,7 +556,7 @@ hu:
           step_1: Hozd létre a közös vázlatod
           step_2: Összehasonlítás közös vázlatokkal
           step_3: Fejezd be a közös vázlatodat
-          step_of: '%{current_step_num}. lépés ennyiből: %{total_steps}'
+          step_of: "%{current_step_num}. lépés ennyiből: %{total_steps}"
       create:
         error: Hiba történt a javaslat mentése során.
         success: Javaslat létrehozása sikeres. Vázlatként mentve.
@@ -587,6 +610,7 @@ hu:
           error: Hiba történt a javaslatra való szavazás során.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Javaslatom más jellegű
           no_similars_found: Szép munka! Nincsen hasonló javaslat
           title: Hasonló javaslatok
@@ -597,9 +621,14 @@ hu:
           proposals_count:
             one: "%{count} javaslat"
             other: "%{count} javaslatot"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Nem kötelező) Melléklet hozzáadása"
           back: Vissza
+          not_geocoded: Not geocoded
           select_a_category: Válassz kategóriát
           send: Küldés
           title: Javaslat szerkesztése
@@ -614,6 +643,7 @@ hu:
           comments: Hozzászólások
         filters:
           activity: Tevékenység
+          amendment_type: Típus
           category: Kategória
           category_prompt: Válassz kategóriát
           origin: Kiindulópont
@@ -621,7 +651,6 @@ hu:
           search: Keresés
           state: Állapot
           voted: Szavazott
-          amendment_type: Típus
         filters_small_view:
           close_modal: Modal bezárása
           filter: Szűrés
@@ -649,13 +678,18 @@ hu:
             document_index: Dokumentum index
           view_index:
             see_index: Lásd az indexet
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Javaslat módosítása
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Ezt a javaslatot a közzétételt követő első percben azonnal szerkesztheted. Miután azonban ez az ablak bezárult, többé nem fogod tudni szerkeszteni a javaslatot.
             other: Ezt a javaslatot a közzétételt követő %{count}. percben már szerkesztheted. Miután azonban ez az ablak bezárult, többé nem fogod tudni szerkeszteni a javaslatot.
           publish: Közzétesz
           title: Javaslatod közzététele
+          update_pos: Update the position
         proposal:
           creation_date: 'Létrehozás: %{date}'
           view_proposal: Javaslat megtekintése
@@ -685,12 +719,18 @@ hu:
           no_votes_remaining: Nincs több szavazat
           vote: Szavazás
           votes_blocked: Szavazás letiltva
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: SZAVAZAT
             other: SZAVAZATOK
           most_popular_proposal: Legnépszerűbb javaslat
           need_more_votes: Több szavazat kell
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Az egyes javaslatok több mint %{limit} támogatást szerezhetnek
@@ -716,7 +756,7 @@ hu:
           step_2: Összehasonlítás
           step_3: Befejez
           step_4: Javaslatod közzététele
-          step_of: '%{current_step_num}. lépés ennyiből: %{total_steps}'
+          step_of: "%{current_step_num}. lépés ennyiből: %{total_steps}"
       publish:
         error: Hiba történt a javaslat közzététele során.
         success: Javaslat közzététele sikeres.
@@ -740,7 +780,7 @@ hu:
           version_number: Verziószám
           version_number_out_of_total: "%{current_version} ennyiből: %{total_count}"
         version:
-          version_index: '%{index} verzió'
+          version_index: "%{index} verzió"
     resource_links:
       copied_from_component:
         proposal_proposal: Kapcsolódó javaslatok

--- a/decidim-proposals/config/locales/id-ID.yml
+++ b/decidim-proposals/config/locales/id-ID.yml
@@ -1,739 +1,785 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       collaborative_draft:
-        body: Tubuh
-        category_id: Kategori
-        decidim_scope_id: Cakupan
-        has_address: Memiliki alamat
-        state: Negara
-        title: Judul
-        user_group_id: Buat draf kolaboratif sebagai
+        body: Body
+        category_id: Category
+        decidim_scope_id: Scope
+        has_address: Has address
+        state: State
+        title: Title
+        user_group_id: Create collaborative draft as
       proposal:
-        answer: Menjawab
-        answered_at: Dijawab di
-        automatic_hashtags: Hashtag secara otomatis ditambahkan
-        body: Tubuh
-        category_id: Kategori
-        has_address: Memiliki alamat
-        scope_id: Cakupan
-        state: Negara
-        suggested_hashtags: Tagar yang disarankan
-        title: Judul
-        user_group_id: Buat proposal sebagai
+        address: Address
+        answer: Answer
+        answered_at: Answered at
+        automatic_hashtags: Hashtags automatically added
+        body: Body
+        category_id: Category
+        has_address: Has address
+        scope_id: Scope
+        state: State
+        suggested_hashtags: Suggested hashtags
+        title: Title
+        user_group_id: Create proposal as
       proposal_answer:
-        answer: Menjawab
+        answer: Answer
       proposals_copy:
-        copy_proposals: Saya memahami bahwa ini akan mengimpor semua proposal dari komponen yang dipilih ke komponen saat ini dan bahwa tindakan ini tidak dapat dibatalkan.
-        origin_component_id: Komponen untuk menyalin proposal dari
+        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
+        origin_component_id: Component to copy the proposals from
     errors:
       models:
         proposal:
           attributes:
             attachment:
-              needs_to_be_reattached: Perlu disambungkan kembali
+              needs_to_be_reattached: Needs to be reattached
     models:
-      decidim/proposals/accepted_proposal_event: Proposal diterima
-      decidim/proposals/admin/update_proposal_category_event: Kategori proposal berubah
-      decidim/proposals/creation_enabled_event: Pembuatan proposal diaktifkan
-      decidim/proposals/endorsing_enabled_event: Proposal dukungan diaktifkan
-      decidim/proposals/evaluating_proposal_event: Proposal sedang dievaluasi
-      decidim/proposals/proposal_endorsed_event: Proposal disetujui
-      decidim/proposals/proposal_mentioned_event: Proposal disebutkan
-      decidim/proposals/publish_proposal_event: Proposal dipublikasikan
-      decidim/proposals/rejected_proposal_event: Proposal ditolak
-      decidim/proposals/voting_enabled_event: Pemungutan suara proposal diaktifkan
+      decidim/proposals/accepted_proposal_event: Proposal accepted
+      decidim/proposals/admin/update_proposal_category_event: Proposal category changed
+      decidim/proposals/creation_enabled_event: Proposal creation enabled
+      decidim/proposals/endorsing_enabled_event: Proposal endorsing enabled
+      decidim/proposals/evaluating_proposal_event: Proposal is being evaluated
+      decidim/proposals/proposal_endorsed_event: Proposal endorsed
+      decidim/proposals/proposal_mentioned_event: Proposal mentioned
+      decidim/proposals/publish_proposal_event: Proposal published
+      decidim/proposals/rejected_proposal_event: Proposal rejected
+      decidim/proposals/voting_enabled_event: Proposal voting enabled
   activerecord:
     models:
       decidim/proposals/collaborative_draft:
-        other: Draf kolaboratif
+        one: Collaborative draft
+        other: Collaborative drafts
       decidim/proposals/proposal:
-        other: Proposal
+        one: Proposal
+        other: Proposals
       decidim/proposals/proposal_endorsement:
-        other: Endorsemen
+        one: Endorsement
+        other: Endorsements
       decidim/proposals/proposal_note:
-        other: Catatan
+        one: Note
+        other: Notes
       decidim/proposals/proposal_vote:
-        other: Suara
+        one: Vote
+        other: Votes
   decidim:
     components:
       proposals:
         actions:
-          create: Membuat
-          endorse: Mengesahkan
-          vote: Memilih
-          withdraw: Menarik
-        name: Proposal
+          create: Create
+          endorse: Endorse
+          vote: Vote
+          withdraw: Withdraw
+        name: Proposals
         settings:
           global:
-            amendments_enabled: Amandemen diaktifkan
-            announcement: Pengumuman
-            attachments_allowed: Izinkan lampiran
-            can_accumulate_supports_beyond_threshold: Dapat mengumpulkan dukungan di luar ambang batas
-            collaborative_drafts_enabled: Draf kolaboratif diaktifkan
-            comments_enabled: Komentar diaktifkan
-            geocoding_enabled: Geocoding diaktifkan
-            minimum_votes_per_user: Suara minimum per pengguna
-            new_proposal_help_text: Teks bantuan proposal baru
-            official_proposals_enabled: Proposal resmi diaktifkan
-            participatory_texts_enabled: Teks partisipatif diaktifkan
-            proposal_answering_enabled: Pengangkatan proposal diaktifkan
-            proposal_edit_before_minutes: Proposal dapat diedit oleh penulis sebelum ini banyak menit berlalu
-            proposal_length: Panjang badan proposal maksimum
-            proposal_limit: Batas proposal per pengguna
-            proposal_wizard_step_1_help_text: Panduan proposal "Buat" teks bantuan langkah
-            proposal_wizard_step_2_help_text: Proposal wizard "Bandingkan" langkah bantuan teks
-            proposal_wizard_step_3_help_text: Panduan proposal, selesaikan langkah bantuan teks
-            proposal_wizard_step_4_help_text: Panduan proposal "Publikasikan" langkah bantuan teks
-            resources_permissions_enabled: Izin tindakan dapat diatur untuk setiap proposal
-            threshold_per_proposal: Ambang batas per proposal
-            vote_limit: Batas suara per pengguna
+            amendments_enabled: Amendments enabled
+            announcement: Announcement
+            attachments_allowed: Allow attachments
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
+            collaborative_drafts_enabled: Collaborative drafts enabled
+            comments_enabled: Comments enabled
+            geocoding_enabled: Geocoding enabled
+            minimum_votes_per_user: Minimum votes per user
+            new_proposal_help_text: New proposal help text
+            official_proposals_enabled: Official proposals enabled
+            participatory_texts_enabled: Participatory texts enabled
+            proposal_answering_enabled: Proposal answering enabled
+            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
+            proposal_length: Maximum proposal body length
+            proposal_limit: Proposal limit per user
+            proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
+            resources_permissions_enabled: Actions permissions can be set for each proposal
+            threshold_per_proposal: Threshold per proposal
+            vote_limit: Vote limit per user
           step:
-            announcement: Pengumuman
-            automatic_hashtags: Hashtag ditambahkan ke semua proposal
-            comments_blocked: Komentar diblokir
-            creation_enabled: Pembuatan proposal diaktifkan
-            endorsements_blocked: Pengesahan dicekal
-            endorsements_enabled: Pengesahan diaktifkan
-            proposal_answering_enabled: Pengangkatan proposal diaktifkan
-            suggested_hashtags: Hashtag disarankan kepada pengguna untuk proposal baru
-            votes_blocked: Voting diblokir
-            votes_enabled: Voting diaktifkan
-            votes_hidden: Memberi suara tersembunyi (jika suara diaktifkan, memeriksa ini akan menyembunyikan jumlah suara)
+            announcement: Announcement
+            automatic_hashtags: Hashtags added to all proposals
+            comments_blocked: Comments blocked
+            creation_enabled: Proposal creation enabled
+            endorsements_blocked: Endorsements blocked
+            endorsements_enabled: Endorsements enabled
+            proposal_answering_enabled: Proposal answering enabled
+            suggested_hashtags: Hashtags suggested to users for new proposals
+            votes_blocked: Voting blocked
+            votes_enabled: Voting enabled
+            votes_hidden: Votes hidden (if votes are enabled, checking this will hide the number of votes)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} telah diterima untuk diakses sebagai kontributor dari draft kolaboratif <a href="%{resource_path}">%{resource_title}</a>.'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah kolaborator dari <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} telah diterima untuk diakses sebagai kontributor dari %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> telah <strong>diterima untuk mengakses sebagai kontributor</strong> dari <a href="%{resource_path}">%{resource_title}</a> draf kolaboratif.
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} telah ditolak untuk diakses sebagai kontributor dari draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah kolaborator dari <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} telah ditolak untuk diakses sebagai kontributor dari %{resource_title} draf kolaboratif."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> telah ditolak <strong>sebagai kontributor</strong> dari <a href="%{resource_path}">%{resource_title}</a> draf kolaboratif.
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} akses yang diminta sebagai kontributor. Anda dapat <strong>menerima atau menolak permintaan</strong> dari halaman draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah kolaborator dari <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} akses yang diminta untuk berkontribusi ke %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> meminta akses untuk berkontribusi</a> draf kolaboratif <a href="%{resource_path}">%{resource_title}</a> . Harap <strong>menerima atau menolak permintaan</strong>.
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: Anda telah diterima untuk mengakses sebagai kontributor dari draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda diminta untuk menjadi kolaborator <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: Anda telah diterima sebagai kontributor %{resource_title}.
-          notification_title: Anda telah <strong>diterima untuk mengakses sebagai kontributor</strong> dari draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been accepted as a contributor of %{resource_title}.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: Anda telah ditolak untuk mengakses sebagai kontributor dari draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda diminta untuk menjadi kolaborator <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: Anda telah ditolak sebagai kontributor %{resource_title}.
-          notification_title: Anda telah ditolak <strong>untuk mengakses sebagai kontributor</strong> dari draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been rejected as a contributor of %{resource_title}.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> menarik draf kolaboratif <a href="%{resource_path}">%{resource_title}</a>.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah kolaborator dari <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{author_name} %{author_nickname} menarik %{resource_title} draf kolaboratif."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>menarik</strong> dari <a href="%{resource_path}">%{resource_title}</a> draft kolaboratif.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
-          email_intro: 'Anda sekarang dapat membuat proposal baru di %{participatory_space_title}! Mulai berpartisipasi di halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Proposal kini tersedia dalam %{participatory_space_title}
-          notification_title: Anda sekarang dapat mengajukan <a href="%{resource_path}">proposal baru</a> dalam <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals now available in %{participatory_space_title}
+          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'Anda dapat mendukung proposal dalam %{participatory_space_title}! Mulai berpartisipasi di halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Proposal yang mendukung telah dimulai untuk %{participatory_space_title}
-          notification_title: Anda sekarang dapat mulai <a href="%{resource_path}">mengesahkan proposal</a> dalam <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals endorsing has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
           affected_user:
-            email_intro: 'Proposal Anda "%{resource_title}" telah diterima. Anda dapat membaca jawabannya di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah pengarang "%{resource_title}".
-            email_subject: Proposal Anda telah diterima
-            notification_title: Proposal Anda <a href="%{resource_path}">%{resource_title}</a> telah diterima.
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal has been accepted
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
-            email_intro: 'Proposal "%{resource_title}" telah diterima. Anda dapat membaca jawabannya di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-            email_subject: Proposal yang Anda ikuti telah diterima
-            notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> telah diterima.
+            email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following has been accepted
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
-          email_intro: '%{endorser_name} %{endorser_nickname}, yang Anda ikuti, baru saja menyetujui proposal "%{resource_title}" dan kami pikir itu mungkin menarik bagi Anda. Lihat dan sumbangkan:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{endorser_nickname}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: "%{endorser_nickname} telah mengesahkan proposal baru"
-          notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> telah disetujui oleh <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: "%{endorser_nickname} has endorsed a new proposal"
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
         proposal_evaluating:
           affected_user:
-            email_intro: 'Proposal Anda "%{resource_title}" saat ini sedang dievaluasi. Anda dapat memeriksa jawaban di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah pengarang "%{resource_title}".
-            email_subject: Proposal Anda sedang dievaluasi
-            notification_title: Proposal Anda <a href="%{resource_path}">%{resource_title}</a> sedang dievaluasi.
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal is being evaluated
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
-            email_intro: 'Proposal "%{resource_title}" saat ini sedang dievaluasi. Anda dapat memeriksa jawaban di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-            email_subject: Proposal yang Anda ikuti sedang dievaluasi
-            notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> sedang dievaluasi.
+            email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following is being evaluated
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
-          email_intro: Proposal Anda "%{mentioned_proposal_title}" telah disebutkan <a href="%{resource_path}">dalam ruang</a> di komentar.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah pengarang "%{resource_title}".
-          email_subject: Proposal Anda "%{mentioned_proposal_title}" telah disebutkan
-          notification_title: Proposal Anda "%{mentioned_proposal_title}" telah disebutkan <a href="%{resource_path}">dalam ruang</a> di komentar.
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          email_outro: You have received this notification because you are an author of "%{resource_title}".
+          email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: '%{author_name} %{author_nickname}, siapa yang Anda ikuti, telah menerbitkan proposal baru yang disebut "%{resource_title}". Lihat dan sumbangkan:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{author_nickname}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Proposal baru "%{resource_title}" oleh %{author_nickname}
-          notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> diterbitkan oleh <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: New proposal "%{resource_title}" by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: Proposal "%{resource_title}" telah ditambahkan ke "%{participatory_space_title}" yang Anda ikuti.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{participatory_space_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Proposal baru "%{resource_title}" ditambahkan ke %{participatory_space_title}
-          notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> telah ditambahkan ke %{participatory_space_title}
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         proposal_rejected:
           affected_user:
-            email_intro: 'Proposal Anda "%{resource_title}" telah ditolak. Anda dapat membaca jawabannya di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah pengarang "%{resource_title}".
-            email_subject: Proposal Anda ditolak
-            notification_title: Proposal Anda <a href="%{resource_path}">%{resource_title}</a> telah ditolak.
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal been rejected
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
-            email_intro: 'Proposal "%{resource_title}" telah ditolak. Anda dapat membaca jawabannya di halaman ini:'
-            email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{resource_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-            email_subject: Proposal yang Anda ikuti telah ditolak
-            notification_title: Proposal <a href="%{resource_path}">%{resource_title}</a> telah ditolak.
+            email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following has been rejected
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
-          email_intro: 'Admin telah memperbarui kategori proposal Anda "%{resource_title}", periksa ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda adalah penulis proposal.
-          email_subject: Kategori proposal %{resource_title} telah diperbarui
-          notification_title: Kategori proposal <a href="%{resource_path}">%{resource_title}</a> telah diperbarui oleh admin.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out:'
+          email_outro: You have received this notification because you are the author of the proposal.
+          email_subject: The %{resource_title} proposal category has been updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'Anda dapat memilih proposal dalam %{participatory_space_title}! Mulai berpartisipasi di halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima notifikasi mengikuti tautan sebelumnya.
-          email_subject: Proposal voting telah dimulai untuk %{participatory_space_title}
-          notification_title: Anda sekarang dapat memulai <a href="%{resource_path}">proposal voting</a> dalam <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can vote proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals voting has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">voting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
-          conditions:
-            - Pilih ruang partisipasi yang Anda minati dengan penyerahan agar proposal diaktifkan
-            - Cobalah membuat proposal yang bisa dilakukan. Dengan cara ini mereka lebih mungkin diterima.
-          description: Lencana ini diberikan ketika Anda secara aktif berpartisipasi dengan proposal baru dan ini diterima.
-          description_another: Pengguna ini telah menerima %{score} proposal.
-          description_own: Anda mendapat %{score} proposal diterima.
-          name: Proposal yang diterima
-          next_level_in: Dapatkan %{score} proposal lagi diterima untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum menerima proposal apa pun.
-          unearned_own: Anda belum menerima proposal.
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Try to make proposals that can be carried out. This way they are more likely to be accepted."]'
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          description_another: This user has gotten %{score} proposals accepted.
+          description_own: You got %{score} proposals accepted.
+          name: Accepted proposals
+          next_level_in: Get %{score} more proposals accepted to reach the next level!
+          unearned_another: This user hasn't gotten any proposals accepted yet.
+          unearned_own: You got no proposals accepted yet.
         proposal_votes:
-          conditions:
-            - Jelajahi dan habiskan waktu untuk membaca proposal orang lain
-            - Berikan dukungan pada proposal yang Anda sukai atau temukan menarik
-          description: Lencana ini diberikan saat Anda mendukung proposal orang lain.
-          description_another: Pengguna ini telah memberikan dukungan untuk %{score} proposal.
-          description_own: Anda telah memberikan dukungan untuk %{score} proposal.
-          name: Dukungan proposal
-          next_level_in: Berikan dukungan untuk %{score} lebih banyak proposal untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum memberikan dukungan untuk proposal apa pun.
-          unearned_own: Anda telah memberi dukungan untuk belum ada proposal.
+          conditions: '["Browse and spend some time reading other people''s proposals", "Give support to the proposals you like or find interesting"]'
+          description: This badge is granted when you support other people's proposals.
+          description_another: This user has given support to %{score} proposals.
+          description_own: You have given support to %{score} proposals.
+          name: Proposal supports
+          next_level_in: Give support to %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't given support to any proposals yet.
+          unearned_own: You have given support to no proposals yet.
         proposals:
-          conditions:
-            - Pilih ruang partisipasi yang Anda minati dengan penyerahan agar proposal diaktifkan
-            - Buat proposal baru
-          description: Lencana ini diberikan ketika Anda secara aktif berpartisipasi dengan proposal baru.
-          description_another: Pengguna ini telah membuat %{score} proposal.
-          description_own: Anda telah membuat %{score} proposal.
-          name: Proposal
-          next_level_in: Buat %{score} proposal lagi untuk mencapai level berikutnya!
-          unearned_another: Pengguna ini belum membuat proposal apa pun.
-          unearned_own: Anda belum membuat proposal.
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Create a new proposal"]'
+          description: This badge is granted when you actively participate with new proposals.
+          description_another: This user has created %{score} proposals.
+          description_own: You have created %{score} proposals.
+          name: Proposals
+          next_level_in: Create %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't created any proposals yet.
+          unearned_own: You have created no proposals yet.
     metrics:
       accepted_proposals:
-        description: Jumlah proposal yang diterima oleh pengguna
-        object: proposal
-        title: Proposal yang Diterima
+        description: Number of proposals accepted by users
+        object: proposals
+        title: Accepted Proposals
       endorsements:
-        description: Jumlah dukungan yang dihasilkan dalam proposal
-        object: dukungan
-        title: Endorsemen
+        description: Number of endorsements generated in proposals
+        object: endorsements
+        title: Endorsements
       proposals:
-        description: Jumlah proposal yang dihasilkan
-        object: proposal
-        title: Proposal
+        description: Number of proposals generated
+        object: proposals
+        title: Proposals
       votes:
-        description: Jumlah suara yang dihasilkan dalam proposal oleh pengguna
-        object: suara
-        title: Suara
+        description: Number of votes generated in proposals by users
+        object: votes
+        title: Votes
     participatory_processes:
       participatory_process_groups:
         highlighted_proposals:
-          proposals: Proposal
+          proposals: Proposals
     participatory_spaces:
       highlighted_proposals:
-        see_all: Lihat semua (%{count})
+        see_all: See all (%{count})
     proposals:
       actions:
-        answer: Menjawab
+        answer: Answer
         edit_proposal: Edit proposal
-        import: Impor dari komponen lain
-        new: Proposal baru
-        participatory_texts: Teks partisipatif
-        private_notes: Catatan pribadi
-        title: Tindakan
+        import: Import from another component
+        new: New proposal
+        participatory_texts: Participatory texts
+        private_notes: Private notes
+        title: Actions
       admin:
         actions:
           preview: Preview
         exports:
-          comments: Komentar
-          proposals: Proposal
+          comments: Comments
+          proposals: Proposals
         models:
           proposal:
-            name: Usul
+            name: Proposal
         participatory_texts:
           bulk-actions:
-            are_you_sure: Apakah Anda yakin akan membuang seluruh konsep teks partisipatif?
-            import_doc: Impor dokumen
-            discard_all: Buang semua
-          import:
-            invalid: Formulirnya tidak valid!
-            success: Selamat, bagian berikut telah diuraikan dari dokumen yang diimpor, mereka telah dikonversi menjadi proposal. Sekarang Anda dapat meninjau dan menyesuaikan apa pun yang Anda perlukan sebelum memublikasikan.
-          index:
-            info_1: Bagian berikut telah diurai dari dokumen yang diimpor, mereka telah dikonversi menjadi proposal. Sekarang Anda dapat meninjau dan menyesuaikan apa pun yang Anda perlukan sebelum memublikasikan.
-            publish_document: Publikasikan dokumen
-            save_draft: Menyimpan konsep
-            title: TEKNIK PREVIEW TEKNIKAL
-          new_import:
-            bottom_hint: "(Anda akan dapat melihat dan menyortir bagian dokumen)"
-            document_legend: 'Tambahkan dokumen yang lebih kecil dari 2MB, setiap bagian hingga 3 level akan diolah menjadi Proposal. Format yang ditawar adalah: Penurunan harga'
-            title: TAMBAHKAN DOKUMEN
-            upload_document: Unggah dokumen
-          publish:
-            invalid: Tidak dapat memublikasikan proposal
-            success: Semua proposal telah dipublikasikan
+            are_you_sure: Are you sure to discard the whole participatory text draft?
+            discard_all: Discard all
+            import_doc: Import document
           discard:
-            success: Semua konsep teks Partisipatif telah dibuang.
+            success: All Participatory text drafts have been discarded.
+          import:
+            invalid: The form is invalid!
+            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+          index:
+            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            publish_document: Publish document
+            save_draft: Save draft
+            title: PREVIEW PARTICIPATORY TEXT
+          new_import:
+            bottom_hint: "(You will be able to preview and sort document sections)"
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            title: ADD DOCUMENT
+            upload_document: Upload document
+          publish:
+            invalid: Could not publish proposals
+            success: All proposals have been published
           sections:
-            article: "<em>Pasal</em>"
-            section: "<em>Bagian:</em> <strong>%{title}</strong>"
-            sub-section: "<em>Sub-bagian:</em> %{title}"
+            article: "<em>Article</em>"
+            section: "<em>Section:</em> <strong>%{title}</strong>"
+            sub-section: "<em>Subsection:</em> %{title}"
           update:
-            success: Teks partisipatif berhasil diperbarui.
+            success: Participatory text updated successfully.
         proposal_answers:
           edit:
-            accepted: Diterima
-            answer_proposal: Menjawab
-            evaluating: Mengevaluasi
-            rejected: Ditolak
-            title: Jawaban untuk proposal %{title}
+            accepted: Accepted
+            answer_proposal: Answer
+            evaluating: Evaluating
+            rejected: Rejected
+            title: Answer for proposal %{title}
         proposal_notes:
           create:
-            error: Ada masalah saat membuat catatan proposal ini
-            success: Catatan proposal berhasil dibuat
+            error: There's been a problem creating this proposal note
+            success: Proposal note successfully created
           form:
-            note: Catatan
-            submit: Menyerahkan
-          leave_your_note: Tinggalkan catatanmu
-          title: Catatan pribadi
+            note: Note
+            submit: Submit
+          leave_your_note: Leave your note
+          title: Private notes
         proposals:
           answer:
-            invalid: Ada masalah saat menjawab proposal ini
-            success: Proposal berhasil dijawab
+            invalid: There's been a problem answering this proposal
+            success: Proposal successfully answered
           create:
-            invalid: Ada masalah saat membuat proposal ini
-            success: Proposal berhasil dibuat
+            invalid: There's been a problem creating this proposal
+            success: Proposal successfully created
           edit:
-            title: Perbarui proposal
-            update: Memperbarui
+            title: Update proposal
+            update: Update
           form:
-            attachment_legend: "(Opsional) Tambahkan lampiran"
-            created_in_meeting: Proposal ini berasal dari rapat
-            select_a_category: Pilih Kategori
-            select_a_meeting: Pilih rapat
+            attachment_legend: "(Optional) Add an attachment"
+            created_in_meeting: This proposal comes from a meeting
+            select_a_category: Select a category
+            select_a_meeting: Select a meeting
           index:
-            actions: Tindakan
-            cancel: Membatalkan
-            change_category: Ubah kategori
-            merge: Bergabunglah dengan yang baru
-            merge_button: Menggabungkan
-            select_component: Pilih komponen
-            selected: terpilih
-            split: Bagi proposal
-            split_button: Membagi
-            title: Proposal
-            update: Memperbarui
+            actions: Actions
+            cancel: Cancel
+            change_category: Change category
+            merge: Merge into a new one
+            merge_button: Merge
+            select_component: Select a component
+            selected: selected
+            split: Split proposals
+            split_button: Split
+            title: Proposals
+            update: Update
           new:
-            create: Membuat
-            title: Buat proposal
+            create: Create
+            title: Create proposal
           update_category:
-            invalid: 'Proposal ini sudah memiliki kategori %{category} : %{proposals}.'
-            select_a_category: Silakan pilih kategori
-            select_a_proposal: Silakan pilih proposal
-            success: 'Proposal berhasil diperbarui ke kategori %{category} : %{proposals}.'
+            invalid: 'These proposals already had the %{category} category: %{proposals}.'
+            select_a_category: Please select a category
+            select_a_proposal: Please select a proposal
+            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
         proposals_imports:
           create:
-            invalid: Ada masalah saat mengimpor proposal
-            success: "%{number} proposal berhasil diimpor"
+            invalid: There's been a problem importing the proposals
+            success: "%{number} proposals successfully imported"
           new:
-            create: Mengimpor proposal
-            no_components: Tidak ada komponen proposal lain dalam ruang partisipatif ini untuk mengimpor proposal dari.
-            select_component: Silakan pilih komponen
-            select_states: Periksa status proposal untuk diimpor
+            create: Import proposals
+            no_components: There are no other proposal components in this participatory space to import the proposals from.
+            select_component: Please select a component
+            select_states: Check the states of the proposals to import
         proposals_merges:
           create:
-            invalid: Terjadi kesalahan saat menggabungkan proposal yang dipilih.
-            success: Berhasil menggabungkan proposal menjadi proposal baru.
+            invalid: There was an error merging the selected proposals.
+            success: Successfully merged the proposals into a new one.
         proposals_splits:
           create:
-            invalid: Terjadi kesalahan saat membagi proposal yang dipilih.
-            success: Berhasil membagi proposal menjadi proposal baru.
+            invalid: There was an error spliting the selected proposals.
+            success: Successfully splitted the proposals into new ones.
         shared:
           info_proposal:
-            body: Tubuh
-            created_at: Tanggal pembuatan
-            proposal_votes_count: Suara menghitung
-            proposals: Proposal
+            body: Body
+            created_at: Creation date
+            proposal_votes_count: Votes count
+            proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} menjawab %{resource_name} proposal pada %{space_name} ruang"
-          create: "%{user_name} membuat %{resource_name} proposal pada %{space_name} ruang sebagai proposal resmi"
-          update: "%{user_name} memperbarui %{resource_name} proposal resmi pada %{space_name} ruang"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
-          create: "%{user_name} meninggalkan catatan pribadi pada %{resource_name} proposal pada %{space_name} ruang"
+          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
       answers:
-        accepted: Diterima
-        evaluating: Mengevaluasi
-        not_answered: Tidak dijawab
-        rejected: Ditolak
-        withdrawn: Ditarik
+        accepted: Accepted
+        evaluating: Evaluating
+        not_answered: Not answered
+        rejected: Rejected
+        withdrawn: Withdrawn
       application_helper:
         filter_origin_values:
-          all: Semua
-          citizens: Warga
-          meetings: Rapat
-          official: Resmi
-          user_groups: Grup Pengguna
+          all: All
+          citizens: Citizens
+          meetings: Meetings
+          official: Official
+          user_groups: User groups
         filter_state_values:
-          accepted: Diterima
-          all: Semua
-          evaluating: Mengevaluasi
-          except_rejected: Semua kecuali ditolak
-          rejected: Ditolak
+          accepted: Accepted
+          all: All
+          evaluating: Evaluating
+          except_rejected: All except rejected
+          rejected: Rejected
         filter_type_values:
-          all: Semua
-          amendments: Amandemen
-          proposals: Proposal
+          all: All
+          amendments: Amendments
+          proposals: Proposals
       collaborative_drafts:
         collaborative_draft:
           publish:
-            error: Ada kesalahan saat memublikasikan draf kolaboratif.
+            error: There's been errors when publishing the collaborative draft.
             irreversible_action_modal:
-              body: Setelah menerbitkan draf sebagai proposal, draf tidak akan dapat diedit lagi. Proposal tidak akan menerima penulis atau kontribusi baru.
-              cancel: Membatalkan
-              ok: Publikasikan sebagai Proposal
-              title: Tindakan berikut tidak dapat diubah
-            success: Draf kolaboratif berhasil diterbitkan sebagai proposal.
-          view_collaborative_draft: Lihat Draf Kolaborasi
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Publish as a Proposal
+              title: The following action is irreversible
+            success: Collaborative draft published successfully as a proposal.
+          view_collaborative_draft: View Collaborative Draft
           withdraw:
-            error: Terjadi kesalahan saat menutup draf kolaboratif.
+            error: There's been errors closing the collaborative draft.
             irreversible_action_modal:
-              body: Setelah menutup draf, draf tidak akan dapat diedit lagi. Draf tidak akan menerima penulis atau kontribusi baru.
-              cancel: Membatalkan
-              ok: Tarik draf kolaboratif
-              title: Tindakan berikut tidak dapat diubah
-            success: Draf kolaboratif berhasil ditarik.
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Withdraw the collaborative draft
+              title: The following action is irreversible
+            success: Collaborative draft withdrawn successfully.
         compare:
-          mine_is_different: Draf kolaboratif saya berbeda
-          no_similars_found: Sudah selesai dilakukan dengan baik! Tidak ditemukan draf kolaboratif yang serupa
-          title: Draf kolaboratif serupa
+          mine_is_different: My collaborative draft is different
+          no_similars_found: Well done! No similar collaborative drafts found
+          title: Similar collaborative drafts
         complete:
-          send: Kirim
-          title: Selesaikan draf kolaboratif Anda
+          send: Send
+          title: Complete your collaborative draft
         count:
           drafts_count:
-            other: "%{count} draf kolaboratif"
+            one: "%{count} collaborative draft"
+            other: "%{count} collaborative draft"
         create:
-          error: Ada masalah saat membuat draf kolaboratif ini
-          success: Draf kolaboratif berhasil dibuat.
+          error: There's been a problem creating this collaborative drafts
+          success: Collaborative draft successfully created.
         edit:
-          attachment_legend: "(Opsional) Tambahkan lampiran"
-          back: Kembali
-          select_a_category: Silakan pilih kategori
-          send: Kirim
-          title: Edit draf kolaboratif
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          select_a_category: Please select a category
+          send: Send
+          title: Edit collaborative draft
         filters:
-          all: Semua
-          amendment: Amandemen
-          category: Kategori
-          category_prompt: Kategori Prompt
-          open: Buka
-          published: Diterbitkan
-          related_to: Berhubungan dengan
-          search: Pencarian
-          state: Negara
-          withdrawn: Ditarik
+          all: All
+          amendment: Amendments
+          category: Category
+          category_prompt: Category Prompt
+          open: Open
+          published: Published
+          related_to: Related to
+          search: Search
+          state: State
+          withdrawn: Withdrawn
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Filter berdasarkan
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         new:
-          send: Terus
-          title: Buat draf kolaboratif Anda
+          send: Continue
+          title: Create Your collaborative draft
         new_collaborative_draft_button:
-          new_collaborative_draft: Draf kolaboratif baru
+          new_collaborative_draft: New collaborative draft
         orders:
-          label: 'Urutan draf oleh:'
-          most_contributed: Sebagian besar berkontribusi
-          random: Acak
-          recent: Baru
+          label: 'Order drafts by:'
+          most_contributed: Most contributed
+          random: Random
+          recent: Recent
         requests:
           accepted_request:
-            error: Tidak dapat diterima sebagai kolaborator, coba lagi nanti.
-            success: "@%{user} telah diterima sebagai kolaborator dengan sukses"
+            error: Could not be accepted as a collaborator, try again later.
+            success: "@%{user} has been accepted as a collaborator successfully"
           access_requested:
-            error: Permintaan Anda tidak dapat diselesaikan, coba lagi nanti.
-            success: Permintaan Anda untuk berkolaborasi telah berhasil dikirim
+            error: Your request could not be completed, try again later.
+            success: Your request to collaborate has been sent successfully
           collaboration_requests:
-            accept_request: Menerima
-            reject_request: Menolak
-            title: Permintaan kolaborasi
+            accept_request: Accept
+            reject_request: Reject
+            title: Collaboration requests
           rejected_request:
-            error: Tidak dapat ditolak sebagai kolaborator, coba lagi nanti.
-            success: "@%{user} telah ditolak sebagai kolaborator dengan sukses"
+            error: Could not be rejected as a collaborator, try again later.
+            success: "@%{user} has been rejected as a collaborator successfully"
         show:
-          back: Kembali
-          edit: Edit draf kolaboratif
-          final_proposal: proposal terakhir
-          final_proposal_help_text: Rancangan ini selesai. Anda dapat melihat proposal selesai akhir
+          back: Back
+          edit: Edit collaborative draft
+          final_proposal: final proposal
+          final_proposal_help_text: This draft is finished. You can see the final finished proposal
           hidden_authors_count:
-            other: dan %{count} lebih banyak orang
-          info-message: Ini adalah <strong>draf kolaboratif</strong> untuk proposal. Ini berarti Anda dapat membantu penulisnya untuk membentuk proposal menggunakan bagian komentar di bawah ini atau meningkatkannya secara langsung dengan meminta akses untuk mengeditnya. Setelah penulis memberi Anda akses, Anda akan dapat membuat perubahan pada draf ini.
-          of_versions: "(dari %{number})"
-          publish: Menerbitkan
-          publish_info: Publikasikan versi draf ini atau
-          published_proposal: proposal yang dipublikasikan
-          request_access: Minta akses
-          requested_access: Akses diminta
-          see_other_versions: lihat versi lain
-          version: Versi %{number}
-          version_history: lihat riwayat versi untuk proposal ini
-          withdraw: tarik draft
+            one: and %{count} more person
+            other: and %{count} more people
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          of_versions: "(of %{number})"
+          publish: Publish
+          publish_info: Publish this version of the draft or
+          published_proposal: published proposal
+          request_access: Request access
+          requested_access: Access requested
+          see_other_versions: see other versions
+          version: Version %{number}
+          version_history: see version history for this proposal
+          withdraw: withdraw the draft
         states:
-          open: Buka
-          published: Diterbitkan
-          withdrawn: Ditarik
+          open: Open
+          published: Published
+          withdrawn: Withdrawn
         update:
-          error: Sudah ada kesalahan saat menyimpan draf kolaboratif.
-          success: Draf kolaboratif berhasil diperbarui.
+          error: There's been errors when saving the collaborative draft.
+          success: Collaborative draft updated successfully.
         wizard_aside:
-          back: Kembali
-          info: Anda membuat <strong>draf kolaboratif</strong>.
+          back: Back
+          info: You are creating a <strong>collaborative draft</strong>.
         wizard_steps:
-          see_steps: lihat langkah-langkahnya
-          step_1: Buat draf kolaboratif Anda
-          step_2: Bandingkan dengan draf kolaboratif
-          step_3: Selesaikan draf kolaboratif Anda
-          step_of: Langkah %{current_step_num} dari %{total_steps}
+          see_steps: see steps
+          step_1: Create your collaborative draft
+          step_2: Compare with collaborative drafts
+          step_3: Complete your collaborative draft
+          step_of: Step %{current_step_num} of %{total_steps}
       create:
-        error: Sudah ada kesalahan saat menyimpan proposal.
-        success: Proposal berhasil dibuat. Disimpan sebagai Draf.
+        error: There's been errors when saving the proposal.
+        success: Proposal created successfully. Saved as a Draft.
       destroy_draft:
-        error: Terjadi kesalahan saat menghapus draf proposal.
-        success: Proposal proposal berhasil dihapus.
+        error: There's been errors deleting the proposal draft.
+        success: Proposal draft was successfully deleted.
       last_activity:
-        new_proposal_at_html: "<span>Proposal baru pada %{link}</span>"
+        new_proposal_at_html: "<span>New proposal at %{link}</span>"
       models:
         collaborative_draft:
           fields:
-            authors: Penulis
-            comments: Komentar
-            contributions: Kontribusi
+            authors: Authors
+            comments: Comments
+            contributions: Contributions
         proposal:
           fields:
-            category: Kategori
-            comments: Komentar
-            endorsements: Endorsemen
+            category: Category
+            comments: Comments
+            endorsements: Endorsements
             id: ID
-            notes: Catatan
-            official_proposal: Proposal resmi
-            published_at: Diterbitkan di
-            scope: Cakupan
-            state: Negara
-            title: Judul
-            votes: Suara
+            notes: Notes
+            official_proposal: Official proposal
+            published_at: Published at
+            scope: Scope
+            state: State
+            title: Title
+            votes: Votes
       new:
-        limit_reached: Anda tidak dapat membuat proposal baru karena Anda telah melampaui batas.
+        limit_reached: You can't create new proposals since you've exceeded the limit.
       participatory_text_proposal:
-        alternative_title: Tidak ada teks partisipatif saat ini
+        alternative_title: There are no participatory texts at the moment
         buttons:
-          amend: Merubah
-          comment: Komentar
-          comments: Komentar
-          endorse: Mengesahkan
+          amend: Amend
+          comment: Comment
+          comments: Comments
+          endorse: Endorse
       proposal_endorsements:
         create:
-          error: Sudah ada kesalahan saat mendukung proposal.
+          error: There's been errors when endorsing the proposal.
         identities:
-          done: Selesai
-          select_identity: Pilih identitas
+          done: Done
+          select_identity: Select identity
       proposal_endorsements_helper:
         endorsement_button:
-          already_endorsed: Didukung
-          endorse: Mengesahkan
+          already_endorsed: Endorsed
+          endorse: Endorse
         render_endorsements_button_card_part:
-          endorse: Mengesahkan
+          endorse: Endorse
       proposal_votes:
         create:
-          error: Ada kesalahan saat memilih proposal.
+          error: There's been errors when voting the proposal.
       proposals:
         compare:
-          mine_is_different: Proposal saya berbeda
-          no_similars_found: Sudah selesai dilakukan dengan baik! Tidak ada proposal serupa yang ditemukan
-          title: Proposal serupa
+          continue: Continue
+          mine_is_different: Моя пропозиція інша
+          no_similars_found: Well done! No similar proposals found
+          title: Similar Proposals
         complete:
-          send: Kirim
-          title: Selesaikan proposal Anda
+          send: Send
+          title: Complete your proposal
         count:
           proposals_count:
-            other: "%{count} proposal"
+            one: "%{count} proposal"
+            other: "%{count} proposals"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
-          attachment_legend: "(Opsional) Tambahkan lampiran"
-          back: Kembali
-          select_a_category: Silakan pilih kategori
-          send: Kirim
+          address: Address (don't forget to specify the city)
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          not_geocoded: Not geocoded
+          select_a_category: Please select a category
+          send: Send
           title: Edit proposal
         edit_draft:
-          discard: Buang draf ini
-          discard_confirmation: Anda yakin ingin membuang draf proposal ini?
+          discard: Discard this draft
+          discard_confirmation: Are you sure you want to discard this proposal draft?
           send: Preview
-          title: Edit Draf Proposal
+          title: Edit Proposal Draft
         endorsement_identities_cabin:
-          endorse: Mengesahkan
+          endorse: Endorse
         endorsements_card_row:
-          comments: Komentar
+          comments: Comments
         filters:
-          activity: Aktivitas
-          category: Kategori
-          category_prompt: Pilih Kategori
-          origin: Asal
-          related_to: Berhubungan dengan
-          search: Pencarian
-          state: Negara
-          voted: Dipilih
-          amendment_type: Mengetik
+          activity: Activity
+          amendment_type: Type
+          category: Category
+          category_prompt: Select a category
+          origin: Origin
+          related_to: Related to
+          search: Search
+          state: State
+          voted: Voted
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Filter berdasarkan
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         index:
-          collaborative_drafts_list: Akses draf kolaboratif
-          new_proposal: Proposal baru
-          see_all_withdrawn: Lihat semua proposal yang ditarik
-          view_proposal: Lihat proposal
+          collaborative_drafts_list: Access collaborative drafts
+          new_proposal: New proposal
+          see_all_withdrawn: See all withdrawn proposals
+          view_proposal: View proposal
         linked_proposals:
           proposal_votes:
-            other: suara
+            one: vote
+            other: votes
         new:
-          send: Terus
-          title: Buat Proposal Anda
+          send: Continue
+          title: Create Your Proposal
         orders:
-          label: 'Memesan proposal dengan:'
-          most_voted: Sebagian besar memilih
-          random: Acak
-          recent: Baru
+          label: 'Order proposals by:'
+          most_voted: Most voted
+          random: Random
+          recent: Recent
         participatory_texts:
           index:
-            document_index: Indeks dokumen
+            document_index: Document index
           view_index:
-            see_index: Lihat indeks
+            see_index: See index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
-          modify: Ubah proposal
+          address: 'Address: %{address}'
+          modify: Modify the proposal
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            other: Anda akan dapat mengedit proposal ini selama %{count} menit pertama setelah proposal diterbitkan. Setelah jendela waktu ini berlalu, Anda tidak akan dapat mengedit proposal.
-          publish: Menerbitkan
-          title: Publikasikan proposal Anda
+            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+          publish: Publish
+          title: Publish your proposal
+          update_pos: Update the position
         proposal:
-          creation_date: 'Penciptaan: %{date}'
-          view_proposal: Lihat proposal
+          creation_date: 'Creation: %{date}'
+          view_proposal: View proposal
         show:
-          back_to: Kembali ke
+          back_to: Back to
           edit_proposal: Edit proposal
-          endorsements_list: Daftar Endorsemen
+          endorsements_list: List of Endorsements
           hidden_endorsers_count:
-            other: dan %{count} lebih banyak orang
-          link_to_collaborative_draft_help_text: Proposal ini adalah hasil dari draf kolaboratif. Tinjau sejarahnya
-          link_to_collaborative_draft_text: Lihat draf kolaboratif
-          proposal_accepted_reason: 'Proposal ini telah diterima karena:'
-          proposal_in_evaluation_reason: Proposal ini sedang dievaluasi
-          proposal_rejected_reason: 'Proposal ini telah ditolak karena:'
-          report: Melaporkan
-          withdraw_btn_hint: Anda dapat menarik proposal Anda jika Anda berubah pikiran, selama Anda belum menerima dukungan apa pun. Proposal tidak dihapus, itu akan muncul dalam daftar proposal yang ditarik.
-          withdraw_confirmation: Apakah Anda yakin untuk membatalkan proposal ini?
-          withdraw_proposal: Tarik proposal
+            one: and %{count} more person
+            other: and %{count} more people
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_text: See the collaborative draft
+          proposal_accepted_reason: 'This proposal has been accepted because:'
+          proposal_in_evaluation_reason: This proposal is being evaluated
+          proposal_rejected_reason: 'This proposal has been rejected because:'
+          report: Report
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
+          withdraw_confirmation: Are you sure to withdraw this proposal?
+          withdraw_proposal: Withdraw proposal
         tags:
-          changed_from: "(diubah dari <u>%{previous_category}</u> oleh administrator)"
-          filed_as: Diarsipkan sebagai
+          changed_from: "(changed from <u>%{previous_category}</u> by an administrator)"
+          filed_as: Filed as
         vote_button:
-          already_voted: Sudah memilih
-          already_voted_hover: Batalkan suara
-          maximum_votes_reached: Batas suara tercapai
-          no_votes_remaining: Tidak ada suara yang tersisa
-          vote: Memilih
-          votes_blocked: Voting dinonaktifkan
+          already_voted: Already voted
+          already_voted_hover: Unvote
+          maximum_votes_reached: Vote limit reached
+          no_votes_remaining: No votes remaining
+          vote: Vote
+          votes_blocked: Voting disabled
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
-            other: SUARA
-          most_popular_proposal: Proposal paling populer
-          need_more_votes: Butuh lebih banyak suara
+            one: VOTE
+            other: VOTES
+          most_popular_proposal: Most popular proposal
+          need_more_votes: Need more votes
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
-            description: Setiap proposal dapat mengumpulkan lebih dari %{limit} dukungan
+            description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: Anda harus mendistribusikan minimal %{votes} suara di antara proposal yang berbeda.
-            given_enough_votes: Anda telah memberikan dukungan yang cukup.
-            supports_remaining: Anda harus memilih %{remaining_votes} proposal lagi agar suara Anda dipertimbangkan.
+            description: You must distribute a minimum of %{votes} votes among different proposals.
+            given_enough_votes: You've given enough supports.
+            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
           proposal_limit:
-            description: Anda dapat membuat hingga %{limit} proposal.
+            description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: Agar proposal yang divalidasi harus mencapai %{limit} dukungan
-          title: 'Voting tunduk pada aturan berikut:'
+            description: In order to be validated proposals need to reach %{limit} supports
+          title: 'Voting is subject to the following rules:'
           vote_limit:
-            description: Anda dapat memilih hingga %{limit} proposal.
-            left: Sisa
-            votes: Suara
+            description: You can vote up to %{limit} proposals.
+            left: Remaining
+            votes: Votes
         wizard_aside:
-          back: Kembali
-          info: Anda membuat <strong>proposal</strong>.
+          back: Back
+          info: You are creating a <strong>proposal</strong>.
         wizard_steps:
-          see_steps: lihat langkah-langkahnya
-          step_1: Buat proposal Anda
-          step_2: Membandingkan
-          step_3: Lengkap
-          step_4: Publikasikan proposal Anda
-          step_of: Langkah %{current_step_num} dari %{total_steps}
+          see_steps: see steps
+          step_1: Create your proposal
+          step_2: Compare
+          step_3: Complete
+          step_4: Publish your proposal
+          step_of: Step %{current_step_num} of %{total_steps}
       publish:
-        error: Sudah ada kesalahan saat memublikasikan proposal.
-        success: Proposal berhasil diterbitkan.
+        error: There's been errors when publishing the proposal.
+        success: Proposal published successfully.
       update:
-        error: Sudah ada kesalahan saat menyimpan proposal.
-        success: Proposal berhasil diperbarui.
+        error: There's been errors when saving the proposal.
+        success: Proposal updated successfully.
       update_draft:
-        error: Ada kesalahan saat menyimpan draf proposal.
-        success: Proposal proposal berhasil diperbarui.
+        error: There's been errors when saving the proposal draft.
+        success: Proposal draft updated successfully.
       versions:
-        changes_at_title: Perubahan pada "%{title}"
+        changes_at_title: Changes at "%{title}"
         index:
-          title: Versi
+          title: Versions
         stats:
-          back_to_collaborative_draft: Kembali ke draf kolaboratif
-          back_to_proposal: Kembali ke proposal
-          number_of_versions: Versi
-          show_all_versions: Tampilkan semua versi
-          version_author: Penulis versi
-          version_created_at: Versi dibuat pada
-          version_number: Nomor versi
-          version_number_out_of_total: "%{current_version} dari %{total_count}"
+          back_to_collaborative_draft: Go back to collaborative draft
+          back_to_proposal: Go back to proposal
+          number_of_versions: Versions
+          show_all_versions: Show all versions
+          version_author: Version author
+          version_created_at: Version created at
+          version_number: Version number
+          version_number_out_of_total: "%{current_version} out of %{total_count}"
         version:
-          version_index: Versi %{index}
+          version_index: Version %{index}
     resource_links:
       copied_from_component:
-        proposal_proposal: Proposal terkait
+        proposal_proposal: Related proposals
       included_projects:
-        project_result: 'Hasil yang muncul dalam proyek ini:'
+        project_result: 'Results appearing in this project:'
       included_proposals:
-        proposal_project: 'Proposal yang muncul dalam proyek-proyek ini:'
-        proposal_result: 'Proposal yang muncul dalam hasil ini:'
+        proposal_project: 'Proposal appearing in these projects:'
+        proposal_result: 'Proposal appearing in these results:'

--- a/decidim-proposals/config/locales/it.yml
+++ b/decidim-proposals/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ it:
         title: Titolo
         user_group_id: Crea una bozza collaborativa come
       proposal:
+        address: Address
         answer: Risposta
         answered_at: Risposto a
         automatic_hashtags: Hashtag aggiunti automaticamente
@@ -105,7 +107,16 @@ it:
             votes_blocked: Votazione bloccata
             votes_enabled: Voto abilitato
             votes_hidden: Voti nascosti (se i voti sono abilitati, controllando questo si nasconderà il numero di voti)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} è stato accettato per accedere come collaboratore al progetto collaborativo <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ it:
             email_outro: Hai ricevuto questa notifica perché sei un autore di "%{resource_title}".
             email_subject: La tua proposta è stata accettata
             notification_title: La tua proposta <a href="%{resource_path}">%{resource_title}</a> è stata accettata.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'La proposta "%{resource_title}" è stata accettata. Puoi leggere la risposta in questa pagina:'
             email_outro: Hai ricevuto questa notifica perché stai seguendo "%{resource_title}". Puoi smettere di seguirlo dal link precedente.
             email_subject: Una proposta che stai seguendo è stata accettata
             notification_title: La proposta <a href="%{resource_path}">%{resource_title}</a> è stata accettata.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, chi stai seguendo, ha appena appoggiato la proposta "%{resource_title}" e pensiamo che potrebbe essere interessante per te. Dai un''occhiata e dai:'
           email_outro: Hai ricevuto questa notifica perché stai seguendo %{endorser_nickname}. È possibile interrompere la ricezione di notifiche seguendo il collegamento precedente.
@@ -169,11 +184,15 @@ it:
             email_outro: Hai ricevuto questa notifica perché sei un autore di "%{resource_title}".
             email_subject: La tua proposta è in corso di valutazione
             notification_title: La tua proposta <a href="%{resource_path}">%{resource_title}</a> è in fase di valutazione.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'La proposta "%{resource_title}" è attualmente in fase di valutazione. Puoi trovare una risposta in questa pagina:'
             email_outro: Hai ricevuto questa notifica perché stai seguendo "%{resource_title}". Puoi smettere di seguirlo dal link precedente.
             email_subject: Una proposta che stai seguendo è in corso di valutazione
             notification_title: La proposta <a href="%{resource_path}">%{resource_title}</a> è in fase di valutazione.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: La tua proposta "%{mentioned_proposal_title}" è stata menzionata <a href="%{resource_path}">in questo spazio</a> nei commenti.
           email_outro: Hai ricevuto questa notifica perché sei un autore di "%{resource_title}".
@@ -195,11 +214,15 @@ it:
             email_outro: Hai ricevuto questa notifica perché sei un autore di "%{resource_title}".
             email_subject: La tua proposta è stata respinta
             notification_title: La tua proposta <a href="%{resource_path}">%{resource_title}</a> è stata respinta.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'La proposta "%{resource_title}" è stata respinta. Puoi leggere la risposta in questa pagina:'
             email_outro: Hai ricevuto questa notifica perché stai seguendo "%{resource_title}". Puoi smettere di seguirlo dal link precedente.
             email_subject: Una proposta che stai seguendo è stata respinta
             notification_title: La proposta <a href="%{resource_path}">%{resource_title}</a> è stata respinta.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Un amministratore ha aggiornato la categoria della tua proposta "%{resource_title}", dai un''occhiata:'
           email_outro: Hai ricevuto questa notifica perché sei l'autore della proposta.
@@ -214,8 +237,8 @@ it:
       badges:
         accepted_proposals:
           conditions:
-            - Scegli lo spazio di partecipazione di tuo interesse con l'invio per le proposte abilitate
-            - Prova a fare proposte che possono essere eseguite. In questo modo è più probabile che vengano accettati.
+          - Scegli lo spazio di partecipazione di tuo interesse con l'invio per le proposte abilitate
+          - Prova a fare proposte che possono essere eseguite. In questo modo è più probabile che vengano accettati.
           description: Questo badge è concesso quando partecipi attivamente a nuove proposte e queste sono accettate.
           description_another: Questo utente ha ottenuto %{score} proposte accettate.
           description_own: Hai accettato %{score} proposte.
@@ -225,8 +248,8 @@ it:
           unearned_own: Non hai ancora accettato nessuna proposta.
         proposal_votes:
           conditions:
-            - Naviga e passa un po 'di tempo a leggere le proposte di altre persone
-            - Dare supporto alle proposte che ti piacciono o che ti interessano
+          - Naviga e passa un po 'di tempo a leggere le proposte di altre persone
+          - Dare supporto alle proposte che ti piacciono o che ti interessano
           description: Questo badge è concesso quando supporti le proposte di altre persone.
           description_another: Questo utente ha fornito supporto a %{score} proposte.
           description_own: Hai fornito supporto a %{score} proposte.
@@ -236,8 +259,8 @@ it:
           unearned_own: Non hai ancora fornito supporto a nessuna proposta.
         proposals:
           conditions:
-            - Scegli lo spazio di partecipazione di tuo interesse con l'invio per le proposte abilitate
-            - Crea una nuova proposta
+          - Scegli lo spazio di partecipazione di tuo interesse con l'invio per le proposte abilitate
+          - Crea una nuova proposta
           description: Questo badge è concesso quando partecipi attivamente a nuove proposte.
           description_another: Questo utente ha creato %{score} proposte.
           description_own: Hai creato %{score} proposte.
@@ -290,8 +313,10 @@ it:
         participatory_texts:
           bulk-actions:
             are_you_sure: Sei sicuro di scartare l'intera bozza del testo partecipativo?
-            import_doc: Importa il documento
             discard_all: Scarta tutto
+            import_doc: Importa il documento
+          discard:
+            success: Tutte le bozze di testo partecipativo sono state scartate.
           import:
             invalid: Il modulo non è valido!
             success: Complimenti, le seguenti sezioni sono state analizzate dal documento importato, sono state convertite in proposte. Ora puoi rivedere e regolare qualsiasi cosa tu abbia bisogno prima di pubblicare.
@@ -308,8 +333,6 @@ it:
           publish:
             invalid: Impossibile pubblicare proposte
             success: Tutte le proposte sono state pubblicate
-          discard:
-            success: Tutte le bozze di testo partecipativo sono state scartate.
           sections:
             article: "<em>Articolo</em>"
             section: "<em>Sezione:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ it:
           error: Ci sono stati errori durante la votazione della proposta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: La mia proposta è diversa
           no_similars_found: Molto bene! Non sono state trovate proposte simili
           title: Proposte simili
@@ -597,9 +621,14 @@ it:
           proposals_count:
             one: "%{count} proposta"
             other: "%{count} proposte"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opzionale) Aggiungi un allegato"
           back: Indietro
+          not_geocoded: Not geocoded
           select_a_category: Seleziona una categoria
           send: Inviare
           title: Modifica la proposta
@@ -614,6 +643,7 @@ it:
           comments: Commenti
         filters:
           activity: Attività
+          amendment_type: genere
           category: Categoria
           category_prompt: Scegli una categoria
           origin: Origine
@@ -621,7 +651,6 @@ it:
           search: Cerca
           state: Stato
           voted: Votata
-          amendment_type: genere
         filters_small_view:
           close_modal: Chiudi modalità
           filter: Filtra
@@ -649,13 +678,18 @@ it:
             document_index: Indice del documento
           view_index:
             see_index: Vedi indice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modifica la proposta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Sarai in grado di modificare questa proposta durante il primo minuto dopo la pubblicazione della proposta. Una volta passata questa finestra, non sarai in grado di modificare la proposta.
             other: Sarai in grado di modificare questa proposta durante il primo %{count} pochi minuti dopo la pubblicazione della proposta. Una volta passata questa finestra, non sarai in grado di modificare la proposta.
           publish: Pubblicare
           title: Pubblica la tua proposta
+          update_pos: Update the position
         proposal:
           creation_date: 'Creazione: %{date}'
           view_proposal: Visualizza la proposta
@@ -685,12 +719,18 @@ it:
           no_votes_remaining: Sono finite le votazioni possibili
           vote: Vota
           votes_blocked: Votazioni disabilitate
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: VOTO
             other: VOTI
           most_popular_proposal: La proposta più popolare
           need_more_votes: Hai bisogno di più voti
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Ogni proposta può accumulare più di %{limit} supporti

--- a/decidim-proposals/config/locales/nl.yml
+++ b/decidim-proposals/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ nl:
         title: Titel
         user_group_id: Creëer samenwerkingsconcept als
       proposal:
+        address: Address
         answer: Antwoord
         answered_at: Beantwoord op
         automatic_hashtags: Hashtags worden automatisch toegevoegd
@@ -99,13 +101,24 @@ nl:
             comments_blocked: Reacties geblokkeerd
             creation_enabled: Creatie nieuw voorstel toegestaan
             endorsements_blocked: Aanbevelingen geblokkeerd
-            endorsements_enabled: "Aanbevelingen toegestaan\n"
+            endorsements_enabled: 'Aanbevelingen toegestaan
+
+'
             proposal_answering_enabled: Formeel antwoord op voorstellen toegestaan.
             suggested_hashtags: Hashtags stelde gebruikers voor nieuwe voorstellen voor
             votes_blocked: Stemmen geblokkeerd
             votes_enabled: Stemmen ingeschakeld
             votes_hidden: Stemmen verborgen (als stemmen is ingeschakeld, zal dit controleren het aantal stemmen verbergen)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} is geaccepteerd om toegang te krijgen als bijdrager voor de <a href="%{resource_path}">%{resource_title}</a> gezamenlijke conceptversie.'
@@ -153,13 +166,17 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u een auteur bent van "%{resource_title}".
             email_subject: Uw voorstel is geaccepteerd
             notification_title: Uw voorstel <a href="%{resource_path}">%{resource_title}</a> is geaccepteerd.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Het voorstel "%{resource_title}" is geaccepteerd. Je kan het antwoord op deze pagina lezen:'
             email_outro: Je hebt deze melding ontvangen omdat je "%{resource_title}" volgt. Ontvolgen kan door te klikken op de voorgaande link.
             email_subject: Een voorstel dat je volgt, is geaccepteerd
             notification_title: Het voorstel <a href="%{resource_path}">%{resource_title}</a> is geaccepteerd.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
-          email_intro: '%{endorser_name} %{endorser_nickname}, wie je volgt, heeft zojuist het ''%{resource_title}voorstel goedgekeurd en we denken dat het misschien interessant voor je is. Bekijk het en draag bij:'
+          email_intro: "%{endorser_name} %{endorser_nickname}, wie je volgt, heeft zojuist het '%{resource_title}voorstel goedgekeurd en we denken dat het misschien interessant voor je is. Bekijk het en draag bij:"
           email_outro: Je hebt deze melding ontvangen omdat je volgt %{endorser_nickname}. Meldingen uitschakelen kan door te klikken op de voorgaande link.
           email_subject: "%{endorser_nickname} heeft een nieuw voorstel goedgekeurd"
           notification_title: Het <a href="%{resource_path}">%{resource_title}</a> voorstel is goedgekeurd door <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
@@ -169,11 +186,15 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u een auteur bent van "%{resource_title}".
             email_subject: Uw voorstel wordt beoordeeld
             notification_title: Uw voorstel <a href="%{resource_path}">%{resource_title}</a> wordt beoordeeld.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Het voorstel "%{resource_title}" is geaccepteerd. Je kan het antwoord op deze pagina lezen:'
             email_outro: Je hebt deze melding ontvangen omdat je "%{resource_title}" volgt. Ontvolgen kan door te klikken op de voorgaande link.
             email_subject: Een voorstel dat je volgt, wordt geëvalueerd
             notification_title: Het voorstel <a href="%{resource_path}">%{resource_title}</a> wordt beoordeeld.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Je voorstel '%{mentioned_proposal_title}' werd in de reacties van <a href="%{resource_path}"> de ruimte </a> vernoemd.
           email_outro: U hebt deze melding ontvangen omdat u een auteur bent van "%{resource_title}".
@@ -195,11 +216,15 @@ nl:
             email_outro: U hebt deze melding ontvangen omdat u een auteur bent van "%{resource_title}".
             email_subject: Uw voorstel is afgewezen
             notification_title: Uw voorstel <a href="%{resource_path}">%{resource_title}</a> is afgewezen.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Het voorstel "%{resource_title}" is afgewezen. Je kan de reden hier lezen:'
             email_outro: Je hebt deze melding ontvangen omdat je "%{resource_title}" volgt. Ontvolgen kan door te klikken op de voorgaande link.
             email_subject: Een voorstel dat je volgt, is afgewezen
             notification_title: Het voorstel <a href="%{resource_path}">%{resource_title}</a> is afgewezen.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Een beheerder heeft de categorie van je voorstel "%{resource_title}" bijgewerkt, bekijk het eens:'
           email_outro: Je hebt deze melding ontvangen omdat je de auteur bent van het voorstel.
@@ -214,8 +239,8 @@ nl:
       badges:
         accepted_proposals:
           conditions:
-            - Kies de deelnemingsruimte van uw interesse met ingediende inzending voor voorstellen
-            - Probeer voorstellen te doen die kunnen worden uitgevoerd. Op deze manier worden ze eerder geaccepteerd.
+          - Kies de deelnemingsruimte van uw interesse met ingediende inzending voor voorstellen
+          - Probeer voorstellen te doen die kunnen worden uitgevoerd. Op deze manier worden ze eerder geaccepteerd.
           description: Deze badge wordt toegekend wanneer u actief deelneemt aan nieuwe voorstellen en deze worden geaccepteerd.
           description_another: Deze gebruiker heeft %{score} voorstellen geaccepteerd gekregen.
           description_own: Je hebt %{score} voorstellen geaccepteerd.
@@ -225,8 +250,8 @@ nl:
           unearned_own: Je hebt nog geen voorstellen geaccepteerd.
         proposal_votes:
           conditions:
-            - Blader door en besteed wat tijd aan het lezen van de voorstellen van anderen
-            - Geef steun aan de voorstellen die je leuk vindt of interessant vindt
+          - Blader door en besteed wat tijd aan het lezen van de voorstellen van anderen
+          - Geef steun aan de voorstellen die je leuk vindt of interessant vindt
           description: Deze badge wordt toegekend wanneer u de voorstellen van andere mensen steunt.
           description_another: Deze gebruiker heeft %{score} voorstellen ondersteund.
           description_own: U hebt %{score} voorstellen ondersteund.
@@ -236,8 +261,8 @@ nl:
           unearned_own: Je hebt nog geen steun gegeven aan nog geen voorstellen.
         proposals:
           conditions:
-            - Kies de deelnemingsruimte van uw interesse met ingediende inzending voor voorstellen
-            - Maak een nieuw voorstel
+          - Kies de deelnemingsruimte van uw interesse met ingediende inzending voor voorstellen
+          - Maak een nieuw voorstel
           description: Deze badge wordt toegekend wanneer u actief deelneemt aan nieuwe voorstellen.
           description_another: Deze gebruiker heeft %{score} voorstellen gemaakt.
           description_own: U hebt %{score} voorstellen gemaakt.
@@ -290,8 +315,10 @@ nl:
         participatory_texts:
           bulk-actions:
             are_you_sure: Weet je zeker dat je de hele deelnemende tekstopmaak wilt verwijderen?
-            import_doc: Document importeren
             discard_all: Gooi alles weg
+            import_doc: Document importeren
+          discard:
+            success: Alle participatieve tekstconcepten zijn genegeerd.
           import:
             invalid: Het formulier is ongeldig!
             success: Gefeliciteerd, de volgende secties zijn geparseerd uit het geïmporteerde document, ze zijn geconverteerd naar voorstellen. Nu kunt u alles bekijken en aanpassen wat u nodig heeft voordat u publiceert.
@@ -308,8 +335,6 @@ nl:
           publish:
             invalid: Kan voorstellen niet publiceren
             success: Alle voorstellen zijn gepubliceerd
-          discard:
-            success: Alle participatieve tekstconcepten zijn genegeerd.
           sections:
             article: "<em>Artikel</em>"
             section: "<em>Sectie:</em> <strong>%{title}</strong>"
@@ -587,6 +612,7 @@ nl:
           error: Er zijn fouten geweest bij het stemmen van het voorstel.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Mijn voorstel is anders
           no_similars_found: Goed gedaan! Geen vergelijkbare voorstellen gevonden
           title: Vergelijkbare voorstellen
@@ -597,9 +623,14 @@ nl:
           proposals_count:
             one: "%{count} voorstel"
             other: "%{count} voorstellen"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Optioneel) Voeg een bijlage toe"
           back: Terug
+          not_geocoded: Not geocoded
           select_a_category: Selecteer een categorie
           send: Verzenden
           title: Bewerk voorstel
@@ -614,6 +645,7 @@ nl:
           comments: Comments
         filters:
           activity: Activiteit
+          amendment_type: Type
           category: Categorie
           category_prompt: Kies een categorie
           origin: Oorsprong
@@ -621,7 +653,6 @@ nl:
           search: Zoeken
           state: Status
           voted: Gestemd
-          amendment_type: Type
         filters_small_view:
           close_modal: Dialoogvenster sluiten
           filter: Filter
@@ -649,13 +680,18 @@ nl:
             document_index: Documentindex
           view_index:
             see_index: Zie index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Pas het voorstel aan
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Je kan dit voorstel bewerken in de eerste %{count} minuut nadat het gepubliceerd is. Zodra deze tijd verstreken is, kan je het voorstel niet meer bewerken.
             other: Je kan dit voorstel bewerken in de eerste %{count} minuten nadat het gepubliceerd is. Zodra deze tijd verstreken is, kan je het voorstel niet meer bewerken.
           publish: Publiceer
           title: Publiceer je voorstel
+          update_pos: Update the position
         proposal:
           creation_date: 'Aangemaakt op: %{date}'
           view_proposal: Bekijk voorstel
@@ -685,12 +721,18 @@ nl:
           no_votes_remaining: Geen stemmen over
           vote: Stem
           votes_blocked: Stemmen uitgeschakeld
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: STEM
             other: STEMMEN
           most_popular_proposal: Populairste voorstel
           need_more_votes: Meer stemmen nodig
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Elk voorstel kan meer dan %{limit} stemmen verzamelen

--- a/decidim-proposals/config/locales/pl.yml
+++ b/decidim-proposals/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ pl:
         title: Tytuł
         user_group_id: Utwórz roboczą wersję roboczą jako
       proposal:
+        address: Address
         answer: Odpowiedź
         answered_at: Odpowiedziałem na
         automatic_hashtags: Hashtagi zostały automatycznie dodane
@@ -46,29 +48,29 @@ pl:
   activerecord:
     models:
       decidim/proposals/collaborative_draft:
-        one: Wspólny projekt
         few: Wersje robocze współpracy
         many: Wersje robocze współpracy
+        one: Wspólny projekt
         other: Wersje robocze współpracy
       decidim/proposals/proposal:
-        one: Wniosek
         few: Propozycje
         many: Propozycje
+        one: Wniosek
         other: Propozycje
       decidim/proposals/proposal_endorsement:
-        one: Poparcie
         few: Adnotacje
         many: Adnotacje
+        one: Poparcie
         other: Adnotacje
       decidim/proposals/proposal_note:
-        one: Uwaga
         few: Uwagi
         many: Uwagi
+        one: Uwaga
         other: Uwagi
       decidim/proposals/proposal_vote:
-        one: Głosować
         few: Głosy
         many: Głosy
+        one: Głosować
         other: Głosy
   decidim:
     components:
@@ -115,7 +117,16 @@ pl:
             votes_blocked: Głosowanie zablokowane
             votes_enabled: Włączone głosowanie
             votes_hidden: Głosy są ukryte (jeśli głosy są włączone, zaznaczenie tego ukryje liczbę głosów)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} zostało zaakceptowane, aby uzyskać dostęp jako współtwórca wspólnego projektu <a href="%{resource_path}">%{resource_title}</a>.'
@@ -163,11 +174,15 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem "%{resource_title}".
             email_subject: Twoja propozycja została zaakceptowana
             notification_title: Twoja propozycja <a href="%{resource_path}">%{resource_title}</a> została zaakceptowana.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Wniosek "%{resource_title}" został zaakceptowany. Możesz przeczytać odpowiedź na tej stronie:'
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz "%{resource_title}". Możesz przestać go obserwować z poprzedniego linku.
             email_subject: Propozycja, którą obserwujesz, została zaakceptowana
             notification_title: Propozycja <a href="%{resource_path}">%{resource_title}</a> została zaakceptowana.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, którego śledzisz, właśnie poparło propozycję "%{resource_title}" i uważamy, że może być dla ciebie interesujące. Sprawdź i pomóż:'
           email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz %{endorser_nickname}. Możesz przestać otrzymywać powiadomienia po poprzednim linku.
@@ -179,11 +194,15 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem "%{resource_title}".
             email_subject: Twoja propozycja jest oceniana
             notification_title: Twoja propozycja <a href="%{resource_path}">%{resource_title}</a> jest oceniana.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Propozycja "%{resource_title}" jest obecnie oceniana. Możesz sprawdzić odpowiedź na tej stronie:'
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz "%{resource_title}". Możesz przestać go obserwować z poprzedniego linku.
             email_subject: Propozycja, którą obserwujesz, jest oceniana
             notification_title: Trwa ocena oferty <a href="%{resource_path}">%{resource_title}</a>.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Twoja propozycja "%{mentioned_proposal_title}" została wspomniana <a href="%{resource_path}">w tym miejscu</a> w komentarzach.
           email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem "%{resource_title}".
@@ -205,11 +224,15 @@ pl:
             email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem "%{resource_title}".
             email_subject: Twoja propozycja została odrzucona
             notification_title: Twoja propozycja <a href="%{resource_path}">%{resource_title}</a> została odrzucona.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Wniosek "%{resource_title}" został odrzucony. Możesz przeczytać odpowiedź na tej stronie:'
             email_outro: Otrzymałeś to powiadomienie, ponieważ obserwujesz "%{resource_title}". Możesz przestać go obserwować z poprzedniego linku.
             email_subject: Propozycja, którą obserwujesz, została odrzucona
             notification_title: <a href="%{resource_path}">%{resource_title}</a> propozycja została odrzucona.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Administrator zaktualizował kategorię Twojej propozycji "%{resource_title}", sprawdź to:'
           email_outro: Otrzymałeś to powiadomienie, ponieważ jesteś autorem wniosku.
@@ -224,8 +247,8 @@ pl:
       badges:
         accepted_proposals:
           conditions:
-            - Wybierz przestrzeń zainteresowań, która Cię interesuje, z włączoną obsługą zgłoszeń
-            - Spróbuj przedstawić propozycje, które można zrealizować. W ten sposób są bardziej prawdopodobne, że zostaną zaakceptowani.
+          - Wybierz przestrzeń zainteresowań, która Cię interesuje, z włączoną obsługą zgłoszeń
+          - Spróbuj przedstawić propozycje, które można zrealizować. W ten sposób są bardziej prawdopodobne, że zostaną zaakceptowani.
           description: Ta odznaka jest przyznawana, gdy aktywnie uczestniczysz w nowych propozycjach i są one akceptowane.
           description_another: Ten użytkownik otrzymał %{score} propozycji zaakceptowanych.
           description_own: Przyjęto %{score} propozycji.
@@ -235,8 +258,8 @@ pl:
           unearned_own: Nie otrzymałeś jeszcze żadnych propozycji.
         proposal_votes:
           conditions:
-            - Przeglądaj i spędzaj trochę czasu czytając propozycje innych osób
-            - Wspieraj propozycje, które lubisz lub które są interesujące
+          - Przeglądaj i spędzaj trochę czasu czytając propozycje innych osób
+          - Wspieraj propozycje, które lubisz lub które są interesujące
           description: Ta odznaka jest przyznawana, gdy wspierasz propozycje innych osób.
           description_another: Ten użytkownik udzielił wsparcia %{score} propozycji.
           description_own: Udzieliłeś wsparcia %{score} propozycji.
@@ -246,8 +269,8 @@ pl:
           unearned_own: Nie udzielałeś już wsparcia żadnym wnioskom.
         proposals:
           conditions:
-            - Wybierz przestrzeń zainteresowań, która Cię interesuje, z włączoną obsługą zgłoszeń
-            - Utwórz nową ofertę
+          - Wybierz przestrzeń zainteresowań, która Cię interesuje, z włączoną obsługą zgłoszeń
+          - Utwórz nową ofertę
           description: Ta plakietka jest przyznawana, gdy aktywnie uczestniczysz w nowych propozycjach.
           description_another: Ten użytkownik stworzył %{score} propozycji.
           description_own: Stworzyłeś %{score} propozycji.
@@ -300,8 +323,10 @@ pl:
         participatory_texts:
           bulk-actions:
             are_you_sure: Czy na pewno chcesz odrzucić cały szkic tekstu dla uczestników?
-            import_doc: Zaimportuj dokument
             discard_all: Odrzuć wszystko
+            import_doc: Zaimportuj dokument
+          discard:
+            success: Wszystkie projekty tekstowe z uczestnictwem zostały odrzucone.
           import:
             invalid: Formularz jest nieprawidłowy!
             success: Gratulacje, z importowanego dokumentu zostały przeanalizowane następujące sekcje, które zostały przekształcone w propozycje. Teraz możesz przejrzeć i dostosować, co potrzebujesz przed publikacją.
@@ -318,8 +343,6 @@ pl:
           publish:
             invalid: Nie można publikować propozycji
             success: Wszystkie wnioski zostały opublikowane
-          discard:
-            success: Wszystkie projekty tekstowe z uczestnictwem zostały odrzucone.
           sections:
             article: "<em>Artykuł</em>"
             section: "<em>Sekcja:</em> <strong>%{title}</strong>"
@@ -458,9 +481,9 @@ pl:
           title: Uzupełnij swój wspólny projekt
         count:
           drafts_count:
-            one: "%{count} wspólny projekt"
             few: "%{count} wspólny projekt"
             many: "%{count} wspólny projekt"
+            one: "%{count} wspólny projekt"
             other: "%{count} wspólny projekt"
         create:
           error: Podczas tworzenia tych roboczych wersji roboczych wystąpił problem
@@ -517,9 +540,9 @@ pl:
           final_proposal: ostateczna propozycja
           final_proposal_help_text: Ten projekt jest gotowy. Możesz zobaczyć końcową gotową propozycję
           hidden_authors_count:
-            one: i %{count} więcej osób
             few: i %{count} więcej osób
             many: i %{count} więcej osób
+            one: i %{count} więcej osób
             other: i %{count} więcej osób
           info-message: Jest to <strong>wspólny projekt</strong> dla wniosku. Oznacza to, że możesz pomóc swoim autorom w kształtowaniu propozycji za pomocą poniższej sekcji komentarza lub poprawić ją bezpośrednio, żądając dostępu, aby ją edytować. Gdy autorzy przyznają Ci dostęp, będziesz mógł wprowadzać zmiany w tej wersji roboczej.
           of_versions: "(z %{number})"
@@ -601,6 +624,7 @@ pl:
           error: Podczas głosowania nad propozycją wystąpiły błędy.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Moja propozycja jest inna
           no_similars_found: Dobra robota! Nie znaleziono podobnych propozycji
           title: Podobne propozycje
@@ -609,13 +633,18 @@ pl:
           title: Uzupełnij swoją propozycję
         count:
           proposals_count:
-            one: "%{count} propozycji"
             few: "%{count} propozycji"
             many: "%{count} propozycji"
+            one: "%{count} propozycji"
             other: "%{count} propozycji"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcjonalnie) Dodaj załącznik"
           back: Plecy
+          not_geocoded: Not geocoded
           select_a_category: Proszę wybrać kategorię
           send: Wysłać
           title: Edytuj propozycję
@@ -630,6 +659,7 @@ pl:
           comments: Komentarze
         filters:
           activity: Czynność
+          amendment_type: Rodzaj
           category: Kategoria
           category_prompt: Wybierz kategorię
           origin: Pochodzenie
@@ -637,7 +667,6 @@ pl:
           search: Szukanie
           state: Stan
           voted: Głosował
-          amendment_type: Rodzaj
         filters_small_view:
           close_modal: Zamknij modal
           filter: Filtr
@@ -650,9 +679,9 @@ pl:
           view_proposal: Wyświetl propozycję
         linked_proposals:
           proposal_votes:
-            one: głosować
             few: głosów
             many: głosów
+            one: głosować
             other: głosów
         new:
           send: dalej
@@ -667,15 +696,20 @@ pl:
             document_index: Indeks dokumentów
           view_index:
             see_index: Zobacz indeks
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Zmodyfikuj propozycję
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: Będziesz mógł edytować tę propozycję w pierwszej minucie po opublikowaniu propozycji. Po przejściu tego okna czasowego nie będzie można edytować propozycji.
             few: Będziesz mógł edytować tę propozycję podczas pierwszej %{count} minut po opublikowaniu propozycji. Po przejściu tego okna czasowego nie będzie można edytować propozycji.
             many: Będziesz mógł edytować tę propozycję podczas pierwszego %{count} minut po opublikowaniu propozycji. Po przejściu tego okna czasowego nie będzie można edytować propozycji.
+            one: Będziesz mógł edytować tę propozycję w pierwszej minucie po opublikowaniu propozycji. Po przejściu tego okna czasowego nie będzie można edytować propozycji.
             other: Będziesz mógł edytować tę propozycję podczas pierwszej %{count} minut po opublikowaniu propozycji. Po przejściu tego okna czasowego nie będzie można edytować propozycji.
           publish: Publikować
           title: Opublikuj swoją propozycję
+          update_pos: Update the position
         proposal:
           creation_date: 'Tworzenie: %{date}'
           view_proposal: Wyświetl propozycję
@@ -684,9 +718,9 @@ pl:
           edit_proposal: Edytuj propozycję
           endorsements_list: Lista rekomendacji
           hidden_endorsers_count:
-            one: i %{count} więcej osób
             few: i %{count} więcej osób
             many: i %{count} więcej osób
+            one: i %{count} więcej osób
             other: i %{count} więcej osób
           link_to_collaborative_draft_help_text: Ta propozycja jest wynikiem wspólnego projektu. Przejrzyj historię
           link_to_collaborative_draft_text: Zobacz wersję roboczą
@@ -707,14 +741,20 @@ pl:
           no_votes_remaining: Brak głosów
           vote: Głosować
           votes_blocked: Głosowanie zostało wyłączone
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
-            one: GŁOSOWAĆ
             few: GŁOSOWANIA
             many: GŁOSY
+            one: GŁOSOWAĆ
             other: GŁOSOWANIA
           most_popular_proposal: Najpopularniejsza propozycja
           need_more_votes: Potrzebujesz więcej głosów
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Każda propozycja może zebrać więcej niż %{limit} podpory

--- a/decidim-proposals/config/locales/pt-BR.yml
+++ b/decidim-proposals/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ pt-BR:
         title: Título
         user_group_id: Criar rascunho colaborativo como
       proposal:
+        address: Address
         answer: Responda
         answered_at: Respondido em
         automatic_hashtags: Hashtags adicionados automaticamente
@@ -105,7 +107,16 @@ pt-BR:
             votes_blocked: Votação desativada
             votes_enabled: Votação habilitada
             votes_hidden: Votos ocultos (se os votos estiverem ativados, verificar isso esconderá o número de votos)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} foi aceito para acessar como colaborador do rascunho colaborativo <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta foi aceita
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> foi aceita.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'A proposta "%{resource_title}" foi aceita. Você pode ler a resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo foi aceita
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi aceita.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, que você está seguindo, acabou de endossar a proposta "%{resource_title}" e achamos que pode ser interessante para você. Confira e contribua:'
           email_outro: Você recebeu esta notificação porque você está seguindo %{endorser_nickname}. Você pode parar de receber notificações após o link anterior.
@@ -169,11 +184,15 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta está sendo avaliada
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> está sendo avaliada.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'A proposta "%{resource_title}" está sendo avaliada atualmente. Você pode verificar uma resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo está sendo avaliada
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> está sendo avaliada.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Sua proposta "%{mentioned_proposal_title}" foi mencionada <a href="%{resource_path}">neste espaço</a> nos comentários.
           email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
@@ -195,11 +214,15 @@ pt-BR:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta foi rejeitada
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> foi rejeitada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'A proposta "%{resource_title}" foi rejeitada. Você pode ler a resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo foi rejeitada
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi rejeitada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Um administrador atualizou a categoria de sua proposta "%{resource_title}", confira:'
           email_outro: Você recebeu esta notificação porque você é o autor da proposta.
@@ -214,8 +237,8 @@ pt-BR:
       badges:
         accepted_proposals:
           conditions:
-            - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
-            - Tente fazer propostas que possam ser realizadas. Desta forma, eles são mais propensos a serem aceitos.
+          - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
+          - Tente fazer propostas que possam ser realizadas. Desta forma, eles são mais propensos a serem aceitos.
           description: Esse selo é concedido quando você participa ativamente de novas propostas e elas são aceitas.
           description_another: Este utilizador obteve %{score} propostas aceites.
           description_own: Você tem %{score} propostas aceitas.
@@ -225,8 +248,8 @@ pt-BR:
           unearned_own: Você não recebeu nenhuma proposta aceita ainda.
         proposal_votes:
           conditions:
-            - Navegue e passe algum tempo lendo as propostas de outras pessoas
-            - Dê apoio às propostas que você gosta ou ache interessante
+          - Navegue e passe algum tempo lendo as propostas de outras pessoas
+          - Dê apoio às propostas que você gosta ou ache interessante
           description: Este selo é concedido quando você oferece suporte a propostas de outras pessoas.
           description_another: Este usuário deu suporte a %{score} propostas.
           description_own: Você deu suporte a %{score} propostas.
@@ -236,8 +259,8 @@ pt-BR:
           unearned_own: Você deu suporte a nenhuma proposta ainda.
         proposals:
           conditions:
-            - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
-            - Criar uma proposta
+          - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
+          - Criar uma proposta
           description: Esse selo é concedido quando você participa ativamente de novas propostas.
           description_another: Este usuário criou %{score} propostas.
           description_own: Você criou %{score} propostas.
@@ -290,8 +313,10 @@ pt-BR:
         participatory_texts:
           bulk-actions:
             are_you_sure: Tem certeza de descartar todo o rascunho do texto participativo?
-            import_doc: Importar documento
             discard_all: Descartar tudo
+            import_doc: Importar documento
+          discard:
+            success: Todos os rascunhos de texto participativos foram descartados.
           import:
             invalid: O formato é inválido!
             success: Parabéns, as seções a seguir foram analisadas do documento importado, elas foram convertidas em propostas. Agora você pode revisar e ajustar o que precisar antes de publicar.
@@ -308,8 +333,6 @@ pt-BR:
           publish:
             invalid: Não foi possível publicar propostas
             success: Todas as propostas foram publicadas
-          discard:
-            success: Todos os rascunhos de texto participativos foram descartados.
           sections:
             article: "<em>Artigo</em>"
             section: "<em>Seção:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ pt-BR:
           error: Houve erros ao votar a proposta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Minha proposta é diferente
           no_similars_found: Bem feito! Não foram encontradas propostas semelhantes
           title: Propostas semelhantes
@@ -597,9 +621,14 @@ pt-BR:
           proposals_count:
             one: "%{count} proposta"
             other: "%{count} propostas"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Adicione um anexo"
           back: Voltar
+          not_geocoded: Not geocoded
           select_a_category: Selecione uma categoria
           send: Enviar
           title: Editar proposta
@@ -614,6 +643,7 @@ pt-BR:
           comments: Comentários
         filters:
           activity: Atividade
+          amendment_type: Tipo
           category: Categoria
           category_prompt: Selecionar uma categoria
           origin: Origem
@@ -621,7 +651,6 @@ pt-BR:
           search: Pesquisa
           state: Estado
           voted: Votado
-          amendment_type: Tipo
         filters_small_view:
           close_modal: Fechar modal
           filter: Filtro
@@ -649,13 +678,18 @@ pt-BR:
             document_index: Índice de documentos
           view_index:
             see_index: Veja o índice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modificar a proposta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Você poderá editar esta proposta durante o primeiro minuto após a publicação da proposta. Uma vez que esta janela de tempo passa, você não poderá editar a proposta.
             other: Você poderá editar esta proposta durante o primeiro %{count} minutos após a publicação da proposta. Uma vez que esta janela de tempo passa, você não poderá editar a proposta.
           publish: Publicar
           title: Publique sua proposta
+          update_pos: Update the position
         proposal:
           creation_date: 'Criação: %{date}'
           view_proposal: Ver proposta
@@ -685,12 +719,18 @@ pt-BR:
           no_votes_remaining: Não há votos restantes
           vote: Voto
           votes_blocked: Votação desativada
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: VOTO
             other: VOTOS
           most_popular_proposal: Proposta mais popular
           need_more_votes: Precisa de mais votos
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada proposta pode acumular mais de %{limit} suporta

--- a/decidim-proposals/config/locales/pt.yml
+++ b/decidim-proposals/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ pt:
         title: Título
         user_group_id: Criar rascunho colaborativo como
       proposal:
+        address: Address
         answer: Responda
         answered_at: Respondido em
         automatic_hashtags: Hashtags adicionados automaticamente
@@ -105,7 +107,16 @@ pt:
             votes_blocked: Votação bloqueada
             votes_enabled: Votação habilitada
             votes_hidden: Votos ocultos (se os votos estiverem ativados, verificar isso esconderá o número de votos)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} foi aceito para acessar como colaborador do rascunho colaborativo <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ pt:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta foi aceita
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> foi aceita.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'A proposta "%{resource_title}" foi aceita. Você pode ler a resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo foi aceita
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi aceita.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, que você está seguindo, acabou de endossar a proposta "%{resource_title}" e achamos que pode ser interessante para você. Confira e contribua:'
           email_outro: Você recebeu esta notificação porque você está seguindo %{endorser_nickname}. Você pode parar de receber notificações após o link anterior.
@@ -169,11 +184,15 @@ pt:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta está sendo avaliada
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> está sendo avaliada.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'A proposta "%{resource_title}" está sendo avaliada atualmente. Você pode verificar uma resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo está sendo avaliada
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> está sendo avaliada.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Sua proposta "%{mentioned_proposal_title}" foi mencionada <a href="%{resource_path}">neste espaço</a> nos comentários.
           email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
@@ -195,11 +214,15 @@ pt:
             email_outro: Você recebeu esta notificação porque é um autor de "%{resource_title}".
             email_subject: Sua proposta foi rejeitada
             notification_title: Sua proposta <a href="%{resource_path}">%{resource_title}</a> foi rejeitada.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'A proposta "%{resource_title}" foi rejeitada. Você pode ler a resposta nesta página:'
             email_outro: Você recebeu esta notificação porque está seguindo "%{resource_title}". Você pode ignorá-lo do link anterior.
             email_subject: Uma proposta que você está seguindo foi rejeitada
             notification_title: A proposta <a href="%{resource_path}">%{resource_title}</a> foi rejeitada.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Um administrador atualizou a categoria de sua proposta "%{resource_title}", confira:'
           email_outro: Você recebeu esta notificação porque você é o autor da proposta.
@@ -214,8 +237,8 @@ pt:
       badges:
         accepted_proposals:
           conditions:
-            - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
-            - Tente fazer propostas que possam ser realizadas. Desta forma, eles são mais propensos a serem aceitos.
+          - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
+          - Tente fazer propostas que possam ser realizadas. Desta forma, eles são mais propensos a serem aceitos.
           description: Esse selo é concedido quando você participa ativamente de novas propostas e elas são aceitas.
           description_another: Este utilizador obteve %{score} propostas aceites.
           description_own: Você tem %{score} propostas aceitas.
@@ -225,8 +248,8 @@ pt:
           unearned_own: Você não recebeu nenhuma proposta aceita ainda.
         proposal_votes:
           conditions:
-            - Navegue e passe algum tempo lendo as propostas de outras pessoas
-            - Dar apoio às propostas que você gosta ou encontrar interessante
+          - Navegue e passe algum tempo lendo as propostas de outras pessoas
+          - Dar apoio às propostas que você gosta ou encontrar interessante
           description: Este selo é concedido quando você oferece suporte a propostas de outras pessoas.
           description_another: Este usuário deu suporte a %{score} propostas.
           description_own: Você deu suporte a %{score} propostas.
@@ -236,8 +259,8 @@ pt:
           unearned_own: Você deu suporte a nenhuma proposta ainda.
         proposals:
           conditions:
-            - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
-            - Crie uma nova proposta
+          - Escolha o espaço de participação de seu interesse com o envio de propostas ativadas
+          - Crie uma nova proposta
           description: Esse selo é concedido quando você participa ativamente de novas propostas.
           description_another: Este usuário criou %{score} propostas.
           description_own: Você criou %{score} propostas.
@@ -290,8 +313,10 @@ pt:
         participatory_texts:
           bulk-actions:
             are_you_sure: Tem certeza de descartar todo o rascunho do texto participativo?
-            import_doc: Documento de importação
             discard_all: Descartar tudo
+            import_doc: Documento de importação
+          discard:
+            success: Todos os rascunhos de texto participativos foram descartados.
           import:
             invalid: O formulário é inválido!
             success: Parabéns, as seções a seguir foram analisadas do documento importado, elas foram convertidas em propostas. Agora você pode revisar e ajustar o que precisar antes de publicar.
@@ -308,8 +333,6 @@ pt:
           publish:
             invalid: Não foi possível publicar propostas
             success: Todas as propostas foram publicadas
-          discard:
-            success: Todos os rascunhos de texto participativos foram descartados.
           sections:
             article: "<em>Artigo</em>"
             section: "<em>Seção:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ pt:
           error: Houve erros ao votar a proposta.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Minha proposta é diferente
           no_similars_found: Bem feito! Não foram encontradas propostas semelhantes
           title: Propostas semelhantes
@@ -597,9 +621,14 @@ pt:
           proposals_count:
             one: "%{count} proposta"
             other: "%{count} propostas"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Opcional) Adicione um anexo"
           back: Voltar
+          not_geocoded: Not geocoded
           select_a_category: Selecione uma categoria
           send: Enviar
           title: Editar proposta
@@ -614,6 +643,7 @@ pt:
           comments: Comentários
         filters:
           activity: Atividade
+          amendment_type: Tipo
           category: Categoria
           category_prompt: Selecione uma categoria
           origin: Origem
@@ -621,7 +651,6 @@ pt:
           search: Pesquisa
           state: Estado
           voted: Votado
-          amendment_type: Tipo
         filters_small_view:
           close_modal: Fechar modal
           filter: Filtro
@@ -649,13 +678,18 @@ pt:
             document_index: Índice de documentos
           view_index:
             see_index: Veja o índice
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Modificar a proposta
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Você poderá editar esta proposta durante o primeiro minuto após a publicação da proposta. Uma vez que esta janela de tempo passa, você não poderá editar a proposta.
             other: Você poderá editar esta proposta durante o primeiro %{count} minutos após a publicação da proposta. Uma vez que esta janela de tempo passa, você não poderá editar a proposta.
           publish: Publicar
           title: Publique sua proposta
+          update_pos: Update the position
         proposal:
           creation_date: 'Criação: %{date}'
           view_proposal: Ver proposta
@@ -685,12 +719,18 @@ pt:
           no_votes_remaining: Não há votos restantes
           vote: Voto
           votes_blocked: Votação desativada
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: VOTO
             other: VOTOS
           most_popular_proposal: Proposta mais popular
           need_more_votes: Precisa de mais votos
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Cada proposta pode acumular mais de %{limit} suporta

--- a/decidim-proposals/config/locales/ru.yml
+++ b/decidim-proposals/config/locales/ru.yml
@@ -1,14 +1,26 @@
+---
 ru:
   activemodel:
     attributes:
+      collaborative_draft:
+        body: Body
+        category_id: Category
+        decidim_scope_id: Scope
+        has_address: Has address
+        state: State
+        title: Title
+        user_group_id: Create collaborative draft as
       proposal:
+        address: Address
         answer: Ответить
         answered_at: 'Получен ответ:'
+        automatic_hashtags: Hashtags automatically added
         body: Основной текст
         category_id: Категория
         has_address: Имеет адрес
         scope_id: Охват
         state: Cостояние
+        suggested_hashtags: Suggested hashtags
         title: Заголовок
         user_group_id: Создать предложение в качестве
       proposal_answer:
@@ -35,25 +47,28 @@ ru:
       decidim/proposals/voting_enabled_event: Включена возможность голосовать по поводу предложений
   activerecord:
     models:
+      decidim/proposals/collaborative_draft:
+        one: Collaborative draft
+        other: Collaborative drafts
       decidim/proposals/proposal:
-        one: Предложение
         few: Предложения
         many: Предложений
+        one: Предложение
         other: Предложений
       decidim/proposals/proposal_endorsement:
-        one: Выражение поддержки
         few: Выражения поддержки
         many: Выражений поддержки
+        one: Выражение поддержки
         other: Выражений поддержки
       decidim/proposals/proposal_note:
-        one: Примечание
         few: Примечания
         many: Примечаний
+        one: Примечание
         other: Примечаний
       decidim/proposals/proposal_vote:
-        one: Голос
         few: Голоса
         many: Голосов
+        one: Голос
         other: Голосов
   decidim:
     components:
@@ -66,13 +81,17 @@ ru:
         name: Предложения
         settings:
           global:
+            amendments_enabled: Amendments enabled
             announcement: Объявление
             attachments_allowed: Разрешить прикрпеленные файлы
             can_accumulate_supports_beyond_threshold: Может накапливать выражения поддержки свыше порогового значения
+            collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Комментарии включены
             geocoding_enabled: Геокодирование включено
+            minimum_votes_per_user: Minimum votes per user
             new_proposal_help_text: Подсказки по созданию нового предложения
             official_proposals_enabled: Включена возможность выдвигать служебные предложения
+            participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Включена возможность отвечать на предложения
             proposal_edit_before_minutes: Предложения могут быть отредактированы авторами до того, как пройдет столько минут
             proposal_length: Предельная длина основного текста предложения
@@ -86,16 +105,57 @@ ru:
             vote_limit: Предельное количество голосов для одного участника
           step:
             announcement: Объявление
+            automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Комментарии отключены
             creation_enabled: Включена возможность создания предложений
             endorsements_blocked: Возможность выразить поддержку отключена
             endorsements_enabled: Возможность выразить поддержку включена
             proposal_answering_enabled: Включена возможность отвечать на предложения
+            suggested_hashtags: Hashtags suggested to users for new proposals
             votes_blocked: Голосование отключено
             votes_enabled: Голосование включено
             votes_hidden: Голоса скрыты (если голосование включено, то при поставленной здесь птичке будет скрыто количество голосов)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
+        collaborative_draft_access_accepted:
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_rejected:
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_requested:
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
+        collaborative_draft_access_requester_accepted:
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been accepted as a contributor of %{resource_title}.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_requester_rejected:
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been rejected as a contributor of %{resource_title}.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_withdrawn:
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
           email_intro: 'Теперь вы можете создавать новые предложения в %{participatory_space_title}! Начните со страницы:'
           email_outro: Вы получили это уведомление, потому что вы следите за «%{participatory_space_title}». Вы можете отписаться от уведомлений, перейдя по приведенной выше ссылке.
@@ -107,38 +167,70 @@ ru:
           email_subject: В %{participatory_space_title} началось предоставление поддержки предложениям
           notification_title: Теперь в <a href="%{participatory_space_url}">%{participatory_space_title}</a> появилась возможность <a href="%{resource_path}">поддерживать предложения</a>
         proposal_accepted:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal has been accepted
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Предложение "%{resource_title}" было принято. Вы можете прочитать ответ на странице:'
             email_outro: Вы получили это уведомление, потому что вы следите за «%{resource_title}». Вы можете перестать за ним следить, перейдя по приведенной выше ссылке.
             email_subject: Предложение, за которым вы следите, было принято
             notification_title: Предложение <a href="%{resource_path}">%{resource_title}</a> было принято.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
           email_outro: Вы получили это уведомление, потому что вы следите за «%{endorser_nickname}». Вы можете отписаться от уведомлений, перейдя по приведенной выше ссылке.
           email_subject: "%{endorser_nickname} поддержал новое предложение"
           notification_title: <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a> поддержал предложение <a href="%{resource_path}">%{resource_title}</a>.
         proposal_evaluating:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal is being evaluated
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Предложение "%{resource_title}" сейчас рассматривается. Вы можете проверить наличие ответа на странице:'
             email_outro: Вы получили это уведомление, потому что вы следите за «%{resource_title}». Вы можете перестать за ним следить, перейдя по приведенной выше ссылке.
             email_subject: Предложение, за которым вы следите, сейчас рассматривается
             notification_title: Предложение <a href="%{resource_path}">%{resource_title}</a> на рассмотрении.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Ваше предложение «%{mentioned_proposal_title}» было упомянуто в комментариях <a href="%{resource_path}">в этом пространстве</a>.
+          email_outro: You have received this notification because you are an author of "%{resource_title}".
           email_subject: Ваше предложение "%{mentioned_proposal_title}"было упомянуто
           notification_title: Ваше предложение «%{mentioned_proposal_title}» было упомянуто в комментариях <a href="%{resource_path}">в этом пространстве</a>.
         proposal_published:
+          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
           email_outro: Вы получили это уведомление, потому что вы следите за «%{author_nickname}». Вы можете отписаться от уведомлений, перейдя по приведенной выше ссылке.
+          email_subject: New proposal "%{resource_title}" by %{author_nickname}
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> обнародовал предложение <a href="%{resource_path}">%{resource_title}</a>.
         proposal_published_for_space:
           email_intro: В "%{participatory_space_title}", за которым вы следите, добавлено предложение "%{resource_title}".
           email_outro: Вы получили это уведомление, потому что вы следите за «%{participatory_space_title}». Вы можете перестать за ним следить, перейдя по приведенной выше ссылке.
+          email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
           notification_title: В %{participatory_space_title} было добавлено предложение <a href="%{resource_path}">%{resource_title}</a>
         proposal_rejected:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal been rejected
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Предложение "%{resource_title}" было отклонено. Вы можете прочитать ответ на странице:'
             email_outro: Вы получили это уведомление, потому что вы следите за «%{resource_title}». Вы можете перестать за ним следить, перейдя по приведенной выше ссылке.
             email_subject: Предложение, за которым вы следите, было отклонено
             notification_title: Предложение <a href="%{resource_path}">%{resource_title}</a> было отклонено.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Администратор обновил категорию вашего предложения «%{resource_title}», проверьте её:'
           email_outro: Вы получили это уведомление, потому что вы являетесь автором предложения.
@@ -149,18 +241,66 @@ ru:
           email_outro: Вы получили это уведомление, потому что вы следите за «%{participatory_space_title}». Вы можете отписаться от уведомлений, перейдя по приведенной выше ссылке.
           email_subject: В %{participatory_space_title} началось голосование по предложениям
           notification_title: Теперь в <a href="%{participatory_space_url}">%{participatory_space_title}</a> появилась возможность <a href="%{resource_path}">голосовать по предложениям</a>
+    gamification:
+      badges:
+        accepted_proposals:
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Try to make proposals that can be carried out. This way they are more likely to be accepted."]'
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          description_another: This user has gotten %{score} proposals accepted.
+          description_own: You got %{score} proposals accepted.
+          name: Accepted proposals
+          next_level_in: Get %{score} more proposals accepted to reach the next level!
+          unearned_another: This user hasn't gotten any proposals accepted yet.
+          unearned_own: You got no proposals accepted yet.
+        proposal_votes:
+          conditions: '["Browse and spend some time reading other people''s proposals", "Give support to the proposals you like or find interesting"]'
+          description: This badge is granted when you support other people's proposals.
+          description_another: This user has given support to %{score} proposals.
+          description_own: You have given support to %{score} proposals.
+          name: Proposal supports
+          next_level_in: Give support to %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't given support to any proposals yet.
+          unearned_own: You have given support to no proposals yet.
+        proposals:
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Create a new proposal"]'
+          description: This badge is granted when you actively participate with new proposals.
+          description_another: This user has created %{score} proposals.
+          description_own: You have created %{score} proposals.
+          name: Proposals
+          next_level_in: Create %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't created any proposals yet.
+          unearned_own: You have created no proposals yet.
     metrics:
+      accepted_proposals:
+        description: Number of proposals accepted by users
+        object: proposals
+        title: Accepted Proposals
+      endorsements:
+        description: Number of endorsements generated in proposals
+        object: endorsements
+        title: Endorsements
+      proposals:
+        description: Number of proposals generated
+        object: proposals
+        title: Proposals
       votes:
+        description: Number of votes generated in proposals by users
+        object: votes
         title: Голоса
     participatory_processes:
       participatory_process_groups:
         highlighted_proposals:
           proposals: Предложения
+    participatory_spaces:
+      highlighted_proposals:
+        see_all: See all (%{count})
     proposals:
       actions:
         answer: Ответить
+        edit_proposal: Edit proposal
         import: Позаимствовать из другой составляющей
         new: Внести новое предложение
+        participatory_texts: Participatory texts
         private_notes: Частные примечания
         title: Действия
       admin:
@@ -172,6 +312,35 @@ ru:
         models:
           proposal:
             name: Предложение
+        participatory_texts:
+          bulk-actions:
+            are_you_sure: Are you sure to discard the whole participatory text draft?
+            discard_all: Discard all
+            import_doc: Import document
+          discard:
+            success: All Participatory text drafts have been discarded.
+          import:
+            invalid: The form is invalid!
+            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+          index:
+            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            publish_document: Publish document
+            save_draft: Save draft
+            title: PREVIEW PARTICIPATORY TEXT
+          new_import:
+            bottom_hint: "(You will be able to preview and sort document sections)"
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            title: ADD DOCUMENT
+            upload_document: Upload document
+          publish:
+            invalid: Could not publish proposals
+            success: All proposals have been published
+          sections:
+            article: "<em>Article</em>"
+            section: "<em>Section:</em> <strong>%{title}</strong>"
+            sub-section: "<em>Subsection:</em> %{title}"
+          update:
+            success: Participatory text updated successfully.
         proposal_answers:
           edit:
             accepted: Принято
@@ -195,14 +364,24 @@ ru:
           create:
             invalid: При попытке создать предложение произошла ошибка
             success: Предложение успешно создано
+          edit:
+            title: Update proposal
+            update: Update
           form:
             attachment_legend: "(Необязательно) Прикрепить файл"
+            created_in_meeting: This proposal comes from a meeting
             select_a_category: Выберите категорию
+            select_a_meeting: Select a meeting
           index:
             actions: Действия
             cancel: Отменить
             change_category: Изменить категорию
+            merge: Merge into a new one
+            merge_button: Merge
+            select_component: Select a component
             selected: выбранные
+            split: Split proposals
+            split_button: Split
             title: Предложения
             update: Обновить
           new:
@@ -222,6 +401,14 @@ ru:
             no_components: В этом пространстве соучастия нет других составляющих предложений, из которых можно было бы позаимствовать предложения.
             select_component: Пожалуйста, выберите составляющую
             select_states: Проверьте состояние предложений, которые вы хотите позаимствовать
+        proposals_merges:
+          create:
+            invalid: There was an error merging the selected proposals.
+            success: Successfully merged the proposals into a new one.
+        proposals_splits:
+          create:
+            invalid: There was an error spliting the selected proposals.
+            success: Successfully splitted the proposals into new ones.
         shared:
           info_proposal:
             body: Основной текст
@@ -232,6 +419,7 @@ ru:
         proposal:
           answer: "%{user_name} ответил на предложение %{resource_name} в пространстве %{space_name}"
           create: "%{user_name} создал в пространстве %{space_name} предложение %{resource_name} в качестве служебного предложения"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
           create: "%{user_name} оставил частное примечание по предложению %{resource_name} в пространстве %{space_name}"
       answers:
@@ -242,20 +430,149 @@ ru:
         withdrawn: Отозван
       application_helper:
         filter_origin_values:
+          all: All
           citizens: Граждане
+          meetings: Meetings
           official: Служебные
+          user_groups: User groups
         filter_state_values:
+          accepted: Accepted
+          all: All
+          evaluating: Evaluating
           except_rejected: Все, кроме отклоненных
+          rejected: Rejected
+        filter_type_values:
+          all: All
+          amendments: Amendments
+          proposals: Proposals
       collaborative_drafts:
+        collaborative_draft:
+          publish:
+            error: There's been errors when publishing the collaborative draft.
+            irreversible_action_modal:
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Publish as a Proposal
+              title: The following action is irreversible
+            success: Collaborative draft published successfully as a proposal.
+          view_collaborative_draft: View Collaborative Draft
+          withdraw:
+            error: There's been errors closing the collaborative draft.
+            irreversible_action_modal:
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Withdraw the collaborative draft
+              title: The following action is irreversible
+            success: Collaborative draft withdrawn successfully.
+        compare:
+          mine_is_different: My collaborative draft is different
+          no_similars_found: Well done! No similar collaborative drafts found
+          title: Similar collaborative drafts
+        complete:
+          send: Send
+          title: Complete your collaborative draft
+        count:
+          drafts_count:
+            one: "%{count} collaborative draft"
+            other: "%{count} collaborative draft"
+        create:
+          error: There's been a problem creating this collaborative drafts
+          success: Collaborative draft successfully created.
+        edit:
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          select_a_category: Please select a category
+          send: Send
+          title: Edit collaborative draft
         filters:
+          all: All
+          amendment: Amendments
+          category: Category
+          category_prompt: Category Prompt
+          open: Open
+          published: Published
+          related_to: Related to
+          search: Search
           state: Cостояние
+          withdrawn: Withdrawn
+        filters_small_view:
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
+        new:
+          send: Continue
+          title: Create Your collaborative draft
+        new_collaborative_draft_button:
+          new_collaborative_draft: New collaborative draft
+        orders:
+          label: 'Order drafts by:'
+          most_contributed: Most contributed
+          random: Random
+          recent: Recent
+        requests:
+          accepted_request:
+            error: Could not be accepted as a collaborator, try again later.
+            success: "@%{user} has been accepted as a collaborator successfully"
+          access_requested:
+            error: Your request could not be completed, try again later.
+            success: Your request to collaborate has been sent successfully
+          collaboration_requests:
+            accept_request: Accept
+            reject_request: Reject
+            title: Collaboration requests
+          rejected_request:
+            error: Could not be rejected as a collaborator, try again later.
+            success: "@%{user} has been rejected as a collaborator successfully"
+        show:
+          back: Back
+          edit: Edit collaborative draft
+          final_proposal: final proposal
+          final_proposal_help_text: This draft is finished. You can see the final finished proposal
+          hidden_authors_count:
+            one: and %{count} more person
+            other: and %{count} more people
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          of_versions: "(of %{number})"
+          publish: Publish
+          publish_info: Publish this version of the draft or
+          published_proposal: published proposal
+          request_access: Request access
+          requested_access: Access requested
+          see_other_versions: see other versions
+          version: Version %{number}
+          version_history: see version history for this proposal
+          withdraw: withdraw the draft
+        states:
+          open: Open
+          published: Published
+          withdrawn: Withdrawn
+        update:
+          error: There's been errors when saving the collaborative draft.
+          success: Collaborative draft updated successfully.
+        wizard_aside:
+          back: Back
+          info: You are creating a <strong>collaborative draft</strong>.
+        wizard_steps:
+          see_steps: see steps
+          step_1: Create your collaborative draft
+          step_2: Compare with collaborative drafts
+          step_3: Complete your collaborative draft
+          step_of: Step %{current_step_num} of %{total_steps}
       create:
         error: При попытке сохранить это предложение произошли ошибки.
         success: Предложение успешно создано. Сохранено как черновик.
       destroy_draft:
         error: При попытке удалить этот черновик предложения произошли ошибки.
         success: Черновик предложения был успешно удален.
+      last_activity:
+        new_proposal_at_html: "<span>New proposal at %{link}</span>"
       models:
+        collaborative_draft:
+          fields:
+            authors: Authors
+            comments: Comments
+            contributions: Contributions
         proposal:
           fields:
             category: Категория
@@ -271,6 +588,13 @@ ru:
             votes: Голоса
       new:
         limit_reached: Вы не можете создавать новые предложения, так как вы превысили лимит.
+      participatory_text_proposal:
+        alternative_title: There are no participatory texts at the moment
+        buttons:
+          amend: Amend
+          comment: Comment
+          comments: Comments
+          endorse: Endorse
       proposal_endorsements:
         create:
           error: При попытке поддержать это предложение произошли ошибки.
@@ -288,15 +612,25 @@ ru:
           error: При голосовании по этому предложению произошли ошибки.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Мое предложение отличается
           no_similars_found: Хорошая работа! Подобных предложений не найдено
           title: Похожие предложения
         complete:
           send: Отправить
           title: Завершите свое предложение
+        count:
+          proposals_count:
+            one: "%{count} proposal"
+            other: "%{count} proposals"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Необязательно) Добавить вложение"
           back: Вернуться
+          not_geocoded: Not geocoded
           select_a_category: Пожалуйста, выберите категорию
           send: Отправить
           title: Редактировать предложение
@@ -311,6 +645,7 @@ ru:
           comments: Комментарии
         filters:
           activity: Деятельность
+          amendment_type: Type
           category: Категория
           category_prompt: Выберите категорию
           origin: Источник
@@ -324,14 +659,15 @@ ru:
           filter_by: 'Отобрать по признаку:'
           unfold: Развернуть
         index:
+          collaborative_drafts_list: Access collaborative drafts
           new_proposal: Внести предложение
           see_all_withdrawn: Просмотреть все отозванные предложения
           view_proposal: Просмотреть предложение
         linked_proposals:
           proposal_votes:
-            one: голосовать
             few: голоса
             many: голоса
+            one: голосовать
             other: голоса
         new:
           send: Продолжить
@@ -341,21 +677,37 @@ ru:
           most_voted: С наибольшим количеством голосов
           random: Произвольно
           recent: Недавние
+        participatory_texts:
+          index:
+            document_index: Document index
+          view_index:
+            see_index: See index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Изменить предложение
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: Вы сможете отредактировать это предложение в течение первой минуты после того, как предложение было обнародовано. После того, как пройдет этот промежуток времени, вы не сможете редактировать предложение.
             few: Вы сможете отредактировать это предложение в течение первых %{count} минут после обнародования предложения. После того, как пройдет этот промежуток времени, вы не сможете редактировать предложение.
             many: Вы сможете отредактировать это предложение в течение первых %{count} минут после обнародования предложения. После того, как пройдет этот промежуток времени, вы не сможете редактировать предложение.
+            one: Вы сможете отредактировать это предложение в течение первой минуты после того, как предложение было обнародовано. После того, как пройдет этот промежуток времени, вы не сможете редактировать предложение.
             other: Вы сможете отредактировать это предложение в течение первых %{count} минут после обнародования предложения. После того, как пройдет этот промежуток времени, вы не сможете редактировать предложение.
           publish: Обнародовать
           title: Обнародуйте свое предложение
+          update_pos: Update the position
         proposal:
           creation_date: 'Создано: %{date}'
           view_proposal: Просмотреть предложение
         show:
+          back_to: Back to
           edit_proposal: Редактировать предложение
           endorsements_list: Список тех, кто поддержал
+          hidden_endorsers_count:
+            one: and %{count} more person
+            other: and %{count} more people
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'Это предложение было принято, поскольку:'
           proposal_in_evaluation_reason: Это предложение сейчас рассматривается
           proposal_rejected_reason: 'Это предложение было отклонено, поскольку:'
@@ -373,17 +725,27 @@ ru:
           no_votes_remaining: Больше не осталось голосов
           vote: Голосовать
           votes_blocked: Голосование отключено
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
-            one: ГОЛОС
             few: ГОЛОСА
             many: ГОЛОСОВ
+            one: ГОЛОС
             other: ГОЛОСА
           most_popular_proposal: Самое популярное предложение
           need_more_votes: Нужно больше голосов
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Каждое предложение может накапливать более %{limit} выражений поддержки
+          minimum_votes_per_user:
+            description: You must distribute a minimum of %{votes} votes among different proposals.
+            given_enough_votes: You've given enough supports.
+            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
           proposal_limit:
             description: Вы можете создать до %{limit} предложений.
           threshold_per_proposal:
@@ -412,6 +774,21 @@ ru:
       update_draft:
         error: При попытке сохранить этот черновик предложения произошли ошибки.
         success: Черновик предложения успешно обновлен.
+      versions:
+        changes_at_title: Changes at "%{title}"
+        index:
+          title: Versions
+        stats:
+          back_to_collaborative_draft: Go back to collaborative draft
+          back_to_proposal: Go back to proposal
+          number_of_versions: Versions
+          show_all_versions: Show all versions
+          version_author: Version author
+          version_created_at: Version created at
+          version_number: Version number
+          version_number_out_of_total: "%{current_version} out of %{total_count}"
+        version:
+          version_index: Version %{index}
     resource_links:
       copied_from_component:
         proposal_proposal: Подобные предложения

--- a/decidim-proposals/config/locales/sv.yml
+++ b/decidim-proposals/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -10,6 +11,7 @@ sv:
         title: Titel
         user_group_id: Skapa samarbetsförslag som
       proposal:
+        address: Address
         answer: Svara
         answered_at: Besvarad vid
         automatic_hashtags: Hashtags läggs till automatiskt
@@ -105,7 +107,16 @@ sv:
             votes_blocked: Röstande blockerat
             votes_enabled: Röstning aktiverat
             votes_hidden: Röster dolda (om röster är aktiverade, kommer detta att gömma antalet röster)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
           email_intro: '%{requester_name} har accepterats för att få tillgång till som medskapare till samarbetsutkastet <a href="%{resource_path}">%{resource_title}</a>.'
@@ -153,11 +164,15 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du är en författare till "%{resource_title}".
             email_subject: Ditt förslag har godkänts
             notification_title: Ditt förslag <a href="%{resource_path}">%{resource_title}</a> har godkänts.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Förslaget "%{resource_title}" har godkänts. Du kan läsa svaret på den här sidan:'
             email_outro: Du har fått den här meddelandet eftersom du följer "%{resource_title}". Du kan sluta följa det från föregående länk.
             email_subject: Ett förslag som du följer är godkänt
             notification_title: Förslaget <a href="%{resource_path}">%{resource_title}</a> har godkänts.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
           email_intro: '%{endorser_name} %{endorser_nickname}, som du följer, har just godkänt förslaget "%{resource_title}" och vi tycker att det kan vara intressant för dig. Kolla in det och bidra med:'
           email_outro: Du har fått den här notifikationen eftersom du följer %{endorser_nickname}. Du kan sluta ta emot meddelanden vid föregående länk.
@@ -169,11 +184,15 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du är en författare till "%{resource_title}".
             email_subject: Ditt förslag utvärderas
             notification_title: Ditt förslag <a href="%{resource_path}">%{resource_title}</a> utvärderas.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Förslaget "%{resource_title}" utvärderas för närvarande. Du kan söka efter ett svar på den här sidan:'
             email_outro: Du har fått den här meddelandet eftersom du följer "%{resource_title}". Du kan sluta följa det från föregående länk.
             email_subject: Ett förslag som du följer utvärderas
             notification_title: Förslaget <a href="%{resource_path}">%{resource_title}</a> utvärderas.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Ditt förslag "%{mentioned_proposal_title}" har nämnts <a href="%{resource_path}">i det här utrymmet</a> i kommentarerna.
           email_outro: Du har fått den här meddelandet eftersom du är en författare till "%{resource_title}".
@@ -195,11 +214,15 @@ sv:
             email_outro: Du har fått den här meddelandet eftersom du är en författare till "%{resource_title}".
             email_subject: Ditt förslag har avslagits
             notification_title: Ditt förslag <a href="%{resource_path}">%{resource_title}</a> har avvisats.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Förslaget "%{resource_title}" har avslagits. Du kan läsa svaret på den här sidan:'
             email_outro: Du har fått den här meddelandet eftersom du följer "%{resource_title}". Du kan sluta följa det från föregående länk.
             email_subject: Ett förslag som du följer har avvisats
             notification_title: Förslaget <a href="%{resource_path}">%{resource_title}</a> har avslagits.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'En administratör har uppdaterat kategorin av ditt förslag "%{resource_title}", kolla in det:'
           email_outro: Du har fått den här meddelandet eftersom du är författaren till förslaget.
@@ -214,8 +237,8 @@ sv:
       badges:
         accepted_proposals:
           conditions:
-            - Välj deltagarutrymme av intresse med inlämning av förslag aktiverade
-            - Försök att lägga fram förslag som kan utföras. På detta sätt är de mer benägna att accepteras.
+          - Välj deltagarutrymme av intresse med inlämning av förslag aktiverade
+          - Försök att lägga fram förslag som kan utföras. På detta sätt är de mer benägna att accepteras.
           description: Detta märke beviljas när du aktivt deltar med nya förslag och dessa accepteras.
           description_another: Den här användaren har fått %{score} förslag accepterade.
           description_own: Du har accepterat %{score} förslag.
@@ -225,8 +248,8 @@ sv:
           unearned_own: Du har inga förslag accepterade än.
         proposal_votes:
           conditions:
-            - Bläddra och spendera lite tid på att läsa andras förslag
-            - Ge stöd till de förslag du tycker om eller hitta intressanta
+          - Bläddra och spendera lite tid på att läsa andras förslag
+          - Ge stöd till de förslag du tycker om eller hitta intressanta
           description: Detta märke beviljas när du stöder andra människors förslag.
           description_another: Denna användare har gett stöd till %{score} förslag.
           description_own: Du har gett stöd till %{score} förslag.
@@ -236,8 +259,8 @@ sv:
           unearned_own: Du har inte stöttat några förslag än.
         proposals:
           conditions:
-            - Välj deltagarutrymme av intresse med inlämning av förslag aktiverade
-            - Skapa ett nytt förslag
+          - Välj deltagarutrymme av intresse med inlämning av förslag aktiverade
+          - Skapa ett nytt förslag
           description: Detta märke beviljas när du aktivt deltar med nya förslag.
           description_another: Den här användaren har skapat %{score} förslag.
           description_own: Du har skapat %{score} förslag.
@@ -290,8 +313,10 @@ sv:
         participatory_texts:
           bulk-actions:
             are_you_sure: Är du säker på att kassera hela deltagande textförslaget?
-            import_doc: Importera dokument
             discard_all: Kassera allt
+            import_doc: Importera dokument
+          discard:
+            success: Alla deltagande textförslag har kasseras.
           import:
             invalid: Blanketten är ogiltig!
             success: Grattis, följande avsnitt har analyserats från det importerade dokumentet, de har konverterats till förslag. Nu kan du granska och justera vad du behöver innan du publicerar.
@@ -308,8 +333,6 @@ sv:
           publish:
             invalid: Kunde inte publicera förslag
             success: Alla förslag har publicerats
-          discard:
-            success: Alla deltagande textförslag har kasseras.
           sections:
             article: "<em>Artikel</em>"
             section: "<em>Avsnitt:</em> <strong>%{title}</strong>"
@@ -587,6 +610,7 @@ sv:
           error: Det har uppstått fel när man röstade om förslaget.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Mitt förslag är annorlunda
           no_similars_found: Bra gjort! Inga liknande förslag hittades
           title: Liknande förslag
@@ -597,9 +621,14 @@ sv:
           proposals_count:
             one: "%{count} förslag"
             other: "%{count} förslag"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Valfritt) Lägg till en bilaga"
           back: Tillbaka
+          not_geocoded: Not geocoded
           select_a_category: Välj en kategori
           send: Skicka
           title: Redigera förslag
@@ -614,6 +643,7 @@ sv:
           comments: Kommentarer
         filters:
           activity: Aktivitet
+          amendment_type: Typ
           category: Kategori
           category_prompt: Välj en kategori
           origin: Ursprung
@@ -621,7 +651,6 @@ sv:
           search: Sök
           state: Status
           voted: Röstade
-          amendment_type: Typ
         filters_small_view:
           close_modal: Stäng fönstret
           filter: Filtrera
@@ -649,13 +678,18 @@ sv:
             document_index: Dokumentindex
           view_index:
             see_index: Se index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Ändra förslaget
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
             one: Du kommer att kunna redigera detta förslag under den första minuten efter att förslaget har publicerats. När det här tidsfönstret passerat kommer du inte att kunna redigera förslaget.
             other: Du kommer att kunna redigera detta förslag under de första %{count} minuter efter att förslaget har publicerats. När det här tidsfönstret passerat kommer du inte att kunna redigera förslaget.
           publish: Publicera
           title: Publicera ditt förslag
+          update_pos: Update the position
         proposal:
           creation_date: 'Skapat: %{date}'
           view_proposal: Visa förslag
@@ -685,12 +719,18 @@ sv:
           no_votes_remaining: Inga röster kvar
           vote: Rösta
           votes_blocked: Röstning inaktiverad
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
             one: RÖST
             other: RÖSTER
           most_popular_proposal: Mest populära förslaget
           need_more_votes: Behöver fler röster
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Varje förslag kan samla mer än %{limit} stöd

--- a/decidim-proposals/config/locales/tr-TR.yml
+++ b/decidim-proposals/config/locales/tr-TR.yml
@@ -1,751 +1,785 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       collaborative_draft:
-        body: Vücut
-        category_id: Kategori
-        decidim_scope_id: kapsam
-        has_address: Adresi var
-        state: Belirtmek, bildirmek
-        title: Başlık
-        user_group_id: Ortak çalışma taslağını oluştur
+        body: Body
+        category_id: Category
+        decidim_scope_id: Scope
+        has_address: Has address
+        state: State
+        title: Title
+        user_group_id: Create collaborative draft as
       proposal:
-        answer: Cevap
-        answered_at: Yanıtladı
-        automatic_hashtags: Hashtag'ler otomatik olarak eklendi
-        body: Vücut
-        category_id: Kategori
-        has_address: Adresi var
-        scope_id: kapsam
-        state: Belirtmek, bildirmek
-        suggested_hashtags: Önerilen hashtag'ler
-        title: Başlık
-        user_group_id: Teklif oluştur
+        address: Address
+        answer: Answer
+        answered_at: Answered at
+        automatic_hashtags: Hashtags automatically added
+        body: Body
+        category_id: Category
+        has_address: Has address
+        scope_id: Scope
+        state: State
+        suggested_hashtags: Suggested hashtags
+        title: Title
+        user_group_id: Create proposal as
       proposal_answer:
-        answer: Cevap
+        answer: Answer
       proposals_copy:
-        copy_proposals: Bunun, tüm önerileri seçilen bileşenden geçerli olana aktardığını ve bu işlemin geri alınamayacağını anlıyorum.
-        origin_component_id: Teklifleri kopyalamak için bileşen
+        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
+        origin_component_id: Component to copy the proposals from
     errors:
       models:
         proposal:
           attributes:
             attachment:
-              needs_to_be_reattached: Yeniden bağlanması gerekiyor
+              needs_to_be_reattached: Needs to be reattached
     models:
-      decidim/proposals/accepted_proposal_event: Teklif kabul edildi
-      decidim/proposals/admin/update_proposal_category_event: Teklif kategorisi değişti
-      decidim/proposals/creation_enabled_event: Teklif oluşturma etkin
-      decidim/proposals/endorsing_enabled_event: Teklif onayı etkin
-      decidim/proposals/evaluating_proposal_event: Teklif değerlendiriliyor
-      decidim/proposals/proposal_endorsed_event: Teklif onaylandı
-      decidim/proposals/proposal_mentioned_event: Bahsi geçen teklif
-      decidim/proposals/publish_proposal_event: Teklif yayınlandı
-      decidim/proposals/rejected_proposal_event: Teklif reddedildi
-      decidim/proposals/voting_enabled_event: Teklif oylama etkin
+      decidim/proposals/accepted_proposal_event: Proposal accepted
+      decidim/proposals/admin/update_proposal_category_event: Proposal category changed
+      decidim/proposals/creation_enabled_event: Proposal creation enabled
+      decidim/proposals/endorsing_enabled_event: Proposal endorsing enabled
+      decidim/proposals/evaluating_proposal_event: Proposal is being evaluated
+      decidim/proposals/proposal_endorsed_event: Proposal endorsed
+      decidim/proposals/proposal_mentioned_event: Proposal mentioned
+      decidim/proposals/publish_proposal_event: Proposal published
+      decidim/proposals/rejected_proposal_event: Proposal rejected
+      decidim/proposals/voting_enabled_event: Proposal voting enabled
   activerecord:
     models:
       decidim/proposals/collaborative_draft:
-        one: İşbirlikçi taslak
-        other: İşbirliği taslakları
+        one: Collaborative draft
+        other: Collaborative drafts
       decidim/proposals/proposal:
-        one: öneri
-        other: Teklif
+        one: Proposal
+        other: Proposals
       decidim/proposals/proposal_endorsement:
-        one: ciro
-        other: Cirolar
+        one: Endorsement
+        other: Endorsements
       decidim/proposals/proposal_note:
-        one: Not
-        other: notlar
+        one: Note
+        other: Notes
       decidim/proposals/proposal_vote:
-        one: Oy
-        other: oy
+        one: Vote
+        other: Votes
   decidim:
     components:
       proposals:
         actions:
-          create: yaratmak
-          endorse: desteklemek
-          vote: Oy
-          withdraw: Çekil
-        name: Teklif
+          create: Create
+          endorse: Endorse
+          vote: Vote
+          withdraw: Withdraw
+        name: Proposals
         settings:
           global:
-            amendments_enabled: Değişiklikler etkinleştirildi
-            announcement: duyuru
-            attachments_allowed: Eklere izin ver
-            can_accumulate_supports_beyond_threshold: Destekleri eşiğin ötesinde biriktirebilir
-            collaborative_drafts_enabled: Ortak çalışma taslakları etkin
-            comments_enabled: Yorumlar etkin
-            geocoding_enabled: Coğrafi kod etkin
-            minimum_votes_per_user: Kullanıcı başına minimum oy
-            new_proposal_help_text: Yeni teklif yardım metni
-            official_proposals_enabled: Resmi teklifler etkinleştirildi
-            participatory_texts_enabled: Katılımcı metinler etkinleştirildi
-            proposal_answering_enabled: Teklif yanıtlama etkin
-            proposal_edit_before_minutes: Teklifler, bu birkaç dakika geçmeden yazarlar tarafından düzenlenebilir
-            proposal_length: Maksimum teklif gövdesi uzunluğu
-            proposal_limit: Kullanıcı başına teklif limiti
-            proposal_wizard_step_1_help_text: Öneri sihirbazı "Oluştur" adımı yardım metni
-            proposal_wizard_step_2_help_text: Öneri sihirbazı "Karşılaştırma" adımı yardım metni
-            proposal_wizard_step_3_help_text: Öneri sihirbazı "Tamamlandı" adım yardım metni
-            proposal_wizard_step_4_help_text: Öneri sihirbazı "Yayınla" adım yardım metni
-            resources_permissions_enabled: Her teklif için işlem izinleri ayarlanabilir
-            threshold_per_proposal: Teklif başına eşik
-            vote_limit: Kullanıcı başına oy sınırı
+            amendments_enabled: Amendments enabled
+            announcement: Announcement
+            attachments_allowed: Allow attachments
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
+            collaborative_drafts_enabled: Collaborative drafts enabled
+            comments_enabled: Comments enabled
+            geocoding_enabled: Geocoding enabled
+            minimum_votes_per_user: Minimum votes per user
+            new_proposal_help_text: New proposal help text
+            official_proposals_enabled: Official proposals enabled
+            participatory_texts_enabled: Participatory texts enabled
+            proposal_answering_enabled: Proposal answering enabled
+            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
+            proposal_length: Maximum proposal body length
+            proposal_limit: Proposal limit per user
+            proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
+            resources_permissions_enabled: Actions permissions can be set for each proposal
+            threshold_per_proposal: Threshold per proposal
+            vote_limit: Vote limit per user
           step:
-            announcement: duyuru
-            automatic_hashtags: Hashtags tüm tekliflere eklendi
-            comments_blocked: Yorumlar engellendi
-            creation_enabled: Teklif oluşturma etkin
-            endorsements_blocked: Onaylar engellendi
-            endorsements_enabled: Onaylar etkin
-            proposal_answering_enabled: Teklif yanıtlama etkin
-            suggested_hashtags: Hashtags, yeni teklifler için kullanıcılara önerdi
-            votes_blocked: Oylama engellendi
-            votes_enabled: Oylama etkin
-            votes_hidden: Oylar gizli (oylar etkinleştirilirse, bu kontrol edilirken oy sayısı gizlenir)
+            announcement: Announcement
+            automatic_hashtags: Hashtags added to all proposals
+            comments_blocked: Comments blocked
+            creation_enabled: Proposal creation enabled
+            endorsements_blocked: Endorsements blocked
+            endorsements_enabled: Endorsements enabled
+            proposal_answering_enabled: Proposal answering enabled
+            suggested_hashtags: Hashtags suggested to users for new proposals
+            votes_blocked: Voting blocked
+            votes_enabled: Voting enabled
+            votes_hidden: Votes hidden (if votes are enabled, checking this will hide the number of votes)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} bir katılımcı olarak erişmek için kabul edilmiş <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslak.'
-          email_outro: Bu bildirimi aldınız çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanısınız.
-          email_subject: "%{requester_name} , %{resource_title}katkı payı olarak kabul edildi."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> , <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın bir katkıcısı</strong> olarak erişim için <strong>kabul edilmiştir.
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '<a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın katılımcısı olarak erişim için %{requester_name} reddedildi.'
-          email_outro: Bu bildirimi aldınız çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanısınız.
-          email_subject: "%{resource_title} işbirlikçi taslağın katılımcısı olarak erişim için %{requester_name} reddedildi."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> , <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın bir katkıcısı</strong> olarak erişmek için <strong>reddedilmiştir.
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: 'Katılımcı olarak %{requester_name} talep edildi. Şunları yapabilirsiniz <strong>isteği kabul veya reddetmek</strong> ila <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslak sayfanın.'
-          email_outro: Bu bildirimi aldınız çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanısınız.
-          email_subject: "%{resource_title}katkıda bulunmak için %{requester_name} istenen erişim."
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağa katkıda bulunmak için <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> talep edildi. Lütfen <strong>isteği kabul edin veya reddedin</strong>.
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın katılımcısı olarak erişiminiz kabul edildi.
-          email_outro: Bu bildirimi aldınız, çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanı olmak istediniz.
-          email_subject: '%{resource_title}katkı olarak kabul edildiniz.'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın</strong> numaralı katılımcısı olarak erişmek için <strong>kabul edildi.
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been accepted as a contributor of %{resource_title}.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın katılımcısı olarak erişim için reddedildiniz.
-          email_outro: Bu bildirimi aldınız, çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanı olmak istediniz.
-          email_subject: '%{resource_title}katkı payı olarak reddedildiniz.'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağın</strong> üyesi olarak erişmek için <strong>reddedildiniz.
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been rejected as a contributor of %{resource_title}.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslağı geri çekmiştir.
-          email_outro: Bu bildirimi aldınız çünkü <a href="%{resource_path}">%{resource_title}</a>ortak çalışanısınız.
-          email_subject: "%{author_name} %{author_nickname} %{resource_title} işbirlikçi taslağı geri çekmiştir."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>çekildi</strong> <a href="%{resource_path}">%{resource_title}</a> işbirlikçi taslak.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
-          email_intro: 'Şimdi %{participatory_space_title}yeni teklifler oluşturabilirsiniz! Bu sayfaya katılmaya başlayın:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: Şu anda %{participatory_space_title}teklif mevcut
-          notification_title: Artık ileri koyabilirsiniz <a href="%{resource_path}">yeni teklifler</a> içinde <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals now available in %{participatory_space_title}
+          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'Teklifleri %{participatory_space_title}onaylayabilirsiniz! Bu sayfaya katılmaya başlayın:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: Teklifler onaylandı %{participatory_space_title}
-          notification_title: Artık başlayabilirsiniz <a href="%{resource_path}">tekliflerini destekleyen</a> de <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals endorsing has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
           affected_user:
-            email_intro: 'Teklifiniz "%{resource_title}" kabul edildi. Cevabı bu sayfada okuyabilirsiniz:'
-            email_outro: Bu bildirimi, "%{resource_title}" ın bir yazarı olduğunuz için aldınız.
-            email_subject: Teklifiniz kabul edildi
-            notification_title: Teklifiniz <a href="%{resource_path}">%{resource_title}</a> kabul edildi.
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal has been accepted
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
-            email_intro: '"%{resource_title}" teklifi kabul edildi. Cevabı bu sayfada okuyabilirsiniz:'
-            email_outro: Bu bildirimi "%{resource_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-            email_subject: Takip ettiğiniz bir teklif kabul edildi
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> teklif kabul edildi.
+            email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following has been accepted
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
-          email_intro: 'Takip ettiğiniz %{endorser_name} %{endorser_nickname}, "%{resource_title}" teklifini onayladı ve sizin için ilginç olabileceğini düşünüyoruz. Bir göz atın ve katkıda bulunun:'
-          email_outro: Bu bildirimi, %{endorser_nickname}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: "%{endorser_nickname} yeni bir teklifi onayladı"
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> teklif <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>tarafından onaylanmıştır.
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: "%{endorser_nickname} has endorsed a new proposal"
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
         proposal_evaluating:
           affected_user:
-            email_intro: 'Şu anda "%{resource_title}" teklifiniz değerlendiriliyor. Bu sayfadaki cevabı kontrol edebilirsiniz:'
-            email_outro: Bu bildirimi, "%{resource_title}" ın bir yazarı olduğunuz için aldınız.
-            email_subject: Teklifiniz değerlendiriliyor
-            notification_title: Teklifiniz <a href="%{resource_path}">%{resource_title}</a> değerlendiriliyor.
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal is being evaluated
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
-            email_intro: 'Şu anda "%{resource_title}" teklifi şu anda değerlendiriliyor. Bu sayfadaki cevabı kontrol edebilirsiniz:'
-            email_outro: Bu bildirimi "%{resource_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-            email_subject: Takip ettiğiniz bir teklif değerlendiriliyor
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> teklifi değerlendiriliyor.
+            email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following is being evaluated
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
-          email_intro: Öneriniz "%{mentioned_proposal_title}" söz edilmiştir <a href="%{resource_path}">bu alanda</a> yorumlardaki.
-          email_outro: Bu bildirimi, "%{resource_title}" ın bir yazarı olduğunuz için aldınız.
-          email_subject: Teklifinizin "%{mentioned_proposal_title}" olduğu belirtildi
-          notification_title: Öneriniz "%{mentioned_proposal_title}" söz edilmiştir <a href="%{resource_path}">bu alanda</a> yorumlardaki.
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          email_outro: You have received this notification because you are an author of "%{resource_title}".
+          email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: 'Takip ettiğiniz %{author_name} %{author_nickname}, "%{resource_title}" adlı yeni bir teklif yayınladı. Bir göz atın ve katkıda bulunun:'
-          email_outro: Bu bildirimi, %{author_nickname}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: Yeni teklif "%{resource_title}" %{author_nickname}
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> teklif <a href="%{author_path}">%{author_name} %{author_nickname}</a>tarafından yayınlandı.
+          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_subject: New proposal "%{resource_title}" by %{author_nickname}
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: Öneri "%{resource_title}" "eklendi%{participatory_space_title}" izlediğinizi.
-          email_outro: Bu bildirimi "%{participatory_space_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-          email_subject: Yeni teklif "%{resource_title}" %{participatory_space_title}eklendi
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> önerisi %{participatory_space_title}eklendi
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         proposal_rejected:
           affected_user:
-            email_intro: 'Teklifiniz "%{resource_title}" reddedildi. Cevabı bu sayfada okuyabilirsiniz:'
-            email_outro: Bu bildirimi, "%{resource_title}" ın bir yazarı olduğunuz için aldınız.
-            email_subject: Teklifiniz reddedildi
-            notification_title: Teklifiniz <a href="%{resource_path}">%{resource_title}</a> reddedildi.
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal been rejected
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
-            email_intro: '"%{resource_title}" teklifi reddedildi. Cevabı bu sayfada okuyabilirsiniz:'
-            email_outro: Bu bildirimi "%{resource_title}" takip ettiğiniz için aldınız. Bir önceki bağlantıdan takip etmeyi bırakabilirsiniz.
-            email_subject: Takip ettiğiniz bir teklif reddedildi
-            notification_title: <a href="%{resource_path}">%{resource_title}</a> teklifi reddedildi.
+            email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_subject: A proposal you're following has been rejected
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
-          email_intro: 'Bir yönetici, "%{resource_title}" teklifinizin kategorisini güncelledi, kontrol et:'
-          email_outro: Bu bildirimi aldınız çünkü teklifin yazarı sizsiniz.
-          email_subject: '%{resource_title} teklif kategorisi güncellendi'
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> teklif kategorisi bir yönetici tarafından güncellendi.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out:'
+          email_outro: You have received this notification because you are the author of the proposal.
+          email_subject: The %{resource_title} proposal category has been updated
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'Teklifleri %{participatory_space_title}oylayabilirsiniz! Bu sayfaya katılmaya başlayın:'
-          email_outro: Bu bildirimi, %{participatory_space_title}izlediğiniz için aldınız. Önceki bağlantıyı takip ederek bildirimleri almayı durdurabilirsiniz.
-          email_subject: '%{participatory_space_title}için teklifler başladı'
-          notification_title: Artık başlayabilirsiniz <a href="%{resource_path}">oylama teklifleri aynı</a> içinde <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          email_intro: 'You can vote proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: Proposals voting has started for %{participatory_space_title}
+          notification_title: You can now start <a href="%{resource_path}">voting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
-          conditions:
-            - Tekliflerin sunulması için gönderim ile ilgilendiğiniz katılım alanını seçin
-            - Gerçekleştirilebilecek teklifler vermeye çalışın. Bu şekilde kabul edilmeleri daha olasıdır.
-          description: Bu rozet, yeni tekliflere aktif olarak katıldığınızda verilir ve bunlar kabul edilir.
-          description_another: Bu kullanıcı %{score} teklif kabul etti.
-          description_own: '%{score} teklif kabul edildi.'
-          name: Kabul edilen teklifler
-          next_level_in: Bir sonraki seviyeye ulaşmak için kabul edilen %{score} teklif daha alın!
-          unearned_another: Bu kullanıcı henüz kabul edilen teklifleri almadı.
-          unearned_own: Henüz kabul edilen teklifin yok.
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Try to make proposals that can be carried out. This way they are more likely to be accepted."]'
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          description_another: This user has gotten %{score} proposals accepted.
+          description_own: You got %{score} proposals accepted.
+          name: Accepted proposals
+          next_level_in: Get %{score} more proposals accepted to reach the next level!
+          unearned_another: This user hasn't gotten any proposals accepted yet.
+          unearned_own: You got no proposals accepted yet.
         proposal_votes:
-          conditions:
-            - Göz atın ve diğer insanların önerilerini okumak için biraz zaman harcayın
-            - Beğendiğiniz ya da ilginç bulduğunuz tekliflere destek verin
-          description: Bu rozet, başkalarının önerilerini desteklediğinizde verilir.
-          description_another: Bu kullanıcı %{score} teklife destek verdi.
-          description_own: '%{score} teklife destek verdiniz.'
-          name: Teklif destekleri
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} teklife destek verin!
-          unearned_another: Bu kullanıcı henüz herhangi bir teklife destek vermedi.
-          unearned_own: Henüz hiçbir teklife destek vermediniz.
+          conditions: '["Browse and spend some time reading other people''s proposals", "Give support to the proposals you like or find interesting"]'
+          description: This badge is granted when you support other people's proposals.
+          description_another: This user has given support to %{score} proposals.
+          description_own: You have given support to %{score} proposals.
+          name: Proposal supports
+          next_level_in: Give support to %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't given support to any proposals yet.
+          unearned_own: You have given support to no proposals yet.
         proposals:
-          conditions:
-            - Tekliflerin sunulması için gönderim ile ilgilendiğiniz katılım alanını seçin
-            - Yeni bir teklif oluştur
-          description: Bu rozete, yeni tekliflere aktif olarak katıldığınızda izin verilir.
-          description_another: Bu kullanıcı %{score} teklif oluşturdu.
-          description_own: '%{score} teklif oluşturdunuz.'
-          name: Teklif
-          next_level_in: Bir sonraki seviyeye ulaşmak için %{score} teklif daha oluşturun!
-          unearned_another: Bu kullanıcı henüz herhangi bir teklif oluşturmadı.
-          unearned_own: Henüz hiç teklif oluşturmadınız.
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Create a new proposal"]'
+          description: This badge is granted when you actively participate with new proposals.
+          description_another: This user has created %{score} proposals.
+          description_own: You have created %{score} proposals.
+          name: Proposals
+          next_level_in: Create %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't created any proposals yet.
+          unearned_own: You have created no proposals yet.
     metrics:
       accepted_proposals:
-        description: Kullanıcılar tarafından kabul edilen teklif sayısı
-        object: önerileri
-        title: Kabul Edilen Teklifler
+        description: Number of proposals accepted by users
+        object: proposals
+        title: Accepted Proposals
       endorsements:
-        description: Tekliflerde oluşturulan ciro sayısı
-        object: onaylar
-        title: Cirolar
+        description: Number of endorsements generated in proposals
+        object: endorsements
+        title: Endorsements
       proposals:
-        description: Oluşturulan tekliflerin sayısı
-        object: önerileri
-        title: Teklif
+        description: Number of proposals generated
+        object: proposals
+        title: Proposals
       votes:
-        description: Kullanıcıların tekliflerinde oluşturulan oy sayısı
-        object: oy
-        title: oy
+        description: Number of votes generated in proposals by users
+        object: votes
+        title: Votes
     participatory_processes:
       participatory_process_groups:
         highlighted_proposals:
-          proposals: Teklif
+          proposals: Proposals
     participatory_spaces:
       highlighted_proposals:
-        see_all: Tümünü gör (%{count})
+        see_all: See all (%{count})
     proposals:
       actions:
-        answer: Cevap
-        edit_proposal: Teklifi düzenle
-        import: Başka bir bileşenden içe aktar
-        new: Yeni teklif
-        participatory_texts: Katılımcı metinler
-        private_notes: Özel notlar
-        title: Eylemler
+        answer: Answer
+        edit_proposal: Edit proposal
+        import: Import from another component
+        new: New proposal
+        participatory_texts: Participatory texts
+        private_notes: Private notes
+        title: Actions
       admin:
         actions:
-          preview: Ön izleme
+          preview: Preview
         exports:
-          comments: Yorumlar
-          proposals: Teklif
+          comments: Comments
+          proposals: Proposals
         models:
           proposal:
-            name: öneri
+            name: Proposal
         participatory_texts:
           bulk-actions:
-            are_you_sure: Katılımcı metin taslağının tamamını atadığınızdan emin misiniz?
-            import_doc: Dokümanı içe aktar
-            discard_all: Hepsini at
-          import:
-            invalid: Form geçersiz!
-            success: Tebrikler, aşağıdaki bölümler içe aktarılan belgeden ayrıştırılmış, tekliflere dönüştürülmüştür. Artık yayınlamadan önce ihtiyacınız olan şeyleri inceleyip ayarlayabilirsin.
-          index:
-            info_1: Aşağıdaki bölümler içe aktarılan belgeden ayrıştırılmış, tekliflere dönüştürülmüştür. Artık yayınlamadan önce ihtiyacınız olan şeyleri inceleyip ayarlayabilirsin.
-            publish_document: Belge yayınla
-            save_draft: Taslağı kaydet
-            title: ÖNEMLİ KATILIMCI METİN
-          new_import:
-            bottom_hint: "(Belge bölümlerini önizleyebilir ve sıralayabilirsiniz)"
-            document_legend: '2MB''dan daha az bir belge ekleyin, her bölüm 3 seviye derinlik Tekliflere ayrıştırılır. Desteklenen biçimler: Markdown'
-            title: BELGE EKLE
-            upload_document: Belge yükle
-          publish:
-            invalid: Teklifler yayınlanamadı
-            success: Tüm teklifler yayınlandı
+            are_you_sure: Are you sure to discard the whole participatory text draft?
+            discard_all: Discard all
+            import_doc: Import document
           discard:
-            success: Tüm Katılımcı metin taslakları atıldı.
+            success: All Participatory text drafts have been discarded.
+          import:
+            invalid: The form is invalid!
+            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+          index:
+            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            publish_document: Publish document
+            save_draft: Save draft
+            title: PREVIEW PARTICIPATORY TEXT
+          new_import:
+            bottom_hint: "(You will be able to preview and sort document sections)"
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            title: ADD DOCUMENT
+            upload_document: Upload document
+          publish:
+            invalid: Could not publish proposals
+            success: All proposals have been published
           sections:
-            article: "<em>Madde</em>"
-            section: "<em>Bölüm:</em> <strong>%{title}</strong>"
-            sub-section: "<em>Alt Bölüm:</em> %{title}"
+            article: "<em>Article</em>"
+            section: "<em>Section:</em> <strong>%{title}</strong>"
+            sub-section: "<em>Subsection:</em> %{title}"
           update:
-            success: Katılımcı metin başarıyla güncellendi.
+            success: Participatory text updated successfully.
         proposal_answers:
           edit:
-            accepted: Kabul edilmiş
-            answer_proposal: Cevap
-            evaluating: değerlendirilmesi
-            rejected: Reddedilen
-            title: Teklifin cevabı %{title}
+            accepted: Accepted
+            answer_proposal: Answer
+            evaluating: Evaluating
+            rejected: Rejected
+            title: Answer for proposal %{title}
         proposal_notes:
           create:
-            error: Bu teklif notu oluşturulurken bir sorun oluştu.
-            success: Teklif notası başarıyla oluşturuldu
+            error: There's been a problem creating this proposal note
+            success: Proposal note successfully created
           form:
-            note: Not
-            submit: Gönder
-          leave_your_note: Notunu bırak
-          title: Özel notlar
+            note: Note
+            submit: Submit
+          leave_your_note: Leave your note
+          title: Private notes
         proposals:
           answer:
-            invalid: Bu teklife cevap veren bir sorun oluştu
-            success: Teklif başarıyla cevaplandı
+            invalid: There's been a problem answering this proposal
+            success: Proposal successfully answered
           create:
-            invalid: Bu teklifin oluşturulmasında bir sorun oluştu
-            success: Teklif başarıyla oluşturuldu
+            invalid: There's been a problem creating this proposal
+            success: Proposal successfully created
           edit:
-            title: Teklifi güncelle
-            update: Güncelleştirme
+            title: Update proposal
+            update: Update
           form:
-            attachment_legend: "(İsteğe bağlı) Bir ek ekleyin"
-            created_in_meeting: Bu teklif bir toplantıdan geliyor
-            select_a_category: bir kategori seç
-            select_a_meeting: Bir toplantı seçin
+            attachment_legend: "(Optional) Add an attachment"
+            created_in_meeting: This proposal comes from a meeting
+            select_a_category: Select a category
+            select_a_meeting: Select a meeting
           index:
-            actions: Eylemler
-            cancel: İptal etmek
-            change_category: Kategoriyi değiştir
-            merge: Yeni biriyle birleştir
-            merge_button: birleşmek
-            select_component: Bir bileşen seç
-            selected: seçilmiş
-            split: Bölünmüş teklifler
-            split_button: Bölünmüş
-            title: Teklif
-            update: Güncelleştirme
+            actions: Actions
+            cancel: Cancel
+            change_category: Change category
+            merge: Merge into a new one
+            merge_button: Merge
+            select_component: Select a component
+            selected: selected
+            split: Split proposals
+            split_button: Split
+            title: Proposals
+            update: Update
           new:
-            create: yaratmak
-            title: Teklif oluştur
+            create: Create
+            title: Create proposal
           update_category:
-            invalid: 'Bu teklifler zaten %{category} kategorisine sahipti: %{proposals}.'
-            select_a_category: Lütfen bir kategori seçin
-            select_a_proposal: Lütfen bir teklif seçin
-            success: 'Teklifler başarıyla %{category} kategorisine güncellendi: %{proposals}.'
+            invalid: 'These proposals already had the %{category} category: %{proposals}.'
+            select_a_category: Please select a category
+            select_a_proposal: Please select a proposal
+            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
         proposals_imports:
           create:
-            invalid: Teklifleri içe aktarırken bir sorun oluştu
-            success: "%{number} teklif başarıyla içe aktarıldı"
+            invalid: There's been a problem importing the proposals
+            success: "%{number} proposals successfully imported"
           new:
-            create: Teklifleri içe aktar
-            no_components: Teklifleri içe aktarmak için bu katılımcı alanda başka hiçbir teklif bileşeni bulunmamaktadır.
-            select_component: Lütfen bir bileşen seçiniz
-            select_states: İçe aktarılacak tekliflerin durumlarını kontrol et
+            create: Import proposals
+            no_components: There are no other proposal components in this participatory space to import the proposals from.
+            select_component: Please select a component
+            select_states: Check the states of the proposals to import
         proposals_merges:
           create:
-            invalid: Seçilen teklifler birleştirilirken bir hata oluştu.
-            success: Teklifler, yeni bir taneyle başarılı bir şekilde birleştirildi.
+            invalid: There was an error merging the selected proposals.
+            success: Successfully merged the proposals into a new one.
         proposals_splits:
           create:
-            invalid: Seçilen teklifleri bölen bir hata oluştu.
-            success: Teklifleri başarılı bir şekilde yenilere ayırdı.
+            invalid: There was an error spliting the selected proposals.
+            success: Successfully splitted the proposals into new ones.
         shared:
           info_proposal:
-            body: Vücut
-            created_at: Oluşturulma tarihi
-            proposal_votes_count: Oy sayısı
-            proposals: Teklif
+            body: Body
+            created_at: Creation date
+            proposal_votes_count: Votes count
+            proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} , %{space_name} uzayda %{resource_name} teklifi yanıtladı"
-          create: "%{user_name} , resmi bir teklif olarak %{space_name} uzayda %{resource_name} teklif oluşturdu"
-          update: "%{user_name} , %{space_name} alanda %{resource_name} resmi öneriyi güncelledi"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
-          create: "%{user_name} , %{space_name} alanda %{resource_name} teklif üzerinde özel bir not bıraktı"
+          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
       answers:
-        accepted: Kabul edilmiş
-        evaluating: değerlendirilmesi
-        not_answered: Cevaplanmadı
-        rejected: Reddedilen
-        withdrawn: çekilmiş
+        accepted: Accepted
+        evaluating: Evaluating
+        not_answered: Not answered
+        rejected: Rejected
+        withdrawn: Withdrawn
       application_helper:
         filter_origin_values:
-          all: Herşey
-          citizens: Vatandaşlar
-          meetings: Toplantılar
-          official: Resmi
-          user_groups: Kullanıcı Grupları
+          all: All
+          citizens: Citizens
+          meetings: Meetings
+          official: Official
+          user_groups: User groups
         filter_state_values:
-          accepted: Kabul edilmiş
-          all: Herşey
-          evaluating: değerlendirilmesi
-          except_rejected: Reddedilenlerin tümü hariç
-          rejected: Reddedilen
+          accepted: Accepted
+          all: All
+          evaluating: Evaluating
+          except_rejected: All except rejected
+          rejected: Rejected
         filter_type_values:
-          all: Herşey
-          amendments: Değişiklikler
-          proposals: Teklif
+          all: All
+          amendments: Amendments
+          proposals: Proposals
       collaborative_drafts:
         collaborative_draft:
           publish:
-            error: Ortak taslak yayınlanırken hatalar oluştu.
+            error: There's been errors when publishing the collaborative draft.
             irreversible_action_modal:
-              body: Taslağı bir teklif olarak yayınladıktan sonra, taslak artık düzenlenemez. Teklif yeni yazarları veya katkıları kabul etmeyecektir.
-              cancel: İptal etmek
-              ok: Teklif olarak yayınla
-              title: Aşağıdaki işlem geri alınamaz
-            success: İşbirlikçi taslak bir teklif olarak başarıyla yayınlandı.
-          view_collaborative_draft: İşbirlikçi Taslak Görüntüle
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Publish as a Proposal
+              title: The following action is irreversible
+            success: Collaborative draft published successfully as a proposal.
+          view_collaborative_draft: View Collaborative Draft
           withdraw:
-            error: İşbirliği taslağını kapatırken hatalar oluştu.
+            error: There's been errors closing the collaborative draft.
             irreversible_action_modal:
-              body: Taslağı kapattıktan sonra, taslak artık düzenlenemez. Taslak yeni yazarları veya katkıları kabul etmeyecek.
-              cancel: İptal etmek
-              ok: İşbirliği taslağını geri çekme
-              title: Aşağıdaki işlem geri alınamaz
-            success: İşbirlikçi taslak başarıyla geri çekildi.
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Withdraw the collaborative draft
+              title: The following action is irreversible
+            success: Collaborative draft withdrawn successfully.
         compare:
-          mine_is_different: Ortak çalışma taslağım farklı
-          no_similars_found: Aferin! Benzer ortak taslak bulunamadı
-          title: Benzer işbirliği taslakları
+          mine_is_different: My collaborative draft is different
+          no_similars_found: Well done! No similar collaborative drafts found
+          title: Similar collaborative drafts
         complete:
-          send: göndermek
-          title: İşbirlikçi taslağınızı tamamlayın
+          send: Send
+          title: Complete your collaborative draft
         count:
           drafts_count:
-            one: "%{count} işbirlikçi taslak"
-            other: "%{count} işbirlikçi taslak"
+            one: "%{count} collaborative draft"
+            other: "%{count} collaborative draft"
         create:
-          error: Bu işbirlikçi taslakları oluştururken bir sorun oluştu
-          success: İşbirlikçi taslak başarıyla oluşturuldu.
+          error: There's been a problem creating this collaborative drafts
+          success: Collaborative draft successfully created.
         edit:
-          attachment_legend: "(İsteğe bağlı) Bir ek ekleyin"
-          back: Geri
-          select_a_category: Lütfen bir kategori seçin
-          send: göndermek
-          title: Ortak taslak düzenle
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          select_a_category: Please select a category
+          send: Send
+          title: Edit collaborative draft
         filters:
-          all: Herşey
-          amendment: Değişiklikler
-          category: Kategori
-          category_prompt: Kategori İstemi
-          open: Açık
-          published: Yayınlanan
-          related_to: İle ilgili
-          search: Arama
-          state: Belirtmek, bildirmek
-          withdrawn: çekilmiş
+          all: All
+          amendment: Amendments
+          category: Category
+          category_prompt: Category Prompt
+          open: Open
+          published: Published
+          related_to: Related to
+          search: Search
+          state: State
+          withdrawn: Withdrawn
         filters_small_view:
-          close_modal: Yakın kalıcı
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         new:
-          send: Devam et
-          title: İşbirlikçi taslak oluştur
+          send: Continue
+          title: Create Your collaborative draft
         new_collaborative_draft_button:
-          new_collaborative_draft: Yeni işbirlikçi taslak
+          new_collaborative_draft: New collaborative draft
         orders:
-          label: 'Sıralama taslakları:'
-          most_contributed: En çok katkıda bulunan
-          random: rasgele
-          recent: Son
+          label: 'Order drafts by:'
+          most_contributed: Most contributed
+          random: Random
+          recent: Recent
         requests:
           accepted_request:
-            error: Ortak çalışan olarak kabul edilemedi, daha sonra tekrar deneyin.
-            success: "@%{user} , ortak çalışan olarak başarıyla kabul edildi"
+            error: Could not be accepted as a collaborator, try again later.
+            success: "@%{user} has been accepted as a collaborator successfully"
           access_requested:
-            error: İsteğiniz tamamlanamadı, daha sonra tekrar deneyin.
-            success: Ortak çalışma isteğiniz başarıyla gönderildi
+            error: Your request could not be completed, try again later.
+            success: Your request to collaborate has been sent successfully
           collaboration_requests:
-            accept_request: Kabul etmek
-            reject_request: reddetmek
-            title: İşbirliği istekleri
+            accept_request: Accept
+            reject_request: Reject
+            title: Collaboration requests
           rejected_request:
-            error: Ortak çalışan olarak reddedilemedi, daha sonra tekrar deneyin.
-            success: "@%{user} , ortak çalışan olarak başarıyla reddedildi"
+            error: Could not be rejected as a collaborator, try again later.
+            success: "@%{user} has been rejected as a collaborator successfully"
         show:
-          back: Geri
-          edit: Ortak taslak düzenle
-          final_proposal: son teklif
-          final_proposal_help_text: Bu taslak bitti. Son bitirme teklifini görebilirsiniz
+          back: Back
+          edit: Edit collaborative draft
+          final_proposal: final proposal
+          final_proposal_help_text: This draft is finished. You can see the final finished proposal
           hidden_authors_count:
-            one: ve %{count} kişi daha
-            other: ve %{count} kişi daha
-          info-message: Bu, bir teklif için <strong>ortak çalışma taslağı</strong> . Bu, yazarlarının aşağıdaki yorum bölümünü kullanarak teklifi şekillendirmesine yardımcı olabilir veya düzenleme için erişim isteğinde bulunarak doğrudan iyileştirebilirsiniz. Yazarlar size erişim izni verdiğinde, bu taslakta değişiklikler yapabileceksiniz.
-          of_versions: "( %{number})"
-          publish: Yayınla
-          publish_info: Taslak bu sürümünü yayınlayın veya
-          published_proposal: yayınlanan teklif
-          request_access: Erişim talep etmek
-          requested_access: Erişim istendi
-          see_other_versions: diğer versiyonları gör
-          version: Sürüm %{number}
-          version_history: bu teklifin sürüm geçmişini gör
-          withdraw: taslağı geri çekmek
+            one: and %{count} more person
+            other: and %{count} more people
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          of_versions: "(of %{number})"
+          publish: Publish
+          publish_info: Publish this version of the draft or
+          published_proposal: published proposal
+          request_access: Request access
+          requested_access: Access requested
+          see_other_versions: see other versions
+          version: Version %{number}
+          version_history: see version history for this proposal
+          withdraw: withdraw the draft
         states:
-          open: Açık
-          published: Yayınlanan
-          withdrawn: çekilmiş
+          open: Open
+          published: Published
+          withdrawn: Withdrawn
         update:
-          error: Ortak taslak kaydedilirken hatalar oluştu.
-          success: İşbirliği taslağı başarıyla güncellendi.
+          error: There's been errors when saving the collaborative draft.
+          success: Collaborative draft updated successfully.
         wizard_aside:
-          back: Geri
-          info: <strong>ortak çalışma taslağı</strong>.
+          back: Back
+          info: You are creating a <strong>collaborative draft</strong>.
         wizard_steps:
-          see_steps: adımları görmek
-          step_1: İşbirlikçi taslağını oluştur
-          step_2: Ortak taslaklarla karşılaştır
-          step_3: İşbirlikçi taslağınızı tamamlayın
-          step_of: '%{total_steps}adımdan %{current_step_num}'
+          see_steps: see steps
+          step_1: Create your collaborative draft
+          step_2: Compare with collaborative drafts
+          step_3: Complete your collaborative draft
+          step_of: Step %{current_step_num} of %{total_steps}
       create:
-        error: Teklif kaydedilirken hatalar oluştu.
-        success: Teklif başarıyla oluşturuldu. Taslak olarak kaydedildi.
+        error: There's been errors when saving the proposal.
+        success: Proposal created successfully. Saved as a Draft.
       destroy_draft:
-        error: Teklif taslağını silerken hatalar oluştu.
-        success: Teklif taslak başarıyla silindi.
+        error: There's been errors deleting the proposal draft.
+        success: Proposal draft was successfully deleted.
       last_activity:
-        new_proposal_at_html: "<span>Yeni teklif %{link}</span>"
+        new_proposal_at_html: "<span>New proposal at %{link}</span>"
       models:
         collaborative_draft:
           fields:
-            authors: Yazarlar
-            comments: Yorumlar
-            contributions: Katılımlar
+            authors: Authors
+            comments: Comments
+            contributions: Contributions
         proposal:
           fields:
-            category: Kategori
-            comments: Yorumlar
-            endorsements: Cirolar
-            id: İD
-            notes: notlar
-            official_proposal: Resmi teklif
-            published_at: Yayınlandı
-            scope: kapsam
-            state: Belirtmek, bildirmek
-            title: Başlık
-            votes: oy
+            category: Category
+            comments: Comments
+            endorsements: Endorsements
+            id: ID
+            notes: Notes
+            official_proposal: Official proposal
+            published_at: Published at
+            scope: Scope
+            state: State
+            title: Title
+            votes: Votes
       new:
-        limit_reached: Sınırı aştığınız için yeni teklifler oluşturamazsınız.
+        limit_reached: You can't create new proposals since you've exceeded the limit.
       participatory_text_proposal:
-        alternative_title: Şu anda katılımcı metin yok
+        alternative_title: There are no participatory texts at the moment
         buttons:
-          amend: değiştirmek
-          comment: Yorum Yap
-          comments: Yorumlar
-          endorse: desteklemek
+          amend: Amend
+          comment: Comment
+          comments: Comments
+          endorse: Endorse
       proposal_endorsements:
         create:
-          error: Teklifin onaylanması sırasında hatalar oluştu.
+          error: There's been errors when endorsing the proposal.
         identities:
-          done: tamam
-          select_identity: Kimlik seç
+          done: Done
+          select_identity: Select identity
       proposal_endorsements_helper:
         endorsement_button:
-          already_endorsed: Onaylanan
-          endorse: desteklemek
+          already_endorsed: Endorsed
+          endorse: Endorse
         render_endorsements_button_card_part:
-          endorse: desteklemek
+          endorse: Endorse
       proposal_votes:
         create:
-          error: Teklif oylanırken hatalar oluştu.
+          error: There's been errors when voting the proposal.
       proposals:
         compare:
-          mine_is_different: Teklifim farklı
-          no_similars_found: Aferin! Benzer teklif bulunamadı
-          title: Benzer teklifler
+          continue: Continue
+          mine_is_different: Моя пропозиція інша
+          no_similars_found: Well done! No similar proposals found
+          title: Similar Proposals
         complete:
-          send: göndermek
-          title: Teklifinizi tamamlayın
+          send: Send
+          title: Complete your proposal
         count:
           proposals_count:
-            one: "%{count} teklif"
-            other: "%{count} teklif"
+            one: "%{count} proposal"
+            other: "%{count} proposals"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
-          attachment_legend: "(İsteğe bağlı) Bir ek ekleyin"
-          back: Geri
-          select_a_category: Lütfen bir kategori seçin
-          send: göndermek
-          title: Teklifi düzenle
+          address: Address (don't forget to specify the city)
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          not_geocoded: Not geocoded
+          select_a_category: Please select a category
+          send: Send
+          title: Edit proposal
         edit_draft:
-          discard: Bu taslağı sil
-          discard_confirmation: Bu teklif taslağını silmek istediğinizden emin misiniz?
-          send: Ön izleme
-          title: Teklif Taslaklarını Düzenle
+          discard: Discard this draft
+          discard_confirmation: Are you sure you want to discard this proposal draft?
+          send: Preview
+          title: Edit Proposal Draft
         endorsement_identities_cabin:
-          endorse: desteklemek
+          endorse: Endorse
         endorsements_card_row:
-          comments: Yorumlar
+          comments: Comments
         filters:
-          activity: Aktivite
-          category: Kategori
-          category_prompt: bir kategori seç
-          origin: Menşei
-          related_to: İle ilgili
-          search: Arama
-          state: Belirtmek, bildirmek
-          voted: oy
-          amendment_type: tip
+          activity: Activity
+          amendment_type: Type
+          category: Category
+          category_prompt: Select a category
+          origin: Origin
+          related_to: Related to
+          search: Search
+          state: State
+          voted: Voted
         filters_small_view:
-          close_modal: Yakın kalıcı
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         index:
-          collaborative_drafts_list: Ortak taslaklara erişme
-          new_proposal: Yeni teklif
-          see_all_withdrawn: Geri çekilen tüm tekliflere bakın
-          view_proposal: Teklifi görüntüle
+          collaborative_drafts_list: Access collaborative drafts
+          new_proposal: New proposal
+          see_all_withdrawn: See all withdrawn proposals
+          view_proposal: View proposal
         linked_proposals:
           proposal_votes:
-            one: oy
-            other: oy
+            one: vote
+            other: votes
         new:
-          send: Devam et
-          title: Teklifinizi Oluşturun
+          send: Continue
+          title: Create Your Proposal
         orders:
-          label: 'Teklifleri şuna göre sırala:'
-          most_voted: En çok oylanan
-          random: rasgele
-          recent: Son
+          label: 'Order proposals by:'
+          most_voted: Most voted
+          random: Random
+          recent: Recent
         participatory_texts:
           index:
-            document_index: Belge indeksi
+            document_index: Document index
           view_index:
-            see_index: Endeksi görmek
+            see_index: See index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
-          modify: Teklifi değiştir
+          address: 'Address: %{address}'
+          modify: Modify the proposal
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: Teklifin yayınlanmasından sonraki ilk dakika boyunca bu teklifi düzenleyebileceksiniz. Bu zaman penceresi geçtikten sonra teklifi düzenleyemezsiniz.
-            other: Teklifin yayınlanmasından sonraki ilk %{count} dakika içinde bu teklifi düzenleyebileceksiniz. Bu zaman penceresi geçtikten sonra teklifi düzenleyemezsiniz.
-          publish: Yayınla
-          title: Teklifinizi yayınlayın
+            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+          publish: Publish
+          title: Publish your proposal
+          update_pos: Update the position
         proposal:
-          creation_date: 'Oluşturma: %{date}'
-          view_proposal: Teklifi görüntüle
+          creation_date: 'Creation: %{date}'
+          view_proposal: View proposal
         show:
-          back_to: Geri
-          edit_proposal: Teklifi düzenle
-          endorsements_list: Onay Listesi
+          back_to: Back to
+          edit_proposal: Edit proposal
+          endorsements_list: List of Endorsements
           hidden_endorsers_count:
-            one: ve %{count} kişi daha
-            other: ve %{count} kişi daha
-          link_to_collaborative_draft_help_text: Bu teklif, işbirlikçi bir taslağın sonucudur. Geçmişi gözden geçirin
-          link_to_collaborative_draft_text: Ortak taslaka bakın
-          proposal_accepted_reason: 'Bu teklif kabul edildi çünkü:'
-          proposal_in_evaluation_reason: Bu teklif değerlendiriliyor
-          proposal_rejected_reason: 'Bu teklif reddedildi çünkü:'
-          report: Rapor
-          withdraw_btn_hint: Herhangi bir destek almadığınız sürece fikrinizi değiştirirseniz teklifinizi geri çekebilirsiniz. Teklif silinmemiş, iptal edilen teklifler listesinde görünecektir.
-          withdraw_confirmation: Bu teklifi geri çektiğinizden emin misiniz?
-          withdraw_proposal: Teklifi geri çek
+            one: and %{count} more person
+            other: and %{count} more people
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_text: See the collaborative draft
+          proposal_accepted_reason: 'This proposal has been accepted because:'
+          proposal_in_evaluation_reason: This proposal is being evaluated
+          proposal_rejected_reason: 'This proposal has been rejected because:'
+          report: Report
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
+          withdraw_confirmation: Are you sure to withdraw this proposal?
+          withdraw_proposal: Withdraw proposal
         tags:
-          changed_from: "(bir yönetici tarafından <u>%{previous_category}</u> değiştirildi)"
-          filed_as: Olarak dosyalandı
+          changed_from: "(changed from <u>%{previous_category}</u> by an administrator)"
+          filed_as: Filed as
         vote_button:
-          already_voted: Çoktan oy verildi
+          already_voted: Already voted
           already_voted_hover: Unvote
-          maximum_votes_reached: Oy limiti aşıldı
-          no_votes_remaining: Kalan oy yok
-          vote: Oy
-          votes_blocked: Oylama devre dışı
+          maximum_votes_reached: Vote limit reached
+          no_votes_remaining: No votes remaining
+          vote: Vote
+          votes_blocked: Voting disabled
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
-            one: OY
-            other: OYLAR
-          most_popular_proposal: En popüler teklif
-          need_more_votes: Daha fazla oy gerekiyor
+            one: VOTE
+            other: VOTES
+          most_popular_proposal: Most popular proposal
+          need_more_votes: Need more votes
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
-            description: Her teklif, %{limit} fazla destek biriktirebilir
+            description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: Farklı teklifler arasında en az %{votes} oy kullanmalısınız.
-            given_enough_votes: Yeterince destek verdin.
-            supports_remaining: Oylarınızın dikkate alınması için %{remaining_votes} daha fazla teklif vermeniz gerekiyor.
+            description: You must distribute a minimum of %{votes} votes among different proposals.
+            given_enough_votes: You've given enough supports.
+            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
           proposal_limit:
-            description: En fazla %{limit} teklif oluşturabilirsin.
+            description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: Onaylanacak tekliflerin %{limit} ulaşması gerekiyor
-          title: 'Oylama aşağıdaki kurallara tabidir:'
+            description: In order to be validated proposals need to reach %{limit} supports
+          title: 'Voting is subject to the following rules:'
           vote_limit:
-            description: En fazla %{limit} teklife oy verebilirsiniz.
-            left: Kalan
-            votes: oy
+            description: You can vote up to %{limit} proposals.
+            left: Remaining
+            votes: Votes
         wizard_aside:
-          back: Geri
-          info: <strong>teklif</strong>.
+          back: Back
+          info: You are creating a <strong>proposal</strong>.
         wizard_steps:
-          see_steps: adımları görmek
-          step_1: Teklifinizi oluşturun
-          step_2: Karşılaştırmak
-          step_3: Tamamlayınız
-          step_4: Teklifinizi yayınlayın
-          step_of: '%{total_steps}adımdan %{current_step_num}'
+          see_steps: see steps
+          step_1: Create your proposal
+          step_2: Compare
+          step_3: Complete
+          step_4: Publish your proposal
+          step_of: Step %{current_step_num} of %{total_steps}
       publish:
-        error: Teklif yayınlanırken hatalar oluştu.
-        success: Teklif başarıyla yayınlandı.
+        error: There's been errors when publishing the proposal.
+        success: Proposal published successfully.
       update:
-        error: Teklif kaydedilirken hatalar oluştu.
-        success: Teklif başarıyla güncellendi.
+        error: There's been errors when saving the proposal.
+        success: Proposal updated successfully.
       update_draft:
-        error: Teklif taslağını kaydederken hatalar oluştu.
-        success: Teklif taslağı başarıyla güncellendi.
+        error: There's been errors when saving the proposal draft.
+        success: Proposal draft updated successfully.
       versions:
-        changes_at_title: '"%{title}" daki değişiklikler'
+        changes_at_title: Changes at "%{title}"
         index:
-          title: Sürümler
+          title: Versions
         stats:
-          back_to_collaborative_draft: İşbirliği taslağına geri dönün
-          back_to_proposal: Teklife geri dön
-          number_of_versions: Sürümler
-          show_all_versions: Tüm versiyonları göster
-          version_author: Sürüm yazarı
-          version_created_at: Sürümde oluşturuldu
-          version_number: Versiyon numarası
-          version_number_out_of_total: "%{current_version} üzerinden %{total_count}"
+          back_to_collaborative_draft: Go back to collaborative draft
+          back_to_proposal: Go back to proposal
+          number_of_versions: Versions
+          show_all_versions: Show all versions
+          version_author: Version author
+          version_created_at: Version created at
+          version_number: Version number
+          version_number_out_of_total: "%{current_version} out of %{total_count}"
         version:
-          version_index: Sürüm %{index}
+          version_index: Version %{index}
     resource_links:
       copied_from_component:
-        proposal_proposal: İlgili teklifler
+        proposal_proposal: Related proposals
       included_projects:
-        project_result: 'Bu projede görünen sonuçlar:'
+        project_result: 'Results appearing in this project:'
       included_proposals:
-        proposal_project: 'Bu projelerde görünen teklif:'
-        proposal_result: 'Bu sonuçlarda görünen teklif:'
+        proposal_project: 'Proposal appearing in these projects:'
+        proposal_result: 'Proposal appearing in these results:'

--- a/decidim-proposals/config/locales/uk.yml
+++ b/decidim-proposals/config/locales/uk.yml
@@ -1,14 +1,26 @@
+---
 uk:
   activemodel:
     attributes:
+      collaborative_draft:
+        body: Body
+        category_id: Category
+        decidim_scope_id: Scope
+        has_address: Has address
+        state: State
+        title: Title
+        user_group_id: Create collaborative draft as
       proposal:
+        address: Address
         answer: Відповісти
         answered_at: 'Отримано відповідь:'
+        automatic_hashtags: Hashtags automatically added
         body: Основний текст
         category_id: Категорія
         has_address: Має адресу
         scope_id: Обсяг
         state: Стан
+        suggested_hashtags: Suggested hashtags
         title: Назва
         user_group_id: Створити пропозицію як
       proposal_answer:
@@ -35,25 +47,28 @@ uk:
       decidim/proposals/voting_enabled_event: Увімкнене голосування по пропозиціям
   activerecord:
     models:
+      decidim/proposals/collaborative_draft:
+        one: Collaborative draft
+        other: Collaborative drafts
       decidim/proposals/proposal:
-        one: Пропозиція
         few: Пропозиції
         many: Пропозицій
+        one: Пропозиція
         other: Пропозицій
       decidim/proposals/proposal_endorsement:
-        one: Прояв підтримки
         few: Прояви підтримки
         many: Проявів підтримки
+        one: Прояв підтримки
         other: Проявів підтримки
       decidim/proposals/proposal_note:
-        one: Примітка
         few: Примітки
         many: Приміток
+        one: Примітка
         other: Приміток
       decidim/proposals/proposal_vote:
-        one: Голос
         few: Голоси
         many: Голосів
+        one: Голос
         other: Голосів
   decidim:
     components:
@@ -66,13 +81,17 @@ uk:
         name: Пропозиції
         settings:
           global:
+            amendments_enabled: Amendments enabled
             announcement: Оголошення
             attachments_allowed: Дозволити вкладення
             can_accumulate_supports_beyond_threshold: Можна накопичувати прояви підтримки більше порогового значення
+            collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Коментарі увімкнено
             geocoding_enabled: Геокодування увімкнено
+            minimum_votes_per_user: Minimum votes per user
             new_proposal_help_text: Підказки зі внесення нової пропозиції
             official_proposals_enabled: Службові пропозиції увімкнено
+            participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Увімкнено відповіді на пропозиції
             proposal_edit_before_minutes: Пропозиції можуть бути відредаговані авторами до того, як пройде стільки хвилин
             proposal_length: Гранична довжина основного тексту пропозиції
@@ -86,16 +105,57 @@ uk:
             vote_limit: Гранична кількість голосів від одного учасника
           step:
             announcement: Оголошення
+            automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Коментарі вимкнено
             creation_enabled: Внесення пропозицій увімкнено
             endorsements_blocked: Надання підтримки вимкнене
             endorsements_enabled: Надання підтримки увімкнено
             proposal_answering_enabled: Відповіді на пропозиції увімкнено
+            suggested_hashtags: Hashtags suggested to users for new proposals
             votes_blocked: Голосування вимкнене
             votes_enabled: Голосування ввімкнене
             votes_hidden: Голоси приховані (якщо голосування увімкнене, то буде сховано кількість голосів)
+            votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
+      proposal_created:
+        email_subject: Nouvelle proposition de %{author_name}.
+        moderation:
+          email_intro: Email intro
+          email_subject: Email subject
+          moderation_url: Moderation url
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        url: 'url de commentaire : %{resource_url}'
       proposals:
+        collaborative_draft_access_accepted:
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_rejected:
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_requested:
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
+        collaborative_draft_access_requester_accepted:
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been accepted as a contributor of %{resource_title}.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_access_requester_rejected:
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: You have been rejected as a contributor of %{resource_title}.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+        collaborative_draft_withdrawn:
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
           email_intro: 'Тепер в %{participatory_space_title} з''явилась можливість вносити нові пропозиції! Почніть брати участь зі сторінки:'
           email_outro: Ви отримали це сповіщення, тому що ви стежите за %{participatory_space_title}. Ви можете відписатися від цих сповіщень, перейшовши за наведеним вище посиланням.
@@ -107,38 +167,70 @@ uk:
           email_subject: У %{participatory_space_title} почалось надання підтримки пропозиціям
           notification_title: Тепер в <a href="%{participatory_space_url}">%{participatory_space_title}</a> відкрилась можливість <a href="%{resource_path}">підтримувати пропозиції</a>
         proposal_accepted:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal has been accepted
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
             email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
             email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
             email_subject: Пропозиція, за якою ви стежите, була прийнята
             notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
           email_outro: Ви отримали це сповіщення, тому що ви стежите за %{endorser_nickname}. Ви можете відписатися від цих сповіщень, перейшовши за наведеним вище посиланням.
           email_subject: "%{endorser_nickname} підтримав нову пропозицію"
           notification_title: <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a> підтримав пропозицію <a href="%{resource_path}">%{resource_title}</a>.
         proposal_evaluating:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal is being evaluated
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
             email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
             email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
             email_subject: Пропозиція, за якою ви стежите, зараз розглядається
             notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
           email_intro: Вашу пропозицію "%{mentioned_proposal_title}" було згадано в коментарях <a href="%{resource_path}">в цьому просторі</a>.
+          email_outro: You have received this notification because you are an author of "%{resource_title}".
           email_subject: Вашу пропозицію "%{mentioned_proposal_title}" було згадано
           notification_title: Вашу пропозицію "%{mentioned_proposal_title}" було згадано в коментарях <a href="%{resource_path}">в цьому просторі</a>.
         proposal_published:
+          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
           email_outro: Ви отримали це сповіщення, тому що ви стежите за %{author_nickname}. Ви можете відписатися від цих сповіщень, перейшовши за наведеним вище посиланням.
+          email_subject: New proposal "%{resource_title}" by %{author_nickname}
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> оприлюднив пропозицію <a href="%{resource_path}">%{resource_title}</a>.
         proposal_published_for_space:
           email_intro: До "%{participatory_space_title}", за яким ви стежите, була додана пропозиція "%{resource_title}".
           email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{participatory_space_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
           notification_title: До %{participatory_space_title} було додано пропозицію <a href="%{resource_path}">%{resource_title}</a>
         proposal_rejected:
+          affected_user:
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal been rejected
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+          email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
             email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
             email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
             email_subject: Пропозиція, за якою ви стежите, була відхилена
             notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
           email_intro: 'Адміністратор оновив категорію вашої пропозиції "%{resource_title}", перевірте її:'
           email_outro: Ви отримали це сповіщення, оскільки ви є автором цієї пропозиції.
@@ -149,18 +241,66 @@ uk:
           email_outro: Ви отримали це сповіщення, тому що ви стежите за %{participatory_space_title}. Ви можете відписатися від цих сповіщень, перейшовши за наведеним вище посиланням.
           email_subject: У %{participatory_space_title} почалось голосування щодо пропозицій
           notification_title: Тепер в <a href="%{participatory_space_url}">%{participatory_space_title}</a> відкрилась можливість <a href="%{resource_path}">голосувати щодо пропозицій</a>
+    gamification:
+      badges:
+        accepted_proposals:
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Try to make proposals that can be carried out. This way they are more likely to be accepted."]'
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          description_another: This user has gotten %{score} proposals accepted.
+          description_own: You got %{score} proposals accepted.
+          name: Accepted proposals
+          next_level_in: Get %{score} more proposals accepted to reach the next level!
+          unearned_another: This user hasn't gotten any proposals accepted yet.
+          unearned_own: You got no proposals accepted yet.
+        proposal_votes:
+          conditions: '["Browse and spend some time reading other people''s proposals", "Give support to the proposals you like or find interesting"]'
+          description: This badge is granted when you support other people's proposals.
+          description_another: This user has given support to %{score} proposals.
+          description_own: You have given support to %{score} proposals.
+          name: Proposal supports
+          next_level_in: Give support to %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't given support to any proposals yet.
+          unearned_own: You have given support to no proposals yet.
+        proposals:
+          conditions: '["Choose the participation space of your interest with submission for proposals enabled", "Create a new proposal"]'
+          description: This badge is granted when you actively participate with new proposals.
+          description_another: This user has created %{score} proposals.
+          description_own: You have created %{score} proposals.
+          name: Proposals
+          next_level_in: Create %{score} more proposals to reach the next level!
+          unearned_another: This user hasn't created any proposals yet.
+          unearned_own: You have created no proposals yet.
     metrics:
+      accepted_proposals:
+        description: Number of proposals accepted by users
+        object: proposals
+        title: Accepted Proposals
+      endorsements:
+        description: Number of endorsements generated in proposals
+        object: endorsements
+        title: Endorsements
+      proposals:
+        description: Number of proposals generated
+        object: proposals
+        title: Proposals
       votes:
+        description: Number of votes generated in proposals by users
+        object: votes
         title: Голоси
     participatory_processes:
       participatory_process_groups:
         highlighted_proposals:
           proposals: Пропозиції
+    participatory_spaces:
+      highlighted_proposals:
+        see_all: See all (%{count})
     proposals:
       actions:
         answer: Відповісти
+        edit_proposal: Edit proposal
         import: Запозичити з іншої складової
         new: Додати нову пропозицію
+        participatory_texts: Participatory texts
         private_notes: Приватні примітки
         title: Дії
       admin:
@@ -172,6 +312,35 @@ uk:
         models:
           proposal:
             name: Пропозиція
+        participatory_texts:
+          bulk-actions:
+            are_you_sure: Are you sure to discard the whole participatory text draft?
+            discard_all: Discard all
+            import_doc: Import document
+          discard:
+            success: All Participatory text drafts have been discarded.
+          import:
+            invalid: The form is invalid!
+            success: Congratulations, the following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+          index:
+            info_1: The following sections have been parsed from the imported document, they have been converted to proposals. Now you can review and adjust whatever you need before publishing.
+            publish_document: Publish document
+            save_draft: Save draft
+            title: PREVIEW PARTICIPATORY TEXT
+          new_import:
+            bottom_hint: "(You will be able to preview and sort document sections)"
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: Markdown'
+            title: ADD DOCUMENT
+            upload_document: Upload document
+          publish:
+            invalid: Could not publish proposals
+            success: All proposals have been published
+          sections:
+            article: "<em>Article</em>"
+            section: "<em>Section:</em> <strong>%{title}</strong>"
+            sub-section: "<em>Subsection:</em> %{title}"
+          update:
+            success: Participatory text updated successfully.
         proposal_answers:
           edit:
             accepted: Прийнято
@@ -195,14 +364,24 @@ uk:
           create:
             invalid: При спробі створити цю пропозицію сталася помилка
             success: Пропозицію успішно внесено
+          edit:
+            title: Update proposal
+            update: Update
           form:
             attachment_legend: "(Необов'язково) Додати вкладений файл"
+            created_in_meeting: This proposal comes from a meeting
             select_a_category: Оберіть категорію
+            select_a_meeting: Select a meeting
           index:
             actions: Дії
             cancel: Скасувати
             change_category: Змінити категорію
+            merge: Merge into a new one
+            merge_button: Merge
+            select_component: Select a component
             selected: обрані
+            split: Split proposals
+            split_button: Split
             title: Пропозиції
             update: Оновити
           new:
@@ -222,6 +401,14 @@ uk:
             no_components: У цьому просторі співучасті немає інших складових пропозицій, звідки можна було б запозичити пропозиції.
             select_component: Будь ласка, оберіть складову
             select_states: Перевірте стани пропозицій, які бажаєте запозичити
+        proposals_merges:
+          create:
+            invalid: There was an error merging the selected proposals.
+            success: Successfully merged the proposals into a new one.
+        proposals_splits:
+          create:
+            invalid: There was an error spliting the selected proposals.
+            success: Successfully splitted the proposals into new ones.
         shared:
           info_proposal:
             body: Основний текст
@@ -232,6 +419,7 @@ uk:
         proposal:
           answer: "%{user_name} відповів на пропозицію %{resource_name} у просторі %{space_name}"
           create: "%{user_name} вніс пропозицію %{resource_name} у просторі %{space_name} як службову"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
           create: "%{user_name} залишив приватну нотатку щодо пропозиції %{resource_name} у просторі %{space_name}"
       answers:
@@ -242,20 +430,149 @@ uk:
         withdrawn: Відкликана
       application_helper:
         filter_origin_values:
+          all: All
           citizens: Громадяни
+          meetings: Meetings
           official: Службове
+          user_groups: User groups
         filter_state_values:
+          accepted: Accepted
+          all: All
+          evaluating: Evaluating
           except_rejected: Усі, окрім відхилених
+          rejected: Rejected
+        filter_type_values:
+          all: All
+          amendments: Amendments
+          proposals: Proposals
       collaborative_drafts:
+        collaborative_draft:
+          publish:
+            error: There's been errors when publishing the collaborative draft.
+            irreversible_action_modal:
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Publish as a Proposal
+              title: The following action is irreversible
+            success: Collaborative draft published successfully as a proposal.
+          view_collaborative_draft: View Collaborative Draft
+          withdraw:
+            error: There's been errors closing the collaborative draft.
+            irreversible_action_modal:
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              cancel: Cancel
+              ok: Withdraw the collaborative draft
+              title: The following action is irreversible
+            success: Collaborative draft withdrawn successfully.
+        compare:
+          mine_is_different: My collaborative draft is different
+          no_similars_found: Well done! No similar collaborative drafts found
+          title: Similar collaborative drafts
+        complete:
+          send: Send
+          title: Complete your collaborative draft
+        count:
+          drafts_count:
+            one: "%{count} collaborative draft"
+            other: "%{count} collaborative draft"
+        create:
+          error: There's been a problem creating this collaborative drafts
+          success: Collaborative draft successfully created.
+        edit:
+          attachment_legend: "(Optional) Add an attachment"
+          back: Back
+          select_a_category: Please select a category
+          send: Send
+          title: Edit collaborative draft
         filters:
+          all: All
+          amendment: Amendments
+          category: Category
+          category_prompt: Category Prompt
+          open: Open
+          published: Published
+          related_to: Related to
+          search: Search
           state: Стан
+          withdrawn: Withdrawn
+        filters_small_view:
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
+        new:
+          send: Continue
+          title: Create Your collaborative draft
+        new_collaborative_draft_button:
+          new_collaborative_draft: New collaborative draft
+        orders:
+          label: 'Order drafts by:'
+          most_contributed: Most contributed
+          random: Random
+          recent: Recent
+        requests:
+          accepted_request:
+            error: Could not be accepted as a collaborator, try again later.
+            success: "@%{user} has been accepted as a collaborator successfully"
+          access_requested:
+            error: Your request could not be completed, try again later.
+            success: Your request to collaborate has been sent successfully
+          collaboration_requests:
+            accept_request: Accept
+            reject_request: Reject
+            title: Collaboration requests
+          rejected_request:
+            error: Could not be rejected as a collaborator, try again later.
+            success: "@%{user} has been rejected as a collaborator successfully"
+        show:
+          back: Back
+          edit: Edit collaborative draft
+          final_proposal: final proposal
+          final_proposal_help_text: This draft is finished. You can see the final finished proposal
+          hidden_authors_count:
+            one: and %{count} more person
+            other: and %{count} more people
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          of_versions: "(of %{number})"
+          publish: Publish
+          publish_info: Publish this version of the draft or
+          published_proposal: published proposal
+          request_access: Request access
+          requested_access: Access requested
+          see_other_versions: see other versions
+          version: Version %{number}
+          version_history: see version history for this proposal
+          withdraw: withdraw the draft
+        states:
+          open: Open
+          published: Published
+          withdrawn: Withdrawn
+        update:
+          error: There's been errors when saving the collaborative draft.
+          success: Collaborative draft updated successfully.
+        wizard_aside:
+          back: Back
+          info: You are creating a <strong>collaborative draft</strong>.
+        wizard_steps:
+          see_steps: see steps
+          step_1: Create your collaborative draft
+          step_2: Compare with collaborative drafts
+          step_3: Complete your collaborative draft
+          step_of: Step %{current_step_num} of %{total_steps}
       create:
         error: При спробі збереження цієї пропозиції сталися помилки.
         success: Пропозицію успішно створено. Збережено як чернетку.
       destroy_draft:
         error: При спробі видалити чернетку цієї пропозиції сталися помилки.
         success: Чернетку пропозиції успішно видалено.
+      last_activity:
+        new_proposal_at_html: "<span>New proposal at %{link}</span>"
       models:
+        collaborative_draft:
+          fields:
+            authors: Authors
+            comments: Comments
+            contributions: Contributions
         proposal:
           fields:
             category: Категорія
@@ -271,6 +588,13 @@ uk:
             votes: Голоси
       new:
         limit_reached: Ви не можете вносити нові пропозиції, оскільки ви перевищили ліміт.
+      participatory_text_proposal:
+        alternative_title: There are no participatory texts at the moment
+        buttons:
+          amend: Amend
+          comment: Comment
+          comments: Comments
+          endorse: Endorse
       proposal_endorsements:
         create:
           error: При спробі надати підтримку цій пропозиції виникла помилка.
@@ -288,15 +612,25 @@ uk:
           error: При голосуванні щодо пропозиції сталися помилки.
       proposals:
         compare:
+          continue: Continue
           mine_is_different: Моя пропозиція інша
           no_similars_found: Гарна робота! Не знайдено схожий пропозицій
           title: Подібні пропозиції
         complete:
           send: Надіслати
           title: Завершіть свою пропозицію
+        count:
+          proposals_count:
+            one: "%{count} proposal"
+            other: "%{count} proposals"
+        dynamic_map_instructions:
+          primary: You can move the point on the map.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
+          address: Address (don't forget to specify the city)
           attachment_legend: "(Необов'язково) Додати вкладений файл"
           back: Повернутись
+          not_geocoded: Not geocoded
           select_a_category: Будь ласка, виберіть категорію
           send: Надіслати
           title: Редагувати пропозицію
@@ -311,6 +645,7 @@ uk:
           comments: Коментарі
         filters:
           activity: Діяльність
+          amendment_type: Type
           category: Категорія
           category_prompt: Оберіть категорію
           origin: Джерело
@@ -324,14 +659,15 @@ uk:
           filter_by: 'Відібрати за ознакою:'
           unfold: Розгорнути
         index:
+          collaborative_drafts_list: Access collaborative drafts
           new_proposal: Додати нову пропозицію
           see_all_withdrawn: Переглянути всі відкликані пропозиції
           view_proposal: Переглянути пропозицію
         linked_proposals:
           proposal_votes:
-            one: голос
             few: голоси
             many: голосів
+            one: голос
             other: голосів
         new:
           send: Продовжити
@@ -341,21 +677,37 @@ uk:
           most_voted: Отримали найбільше голосів
           random: Довільно
           recent: Нещодавні
+        participatory_texts:
+          index:
+            document_index: Document index
+          view_index:
+            see_index: See index
+        placeholder:
+          address: "[n°] [street] [postal] [city]"
         preview:
+          address: 'Address: %{address}'
           modify: Внести зміни в пропозицію
+          not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: Ви зможете редагувати цю пропозицію протягом першої хвилини після оприлюднення пропозиції. Після цього проміжку часу ви не зможете редагувати пропозицію.
             few: Ви зможете редагувати цю пропозицію протягом перших %{count} хвилин після оприлюднення пропозиції. Після цього проміжку часу ви не зможете редагувати пропозицію.
             many: Ви зможете редагувати цю пропозицію протягом перших %{count} хвилин після оприлюднення пропозиції. Після цього проміжку часу ви не зможете редагувати пропозицію.
+            one: Ви зможете редагувати цю пропозицію протягом першої хвилини після оприлюднення пропозиції. Після цього проміжку часу ви не зможете редагувати пропозицію.
             other: Ви зможете редагувати цю пропозицію протягом перших %{count} хвилин після оприлюднення пропозиції. Після цього проміжку часу ви не зможете редагувати пропозицію.
           publish: Оприлюднити
           title: Оприлюднити свою пропозицію
+          update_pos: Update the position
         proposal:
           creation_date: 'Внесено: %{date}'
           view_proposal: Переглянути пропозицію
         show:
+          back_to: Back to
           edit_proposal: Редагувати пропозицію
           endorsements_list: Перелік тих, хто підтримав
+          hidden_endorsers_count:
+            one: and %{count} more person
+            other: and %{count} more people
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'Ця пропозиція була прийнята, тому що:'
           proposal_in_evaluation_reason: Ця пропозиція розглядається
           proposal_rejected_reason: 'Ця пропозиція була відхилена, оскільки:'
@@ -373,17 +725,27 @@ uk:
           no_votes_remaining: Не залишилось голосів
           vote: Голосувати
           votes_blocked: Голосування вимкнене
+        vote_weight:
+          maximum_votes_reached: Maximum votes reached
+          no_votes_remaining: No votes remaining
+          votes_blocked: Votes blocked
         votes_count:
           count:
-            one: ГОЛОС
             few: ГОЛОСИ
             many: ГОЛОСІВ
+            one: ГОЛОС
             other: ГОЛОСІВ
           most_popular_proposal: Найпопулярніша пропозиція
           need_more_votes: Потрібно більше голосів
+        votes_weight:
+          count: Count
         voting_rules:
           can_accumulate_supports_beyond_threshold:
             description: Кожну пропозицію можуть підтримувати понад %{limit} людей
+          minimum_votes_per_user:
+            description: You must distribute a minimum of %{votes} votes among different proposals.
+            given_enough_votes: You've given enough supports.
+            supports_remaining: You have to vote %{remaining_votes} more proposals for your votes to be taken into account.
           proposal_limit:
             description: Ви можете висунути до %{limit} пропозицій.
           threshold_per_proposal:
@@ -402,7 +764,7 @@ uk:
           step_2: Порівняти
           step_3: Завершити
           step_4: Оприлюднити свою пропозицію
-          step_of: '%{current_step_num}-й крок з %{total_steps} кроків'
+          step_of: "%{current_step_num}-й крок з %{total_steps} кроків"
       publish:
         error: При спробі оприлюднити цю пропозицію сталися помилки.
         success: Пропозицію успішно оприлюднено.
@@ -412,6 +774,21 @@ uk:
       update_draft:
         error: При спробі збереження чернетки цієї пропозиції сталися помилки.
         success: Чернетку пропозиції успішно оновлено.
+      versions:
+        changes_at_title: Changes at "%{title}"
+        index:
+          title: Versions
+        stats:
+          back_to_collaborative_draft: Go back to collaborative draft
+          back_to_proposal: Go back to proposal
+          number_of_versions: Versions
+          show_all_versions: Show all versions
+          version_author: Version author
+          version_created_at: Version created at
+          version_number: Version number
+          version_number_out_of_total: "%{current_version} out of %{total_count}"
+        version:
+          version_index: Version %{index}
     resource_links:
       copied_from_component:
         proposal_proposal: Супутні пропозиції

--- a/decidim-sortitions/config/locales/fi-pl.yml
+++ b/decidim-sortitions/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -139,7 +140,7 @@ fi-pl:
           random_seed: Satunnainen jako
           selected_proposals:
             one: ehdotus valittu
-            other: '%{count} ehdotusta valittu'
+            other: "%{count} ehdotusta valittu"
           view: Näytä
         sortition_author:
           deleted: Poistettu käyttäjä

--- a/decidim-sortitions/config/locales/id-ID.yml
+++ b/decidim-sortitions/config/locales/id-ID.yml
@@ -1,137 +1,152 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       sortition:
-        additional_info: Informasi penyortiran
-        decidim_category_id: Kategori set proposal tempat Anda ingin menerapkan undian
-        decidim_proposals_component_id: Proposal ditetapkan
-        dice: Hasil die roll. Gulung dadu 6 sisi, atau cari cara acak lain untuk menghasilkan angka dari 1 hingga 6, dan masukkan di sini angka yang dihasilkan di depan beberapa saksi. Ini berkontribusi pada kualitas dan jaminan keacakan hasil
-        target_items: Jumlah proposal yang akan dipilih (menunjukkan jumlah proposal yang ingin Anda pilih dengan menggambar banyak kelompok proposal yang telah Anda pilih sebelumnya)
-        title: Judul
-        witnesses: Saksi
+        additional_info: Sortition information
+        decidim_category_id: Categories of the set of proposals in which you want to apply the draw
+        decidim_proposals_component_id: Proposals set
+        dice: Result of die roll. Roll a 6-sided die, or look for another random way to generate a number from 1 to 6, and enter here the resulting number in front of some witnesses. This contributes to the quality and guarantees of the randomness of the result
+        target_items: Number of proposals to be selected (indicates the number of proposals you want to be selected by drawing lots of the group of proposals you have previously chosen)
+        title: Title
+        witnesses: Witnesses
     models:
-      decidim/sortitions/create_sortition_event: Undian
+      decidim/sortitions/create_sortition_event: Sortition
   activerecord:
     models:
       decidim/sortitions/sortition:
-        other: Sortasi
+        one: Sortition
+        other: Sortitions
   decidim:
     components:
       sortitions:
-        name: Sortasi
+        name: Sortitions
         settings:
           global:
-            comments_enabled: Komentar diaktifkan
+            comments_enabled: Comments enabled
     events:
       sortitions:
         sortition_created:
-          email_intro: Sortasi "%{resource_title}" telah ditambahkan ke "%{participatory_space_title}" yang Anda ikuti.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti "%{participatory_space_title}". Anda dapat berhenti mengikutinya dari tautan sebelumnya.
-          email_subject: Sortasi baru ditambahkan ke %{participatory_space_title}
-          notification_title: Sortasi <a href="%{resource_path}">%{resource_title}</a> telah ditambahkan ke %{participatory_space_title}
+          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New sortition added to %{participatory_space_title}
+          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
     pages:
       home:
         statistics:
-          sortitions_count: Sortasi
+          sortitions_count: Sortitions
     participatory_processes:
       statistics:
-        sortitions_count: Sortasi
+        sortitions_count: Sortitions
     sortitions:
       admin:
         actions:
-          destroy: Batalkan penyortiran
+          destroy: Cancel the sortition
           edit: Edit
-          new: Pemilahan baru
-          show: Detail penyortiran
+          new: New sortition
+          show: Sortition details
         models:
           sortition:
             fields:
-              category: Kategori
-              created_at: Tanggal pembuatan
-              decidim_proposals_component: Komponen proposal
-              dice: Dadu
-              reference: Referensi
-              request_timestamp: Luangkan waktu
-              seed: Benih
-              target_items: Item untuk dipilih
-              title: Judul
+              category: Category
+              created_at: Creation date
+              decidim_proposals_component: Proposals component
+              dice: Dice
+              reference: Reference
+              request_timestamp: Draw time
+              seed: Seed
+              target_items: Items to select
+              title: Title
             name:
-              other: Sortasi
+              one: Sortition
+              other: Sortitions
         sortitions:
           confirm_destroy:
-            confirm_destroy: Apakah Anda yakin ingin membatalkan penyortiran ini?
-            destroy: Batalkan penyortiran
-            title: Pembatalan penyortiran
+            confirm_destroy: Are you sure you want to cancel this sortition?
+            destroy: Cancel sortition
+            title: Cancellation of the sortition
           create:
-            success: Sortasi berhasil dibuat
+            error: There was an error creating a new sortition.
+            success: Sortition successfully created
           destroy:
-            error: Tidak dapat membatalkan penyortiran.
-            success: Penyortiran berhasil dibatalkan
+            error: Can not cancel the sortition.
+            success: Sortition successfully cancelled
           edit:
-            title: Perbarui informasi tentang penyortiran
-            update: Memperbarui
+            title: Update the information about the sortition
+            update: Update
           form:
-            all_categories: Semua Kategori
-            select_proposal_component: Pilih set proposal
-            title: Sortasi baru untuk proposal
+            all_categories: All categories
+            select_proposal_component: Select the proposals set
+            title: New sortition for proposals
           index:
-            title: Sortasi
+            title: Sortitions
           new:
-            confirm: Dengan menekan tombol berikutnya, Decidim akan merekam tanggal dan waktu (dengan ketepatan detik) dan bersama dengan gulungan dadu, informasi ini akan digunakan untuk menghasilkan pilihan acak. Tindakan ini tidak akan dapat dikembalikan, setelah tombol diklik, hasil undian ini akan dipublikasikan, bersama dengan data yang dimasukkan dalam formulir ini dan tidak dapat dimodifikasi, silakan periksa konten dengan cermat
-            create: Membuat
-            title: Pemilahan baru
+            confirm: By pressing the next button Decidim will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
+            create: Create
+            title: New sortition
           show:
-            selected_proposals: Proposal dipilih untuk pengundian
+            selected_proposals: Proposals selected for draw
           update:
-            success: Penyortiran berhasil diperbarui
+            error: There was an error updating the sortition.
+            success: Sortition successfully updated
       admin_log:
         sortition:
-          create: "%{user_name} menciptakan %{resource_name} sortasi dalam %{space_name}"
-          delete: "%{user_name} membatalkan %{resource_name} penyortiran dalam %{space_name}"
-          update: "%{user_name} memperbarui penyortiran %{resource_name} dalam %{space_name}"
+          create: "%{user_name} created the %{resource_name} sortition in %{space_name}"
+          delete: "%{user_name} cancelled the %{resource_name} sortition in %{space_name}"
+          update: "%{user_name} updated the %{resource_name} sortition in %{space_name}"
       sortitions:
         count:
           proposals_count:
-            other: "%{count} proposal"
+            one: 1 proposal
+            other: "%{count} proposals"
         filters:
-          active: Aktif
-          all: Semua
-          cancelled: Dibatalkan
-          category: Kategori
-          category_prompt: Pilih Kategori
-          search: Pencarian
+          active: Active
+          all: All
+          cancelled: Cancelled
+          category: Category
+          category_prompt: Select a category
+          search: Search
+          state: State
         filters_small_view:
-          close_modal: Tutup modal
+          close_modal: Close modal
           filter: Filter
-          filter_by: Saring menurut
-          unfold: Membuka
+          filter_by: Filter by
+          unfold: Unfold
         linked_sortitions:
-          selected_proposals: Usulan yang dipilih
+          selected_proposals: Selected proposals
         orders:
-          label: 'Urutkan penyortiran menurut:'
-          random: Acak
-          recent: Baru
+          label: 'Order sortitions by:'
+          random: Random
+          recent: Recent
         results_count:
           count:
-            other: proposal yang dipilih
+            one: selected proposal
+            other: selected proposals
         show:
-          any_category: dari semua kategori
-          cancelled: Pengurutan yang dibatalkan
-          candidate_proposal_ids: Urutan proposal pengurutan dan ID
-          candidate_proposals_info: 'Penyortiran dilakukan di antara proposal berikut (%{category_label}), dengan ID berikut (dalam huruf tebal proposal yang dipilih)  '
-          category: dari kategori %{category}
-          dice_result: "(1) Hasil dadu"
-          introduction: 'Halaman ini berisi hasil sortasi %{reference}. Melalui penyortiran ini, %{target_items} jumlah hasil telah dipilih secara acak dan dengan distribusi probabilitas yang sama dari sekumpulan proposal yang ditampilkan di bawah. Bersama dengan hasilnya, informasi yang ditampilkan pada halaman ini memberikan semua informasi yang diperlukan untuk memaksimalkan jaminan dan mereproduksi hasil. Kunci kualitas penyortiran ini adalah keacakan ganda yang diberikan oleh pengguliran dadu (diverifikasi oleh saksi) dan waktu penyisihan yang tepat yang memberikan input untuk suatu algoritma yang menghasilkan seleksi acak. Benih waktu untuk penyortiran sangat akurat (detik) sehingga tidak mungkin dikendalikan oleh manusia sehingga memberikan input ganda "tidak terkendali" untuk menjamin hasil yang adil.  '
-          mathematical_result: Hasil (1) x (2)
-          proposals_selected_by_sortition: Proposal dipilih berdasarkan penyortiran
-          sortition_reproducibility_details: Rincian reproduksibilitas penyortiran
-          time_seed: "(2) Benih waktu"
-          witnesses: Saksi
+          algorithm: Sortition's Algorithm code
+          any_category: from all categories
+          cancelled: Cancelled sortition
+          candidate_proposal_ids: Sortition proposals order and IDs
+          candidate_proposals_info: 'The sortition was carried out among the following proposals (%{category_label}), with the following IDs (in bold the selected proposals)  '
+          category: from the %{category} category
+          dice_result: "(1) Dice result"
+          introduction: 'This page contains the results of the sortition %{reference}. By means of this sortition, %{target_items} number of results have been selected randomly and with an equal probability distribution from the set of proposals displayed bellow. Together with the results, the information displayed on this page provides all the information required to maximize guarantees and to reproduce the results. The key to the quality of this sortition is the double randomness provided by a the rolling of a dice(verified by witnesses) and the precise time of the sortition that provides input for an algorithm that generates a random selection. The time-seed for the sortition is so accurate (seconds) that it is impossible to control by humans thus providing a double "uncontrollable" input to guarantee a fair result.  '
+          mathematical_result: Result (1) x (2)
+          proposals_selected_by_sortition: Proposals selected by sortition
+          sortition_reproducibility_details: Sortition reproducibility details
+          time_seed: "(2) Time seed"
+          witnesses: Witnesses
         sortition:
-          random_seed: Benih acak
+          random_seed: Random seed
           selected_proposals:
-            other: proposal yang dipilih
-          view: Melihat
+            one: proposal selected
+            other: proposals selected
+          view: View
+        sortition_author:
+          deleted: Deleted user
+        sortition_cancel_author:
+          deleted: Deleted user
         sortitions_count:
           count:
-            other: "%{count} penyortiran"
+            one: 1 sortition
+            other: "%{count} sortitions"

--- a/decidim-sortitions/config/locales/tr-TR.yml
+++ b/decidim-sortitions/config/locales/tr-TR.yml
@@ -1,14 +1,15 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       sortition:
-        additional_info: Sıralama bilgileri
-        decidim_category_id: Draw'ı uygulamak istediğiniz teklif kümesinin kategorileri
-        decidim_proposals_component_id: Teklifler belirlendi
-        dice: Kalıp rulosunun sonucu. 6 taraflı bir kalıbı yuvarlayın veya 1 ila 6 arasında bir sayı oluşturmak için rastgele bir yol arayın ve sonuçta bazı tanıkların önüne buradaki sayıyı girin. Bu, sonucun rastlantısallığının kalitesine ve garantisine katkıda bulunur.
-        target_items: Seçilecek teklif sayısı (daha önce seçmiş olduğunuz teklif grubunun çoğunu çizerek, seçmek istediğiniz teklif sayısını gösterir)
-        title: Başlık
-        witnesses: Tanıklar
+        additional_info: Sortition information
+        decidim_category_id: Categories of the set of proposals in which you want to apply the draw
+        decidim_proposals_component_id: Proposals set
+        dice: Result of die roll. Roll a 6-sided die, or look for another random way to generate a number from 1 to 6, and enter here the resulting number in front of some witnesses. This contributes to the quality and guarantees of the randomness of the result
+        target_items: Number of proposals to be selected (indicates the number of proposals you want to be selected by drawing lots of the group of proposals you have previously chosen)
+        title: Title
+        witnesses: Witnesses
     models:
       decidim/sortitions/create_sortition_event: Sortition
   activerecord:
@@ -22,14 +23,14 @@ tr:
         name: Sortitions
         settings:
           global:
-            comments_enabled: Yorumlar etkin
+            comments_enabled: Comments enabled
     events:
       sortitions:
         sortition_created:
-          email_intro: Sortition "%{resource_title}" "eklendi%{participatory_space_title}" izlediğinizi.
-          email_outro: Bu bildirimi aldınız çünkü "%{participatory_space_title}" u takip ediyorsun. Bunu önceki linkten takip edebilirsiniz.
-          email_subject: Yeni sortition eklenen %{participatory_space_title}
-          notification_title: <a href="%{resource_path}">%{resource_title}</a> %{participatory_space_title}eklendi
+          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_subject: New sortition added to %{participatory_space_title}
+          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
     pages:
       home:
         statistics:
@@ -40,112 +41,112 @@ tr:
     sortitions:
       admin:
         actions:
-          destroy: Sıralamayı iptal et
-          edit: Düzenle
-          new: Yeni sıralama
-          show: Sıralama detayları
+          destroy: Cancel the sortition
+          edit: Edit
+          new: New sortition
+          show: Sortition details
         models:
           sortition:
             fields:
-              category: Kategori
-              created_at: Oluşturulma tarihi
-              decidim_proposals_component: Teklifler bileşeni
-              dice: Zar
-              reference: Referans
-              request_timestamp: Zaman çekmek
-              seed: Tohum
-              target_items: Seçilecek öğeler
-              title: Başlık
+              category: Category
+              created_at: Creation date
+              decidim_proposals_component: Proposals component
+              dice: Dice
+              reference: Reference
+              request_timestamp: Draw time
+              seed: Seed
+              target_items: Items to select
+              title: Title
             name:
               one: Sortition
               other: Sortitions
         sortitions:
           confirm_destroy:
-            confirm_destroy: Bu sıralamayı iptal etmek istediğinize emin misiniz?
-            destroy: Sıralamayı iptal et
-            title: Sıralamanın iptali
+            confirm_destroy: Are you sure you want to cancel this sortition?
+            destroy: Cancel sortition
+            title: Cancellation of the sortition
           create:
-            error: Yeni bir sıralama oluşturulurken bir hata oluştu.
-            success: Sıralama başarıyla oluşturuldu
+            error: There was an error creating a new sortition.
+            success: Sortition successfully created
           destroy:
-            error: Sıralama iptal edilemez.
-            success: Sıralama başarıyla iptal edildi
+            error: Can not cancel the sortition.
+            success: Sortition successfully cancelled
           edit:
-            title: Sıralama hakkındaki bilgileri güncelleyin
-            update: Güncelleştirme
+            title: Update the information about the sortition
+            update: Update
           form:
-            all_categories: Tüm Kategoriler
-            select_proposal_component: Belirlenen teklifleri seçin
-            title: Teklifler için yeni sıralama
+            all_categories: All categories
+            select_proposal_component: Select the proposals set
+            title: New sortition for proposals
           index:
             title: Sortitions
           new:
-            confirm: Bir sonraki düğmeye basıldığında Decidim, tarih ve saati (saniyenin kesinliği ile) kaydedecek ve zar rulosuyla birlikte, bu bilgi rastgele bir seçim oluşturmak için kullanılacak. İşlem geri alınamaz, düğme tıklandıktan sonra bu çekilişin sonucu yayınlanacak, bu forma girilen verilerle birlikte değiştirilemez, lütfen içeriği dikkatlice kontrol edin
-            create: yaratmak
-            title: Yeni sıralama
+            confirm: By pressing the next button Decidim will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
+            create: Create
+            title: New sortition
           show:
-            selected_proposals: Çizim için seçilen teklifler
+            selected_proposals: Proposals selected for draw
           update:
-            error: Sıralama güncellenirken bir hata oluştu.
-            success: Sıralama başarıyla güncellendi
+            error: There was an error updating the sortition.
+            success: Sortition successfully updated
       admin_log:
         sortition:
-          create: "%{user_name} , %{space_name}%{resource_name} sıralamayı yarattı"
-          delete: "%{user_name} , %{space_name}%{resource_name} sıralamayı iptal etti"
-          update: "%{user_name} updated %{resource_name} de sortition %{space_name}"
+          create: "%{user_name} created the %{resource_name} sortition in %{space_name}"
+          delete: "%{user_name} cancelled the %{resource_name} sortition in %{space_name}"
+          update: "%{user_name} updated the %{resource_name} sortition in %{space_name}"
       sortitions:
         count:
           proposals_count:
-            one: 1 teklif
-            other: "%{count} teklif"
+            one: 1 proposal
+            other: "%{count} proposals"
         filters:
-          active: Aktif
-          all: Herşey
-          cancelled: İptal edildi
-          category: Kategori
-          category_prompt: bir kategori seç
-          search: Arama
-          state: Durum
+          active: Active
+          all: All
+          cancelled: Cancelled
+          category: Category
+          category_prompt: Select a category
+          search: Search
+          state: State
         filters_small_view:
-          close_modal: Kalıcı modal
-          filter: filtre
-          filter_by: Tarafından filtre
-          unfold: açılmak
+          close_modal: Close modal
+          filter: Filter
+          filter_by: Filter by
+          unfold: Unfold
         linked_sortitions:
-          selected_proposals: Seçili teklifler
+          selected_proposals: Selected proposals
         orders:
-          label: 'Sıralama sıralamaları:'
-          random: rasgele
-          recent: Son
+          label: 'Order sortitions by:'
+          random: Random
+          recent: Recent
         results_count:
           count:
-            one: seçilen teklif
-            other: seçilen teklifler
+            one: selected proposal
+            other: selected proposals
         show:
-          algorithm: Sıralamanın Algoritma kodu
-          any_category: tüm kategorilerden
-          cancelled: İptal edilen sıralama
-          candidate_proposal_ids: Sıralama teklifleri siparişi ve kimlikleri
-          candidate_proposals_info: 'Sıralama, aşağıdaki teklifler arasında (%{category_label}), aşağıdaki kimliklerle (seçilen tekliflerin kalın harflerle belirtildiği şekilde) yapıldı.  '
-          category: '%{category} kategoriden'
-          dice_result: "(1) Zar sonucu"
-          introduction: 'Bu sayfa, %{reference}sıralamasının sonuçlarını içerir. Bu sıralama yoluyla, %{target_items} sonuç, rastgele ve aşağıda gösterilen teklif grubundan eşit olasılık dağılımına sahip olarak seçilmiştir. Sonuçlarla birlikte, bu sayfada görüntülenen bilgiler garantileri en üst düzeye çıkarmak ve sonuçları çoğaltmak için gereken tüm bilgileri sağlar. Bu sıralamanın kalitesinin anahtarı, bir zarın (tanıkların doğruladığı) yuvarlanmasıyla sağlanan çift rastgele ve rastgele bir seçim üreten bir algoritma için girdi sağlayan sıralamanın tam zamanıdır. Sıralama için gereken zaman aralığı o kadar hassastır ki (saniye) insanlar tarafından kontrol edilmesi imkansızdır, bu nedenle adil bir sonuç elde etmek için çift "kontrol edilemez" bir giriş sağlar.  '
-          mathematical_result: Sonuç (1) x (2)
-          proposals_selected_by_sortition: Sıralamaya göre seçilen teklifler
-          sortition_reproducibility_details: Sıralama tekrarlanabilirliği ayrıntıları
-          time_seed: "(2) Zaman tohumu"
-          witnesses: Tanıklar
+          algorithm: Sortition's Algorithm code
+          any_category: from all categories
+          cancelled: Cancelled sortition
+          candidate_proposal_ids: Sortition proposals order and IDs
+          candidate_proposals_info: 'The sortition was carried out among the following proposals (%{category_label}), with the following IDs (in bold the selected proposals)  '
+          category: from the %{category} category
+          dice_result: "(1) Dice result"
+          introduction: 'This page contains the results of the sortition %{reference}. By means of this sortition, %{target_items} number of results have been selected randomly and with an equal probability distribution from the set of proposals displayed bellow. Together with the results, the information displayed on this page provides all the information required to maximize guarantees and to reproduce the results. The key to the quality of this sortition is the double randomness provided by a the rolling of a dice(verified by witnesses) and the precise time of the sortition that provides input for an algorithm that generates a random selection. The time-seed for the sortition is so accurate (seconds) that it is impossible to control by humans thus providing a double "uncontrollable" input to guarantee a fair result.  '
+          mathematical_result: Result (1) x (2)
+          proposals_selected_by_sortition: Proposals selected by sortition
+          sortition_reproducibility_details: Sortition reproducibility details
+          time_seed: "(2) Time seed"
+          witnesses: Witnesses
         sortition:
-          random_seed: Rastgele tohum
+          random_seed: Random seed
           selected_proposals:
-            one: teklif seçildi
-            other: teklif seçildi
-          view: Görünüm
+            one: proposal selected
+            other: proposals selected
+          view: View
         sortition_author:
-          deleted: Silinmiş kullanıcı
+          deleted: Deleted user
         sortition_cancel_author:
-          deleted: Silinmiş kullanıcı
+          deleted: Deleted user
         sortitions_count:
           count:
-            one: 1 sıralama
-            other: "%{count} sıralama"
+            one: 1 sortition
+            other: "%{count} sortitions"

--- a/decidim-surveys/config/locales/fi-pl.yml
+++ b/decidim-surveys/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     models:

--- a/decidim-surveys/config/locales/id-ID.yml
+++ b/decidim-surveys/config/locales/id-ID.yml
@@ -1,42 +1,57 @@
-id:
+---
+id-ID:
   activemodel:
     models:
-      decidim/surveys/closed_survey_event: Survei berakhir
-      decidim/surveys/opened_survey_event: Survei dimulai
+      decidim/surveys/closed_survey_event: Survey ended
+      decidim/surveys/opened_survey_event: Survey started
   activerecord:
     models:
       decidim/surveys/survey:
-        other: Survei
+        one: Survey
+        other: Surveys
       decidim/surveys/survey_answer:
-        other: Jawaban
+        one: Answer
+        other: Answers
   decidim:
     components:
       surveys:
         actions:
-          answer: Menjawab
-        name: Survei
+          answer: Answer
+        name: Survey
         settings:
           global:
-            announcement: Pengumuman
+            announcement: Announcement
           step:
-            allow_answers: Izinkan jawaban
-            announcement: Pengumuman
+            allow_answers: Allow answers
+            announcement: Announcement
     events:
       surveys:
         survey_closed:
-          email_intro: Survei %{resource_title} in %{participatory_space_title} telah ditutup.
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Survei selesai pada %{participatory_space_title}
-          notification_title: Survei <a href="%{resource_path}">%{resource_title}</a> di <a href="%{participatory_space_url}">%{participatory_space_title}</a> telah selesai.
+          email_intro: The survey %{resource_title} in %{participatory_space_title} has been closed.
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A survey has finished in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> has finished.
         survey_opened:
-          email_intro: 'Survei %{resource_title} in %{participatory_space_title} sekarang terbuka. Anda dapat berpartisipasi di dalamnya dari halaman ini:'
-          email_outro: Anda telah menerima pemberitahuan ini karena Anda mengikuti %{participatory_space_title}. Anda dapat berhenti menerima pemberitahuan setelah tautan sebelumnya.
-          email_subject: Survei baru di %{participatory_space_title}
-          notification_title: Survei <a href="%{resource_path}">%{resource_title}</a> di <a href="%{participatory_space_url}">%{participatory_space_title}</a> sekarang terbuka.
+          email_intro: 'The survey %{resource_title} in %{participatory_space_title} is now open. You can participate in it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A new survey in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> is now open.
     metrics:
       survey_answers:
-        object: jawaban untuk survei
-        title: Jawaban untuk survei
+        description: Number of surveys answered by users
+        object: answers to surveys
+        title: Answers to surveys
     surveys:
+      admin:
+        exports:
+          survey_user_answers: Survey user answers
+        surveys:
+          update:
+            invalid: There's been errors when saving the survey.
+            success: Survey saved successfully.
       last_activity:
-        new_survey_at_html: "<span>Survei baru di %{link}</span>"
+        new_survey_at_html: "<span>New survey at %{link}</span>"
+      surveys:
+        answer:
+          invalid: There's been errors when answering the survey.
+          success: Survey answered successfully.

--- a/decidim-surveys/config/locales/tr-TR.yml
+++ b/decidim-surveys/config/locales/tr-TR.yml
@@ -1,56 +1,57 @@
-tr:
+---
+tr-TR:
   activemodel:
     models:
-      decidim/surveys/closed_survey_event: Anket sona erdi
-      decidim/surveys/opened_survey_event: Anket başladı
+      decidim/surveys/closed_survey_event: Survey ended
+      decidim/surveys/opened_survey_event: Survey started
   activerecord:
     models:
       decidim/surveys/survey:
-        one: anket
-        other: Anketler
+        one: Survey
+        other: Surveys
       decidim/surveys/survey_answer:
-        one: Cevap
-        other: Cevaplar
+        one: Answer
+        other: Answers
   decidim:
     components:
       surveys:
         actions:
-          answer: Cevap
-        name: anket
+          answer: Answer
+        name: Survey
         settings:
           global:
-            announcement: duyuru
+            announcement: Announcement
           step:
-            allow_answers: Cevaplara izin ver
-            announcement: duyuru
+            allow_answers: Allow answers
+            announcement: Announcement
     events:
       surveys:
         survey_closed:
-          email_intro: Anket %{resource_title} %{participatory_space_title} kapatıldı.
-          email_outro: '%{participatory_space_title}takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-          email_subject: Bir anket %{participatory_space_title}bitti
-          notification_title: Anket <a href="%{resource_path}">%{resource_title}</a> <a href="%{participatory_space_url}">%{participatory_space_title}</a> bitti.
+          email_intro: The survey %{resource_title} in %{participatory_space_title} has been closed.
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A survey has finished in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> has finished.
         survey_opened:
-          email_intro: 'Anket %{resource_title} %{participatory_space_title} açık. Bu sayfadan katılabilirsiniz:'
-          email_outro: '%{participatory_space_title}takip ettiğiniz için bu bildirimi aldınız. Önceki bağlantıyı takip ederek bildirim almayı durdurabilirsiniz.'
-          email_subject: '%{participatory_space_title}yeni bir anket'
-          notification_title: Anket <a href="%{resource_path}">%{resource_title}</a> <a href="%{participatory_space_url}">%{participatory_space_title}</a> açıktır.
+          email_intro: 'The survey %{resource_title} in %{participatory_space_title} is now open. You can participate in it from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_subject: A new survey in %{participatory_space_title}
+          notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> is now open.
     metrics:
       survey_answers:
-        description: Kullanıcılar tarafından yanıtlanan anket sayısı
-        object: anketlerin cevapları
-        title: Anketlere verilen cevaplar
+        description: Number of surveys answered by users
+        object: answers to surveys
+        title: Answers to surveys
     surveys:
       admin:
         exports:
-          survey_user_answers: Kullanıcı anket cevapları
+          survey_user_answers: Survey user answers
         surveys:
           update:
-            invalid: Anketi kaydederken hatalar oluştu.
-            success: Anket başarıyla kaydedildi.
+            invalid: There's been errors when saving the survey.
+            success: Survey saved successfully.
       last_activity:
-        new_survey_at_html: "<span> %{link}</span>yeni anket"
+        new_survey_at_html: "<span>New survey at %{link}</span>"
       surveys:
         answer:
-          invalid: Anketi cevaplarken hatalar oldu.
-          success: Anket başarıyla yanıtlandı.
+          invalid: There's been errors when answering the survey.
+          success: Survey answered successfully.

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -56,7 +56,7 @@ module Decidim
           badges_enabled: true,
           user_groups_enabled: true,
           default_locale: form.default_locale,
-          smtp_settings: form.encrypted_smtp_settings,
+          smtp_settings: form.set_smtp_settings,
           send_welcome_notification: true
         )
       end

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -56,6 +56,7 @@ module Decidim
           badges_enabled: true,
           user_groups_enabled: true,
           default_locale: form.default_locale,
+          smtp_settings: form.encrypted_smtp_settings,
           send_welcome_notification: true
         )
       end

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -46,6 +46,7 @@ module Decidim
         organization.secondary_hosts = form.clean_secondary_hosts
         organization.available_authorizations = form.clean_available_authorizations
         organization.users_registration_mode = form.users_registration_mode
+        organization.smtp_settings = form.encrypted_smtp_settings
 
         organization.save!
       end

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -46,7 +46,7 @@ module Decidim
         organization.secondary_hosts = form.clean_secondary_hosts
         organization.available_authorizations = form.clean_available_authorizations
         organization.users_registration_mode = form.users_registration_mode
-        organization.smtp_settings = form.encrypted_smtp_settings
+        organization.smtp_settings = form.set_smtp_settings
 
         organization.save!
       end

--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -7,6 +7,7 @@ module Decidim
     # A form object used to create organizations from the system dashboard.
     #
     class RegisterOrganizationForm < UpdateOrganizationForm
+      include JsonbAttributes
       mimic :organization
 
       attribute :organization_admin_email, String

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -19,6 +19,8 @@ module Decidim
       attribute :users_registration_mode, String
       jsonb_attribute :smtp_settings, [
         [:from, String],
+        [:from_email, String],
+        [:from_label, String],
         [:user_name, String],
         [:encrypted_password, String],
         [:address, String],
@@ -55,6 +57,19 @@ module Decidim
 
       def encrypted_smtp_settings
         smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(@password))
+      end
+
+      def set_from
+        if smtp_settings[:from_label].blank?
+          smtp_settings.merge(from: "#{smtp_settings[:from_email]} <#{smtp_settings[:from_email]}>")
+        else
+          smtp_settings.merge(from: "#{smtp_settings[:from_label]} <#{smtp_settings[:from_email]}>")
+        end
+      end
+
+      def set_smtp_settings
+        encrypted_smtp_settings
+        set_from
       end
 
       private

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -8,6 +8,7 @@ module Decidim
     #
     class UpdateOrganizationForm < Form
       include TranslatableAttributes
+      include JsonbAttributes
 
       mimic :organization
 
@@ -16,6 +17,17 @@ module Decidim
       attribute :secondary_hosts, String
       attribute :available_authorizations, Array[String]
       attribute :users_registration_mode, String
+      jsonb_attribute :smtp_settings, [
+        [:from, String],
+        [:user_name, String],
+        [:encrypted_password, String],
+        [:address, String],
+        [:port, Integer],
+        [:authentication, String],
+        [:enable_starttls_auto, Boolean]
+      ]
+
+      attr_writer :password
 
       validates :name, :host, :users_registration_mode, presence: true
       validate :validate_organization_uniqueness
@@ -35,6 +47,14 @@ module Decidim
         return unless available_authorizations
 
         available_authorizations.select(&:present?)
+      end
+
+      def password
+        Decidim::AttributeEncryptor.decrypt(encrypted_password) unless encrypted_password.nil?
+      end
+
+      def encrypted_smtp_settings
+        smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(@password))
       end
 
       private

--- a/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
@@ -1,0 +1,20 @@
+<div class="fieldset">
+  <h4><%= t("decidim.system.models.organization.fields.smtp_settings") %></h4>
+  <%= f.fields_for :smtp_settings do %>
+    <div class="field">
+      <%= f.email_field :from %>
+    </div>
+    <div class="field">
+      <%= f.text_field :user_name %>
+    </div>
+    <div class="field">
+      <%= f.text_field :password %>
+    </div>
+    <div class="field">
+      <%= f.text_field :address %>
+    </div>
+    <div class="field">
+      <%= f.number_field :port %>
+    </div>
+  <% end %>
+</div>

--- a/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb
@@ -2,19 +2,22 @@
   <h4><%= t("decidim.system.models.organization.fields.smtp_settings") %></h4>
   <%= f.fields_for :smtp_settings do %>
     <div class="field">
-      <%= f.email_field :from %>
+      <%= f.email_field :from_label, placeholder: t(".from_label", scope: "instructions") %>
     </div>
     <div class="field">
-      <%= f.text_field :user_name %>
+      <%= f.email_field :from_email, placeholder: t(".from_email", scope: "instructions") %>
     </div>
     <div class="field">
-      <%= f.text_field :password %>
+      <%= f.text_field :user_name, placeholder: t(".user_name", scope: "instructions") %>
     </div>
     <div class="field">
-      <%= f.text_field :address %>
+      <%= f.text_field :password, placeholder: t(".password", scope: "instructions") %>
     </div>
     <div class="field">
-      <%= f.number_field :port %>
+      <%= f.text_field :address, placeholder: t(".address", scope: "instructions") %>
+    </div>
+    <div class="field">
+      <%= f.number_field :port, placeholder: t(".port", scope: "instructions") %>
     </div>
   <% end %>
 </div>

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -25,6 +25,8 @@
     <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_workflows, :name, :description %>
   </div>
 
+  <%= render partial: "smtp_settings", locals: { f: f } %>
+
   <div class="actions">
     <%= f.submit t("decidim.system.actions.save") %>
   </div>

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -66,6 +66,8 @@
     <%= f.collection_check_boxes :available_authorizations, Decidim.authorization_workflows, :name, :description %>
   </div>
 
+  <%= render partial: "smtp_settings", locals: { f: f } %>
+
   <div class="actions">
     <%= f.submit t("decidim.system.models.organization.actions.save_and_invite") %>
   </div>

--- a/decidim-system/config/locales/ca.yml
+++ b/decidim-system/config/locales/ca.yml
@@ -48,6 +48,7 @@ ca:
           fields:
             created_at: Data de creació
             name: Nom
+            smtp_settings: SMTP settings
           name: Organització
       organizations:
         create:

--- a/decidim-system/config/locales/de.yml
+++ b/decidim-system/config/locales/de.yml
@@ -48,6 +48,7 @@ de:
           fields:
             created_at: Hergestellt in
             name: Name
+            smtp_settings: SMTP settings
           name: Organisation
       organizations:
         create:

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
           fields:
             created_at: Created at
             name: Name
+            smtp_settings: SMTP settings
           name: Organization
       organizations:
         create:

--- a/decidim-system/config/locales/es-PY.yml
+++ b/decidim-system/config/locales/es-PY.yml
@@ -48,6 +48,7 @@ es-PY:
           fields:
             created_at: Fecha de creación
             name: Nombre
+            smtp_settings: SMTP settings
           name: Organización
       organizations:
         create:

--- a/decidim-system/config/locales/es.yml
+++ b/decidim-system/config/locales/es.yml
@@ -48,6 +48,7 @@ es:
           fields:
             created_at: Fecha de creación
             name: Nombre
+            smtp_settings: SMTP settings
           name: Organización
       organizations:
         create:

--- a/decidim-system/config/locales/eu.yml
+++ b/decidim-system/config/locales/eu.yml
@@ -48,6 +48,7 @@ eu:
           fields:
             created_at: Tan sortua
             name: Izena
+            smtp_settings: SMTP settings
           name: Erakundea
       organizations:
         create:

--- a/decidim-system/config/locales/fi-pl.yml
+++ b/decidim-system/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   decidim:
     system:
@@ -47,6 +48,7 @@ fi-pl:
           fields:
             created_at: Luotu
             name: Nimi
+            smtp_settings: SMTP settings
           name: Organisaatio
       organizations:
         create:

--- a/decidim-system/config/locales/fi.yml
+++ b/decidim-system/config/locales/fi.yml
@@ -48,6 +48,7 @@ fi:
           fields:
             created_at: Luotu
             name: Nimi
+            smtp_settings: SMTP settings
           name: Organisaatio
       organizations:
         create:

--- a/decidim-system/config/locales/fr.yml
+++ b/decidim-system/config/locales/fr.yml
@@ -48,6 +48,7 @@ fr:
           fields:
             created_at: Créé le
             name: Nom
+            smtp_settings: SMTP settings
           name: Organisation
       organizations:
         create:

--- a/decidim-system/config/locales/gl.yml
+++ b/decidim-system/config/locales/gl.yml
@@ -48,6 +48,7 @@ gl:
           fields:
             created_at: Creado en
             name: Nome
+            smtp_settings: SMTP settings
           name: Organización
       organizations:
         create:

--- a/decidim-system/config/locales/hu.yml
+++ b/decidim-system/config/locales/hu.yml
@@ -48,6 +48,7 @@ hu:
           fields:
             created_at: 'Létrehozva:'
             name: Név
+            smtp_settings: SMTP settings
           name: Szervezet
       organizations:
         create:

--- a/decidim-system/config/locales/id-ID.yml
+++ b/decidim-system/config/locales/id-ID.yml
@@ -1,60 +1,77 @@
-id:
+---
+id-ID:
   decidim:
     system:
       actions:
-        confirm_destroy: apa kamu yakin ingin menghapus ini?
-        destroy: Menghapus
+        confirm_destroy: Are you sure you want to delete this?
+        destroy: Delete
         edit: Edit
-        new: Baru
-        save: Menyimpan
-        title: Tindakan
+        new: New
+        save: Save
+        title: Actions
       admins:
+        create:
+          error: There was an error when creating a new admin.
+          success: Admin created successfully
         destroy:
-          success: Admin berhasil dihapus
+          success: Admin successfully deleted
         edit:
           title: Edit admin
-          update: Memperbarui
+          update: Update
         index:
-          title: Admin
+          title: Admins
         new:
-          create: Membuat
-          title: Admin baru
+          create: Create
+          title: New admin
+        update:
+          error: There was an error when updating this admin.
+          success: Admin updated successfully
       default_pages:
         placeholders:
-          content: Silakan tambahkan konten yang bermakna ke %{page} halaman statis di dasbor admin.
-          title: Judul default untuk %{page}
+          content: Please add meaningful content to the %{page} static page on the admin dashboard.
+          title: Default title for %{page}
       menu:
-        admins: Admin
-        dashboard: Dasbor
-        organizations: Organisasi
+        admins: Admins
+        dashboard: Dashboard
+        organizations: Organizations
       models:
         admin:
           fields:
-            created_at: Dibuat di
-            email: E-mail
+            created_at: Created at
+            email: Email
           name: Admin
           validations:
-            email_uniqueness: admin lain dengan email yang sama sudah ada
+            email_uniqueness: another admin with the same email already exists
         organization:
           actions:
-            save_and_invite: Buat organisasi & undang admin
+            save_and_invite: Create organization & invite admin
           fields:
-            created_at: Dibuat di
-            name: Nama
-          name: Organisasi
+            created_at: Created at
+            name: Name
+            smtp_settings: SMTP settings
+          name: Organization
       organizations:
+        create:
+          error: There was an error when creating a new organization.
+          success: Organization created successfully.
         edit:
-          secondary_hosts_hint: Masukkan masing-masing dari mereka di baris baru
+          secondary_hosts_hint: Enter each one of them in a new line
         index:
-          title: Organisasi
+          title: Organizations
         new:
-          secondary_hosts_hint: Masukkan masing-masing dari mereka di baris baru
-          title: Organisasi baru
+          reference_prefix_hint: The reference prefix is used to uniquely identify resources across all organizations
+          secondary_hosts_hint: Enter each one of them in a new line
+          title: New organization
+        update:
+          error: There was an error when updating this organization.
+          success: Organization updated successfully.
         users_registration_mode:
-          disabled: Akses hanya dapat dilakukan dengan akun eksternal
+          disabled: Access only can be done with external accounts
+          enabled: Allow users to register and login
+          existing: Don't allow users to register, but allow existing users to login
       shared:
         notices:
-          no_organization_warning_html: Anda harus membuat organisasi untuk memulai. Pastikan Anda membaca %{guide} sebelum melanjutkan.
-          our_getting_started_guide: panduan memulai kami
+          no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.
+          our_getting_started_guide: our getting started guide
       titles:
-        dashboard: Dasbor
+        dashboard: Dashboard

--- a/decidim-system/config/locales/it.yml
+++ b/decidim-system/config/locales/it.yml
@@ -48,6 +48,7 @@ it:
           fields:
             created_at: Data/ora di creazione
             name: Nome
+            smtp_settings: SMTP settings
           name: Organizzazione
       organizations:
         create:

--- a/decidim-system/config/locales/nl.yml
+++ b/decidim-system/config/locales/nl.yml
@@ -48,6 +48,7 @@ nl:
           fields:
             created_at: Gemaakt bij
             name: Naam
+            smtp_settings: SMTP settings
           name: Organisatie
       organizations:
         create:

--- a/decidim-system/config/locales/pl.yml
+++ b/decidim-system/config/locales/pl.yml
@@ -48,6 +48,7 @@ pl:
           fields:
             created_at: Utworzono w
             name: Nazwa
+            smtp_settings: SMTP settings
           name: Organizacja
       organizations:
         create:

--- a/decidim-system/config/locales/pt-BR.yml
+++ b/decidim-system/config/locales/pt-BR.yml
@@ -48,6 +48,7 @@ pt-BR:
           fields:
             created_at: Criado em
             name: Nome
+            smtp_settings: SMTP settings
           name: Organização
       organizations:
         create:

--- a/decidim-system/config/locales/pt.yml
+++ b/decidim-system/config/locales/pt.yml
@@ -48,6 +48,7 @@ pt:
           fields:
             created_at: Criado em
             name: Nome
+            smtp_settings: SMTP settings
           name: Organização
       organizations:
         create:

--- a/decidim-system/config/locales/ru.yml
+++ b/decidim-system/config/locales/ru.yml
@@ -48,6 +48,7 @@ ru:
           fields:
             created_at: 'Добавлено:'
             name: Имя
+            smtp_settings: SMTP settings
           name: Организация
       organizations:
         create:

--- a/decidim-system/config/locales/sv.yml
+++ b/decidim-system/config/locales/sv.yml
@@ -48,6 +48,7 @@ sv:
           fields:
             created_at: Skapad vid
             name: Namn
+            smtp_settings: SMTP settings
           name: Organisation
       organizations:
         create:

--- a/decidim-system/config/locales/tr-TR.yml
+++ b/decidim-system/config/locales/tr-TR.yml
@@ -1,75 +1,77 @@
-tr:
+---
+tr-TR:
   decidim:
     system:
       actions:
-        confirm_destroy: Bunu silmek istediğinizden emin misiniz?
-        destroy: silmek
-        edit: Düzenle
-        new: Yeni
-        save: Kayıt etmek
-        title: Eylemler
+        confirm_destroy: Are you sure you want to delete this?
+        destroy: Delete
+        edit: Edit
+        new: New
+        save: Save
+        title: Actions
       admins:
         create:
-          error: Yeni bir yönetici oluşturulurken bir hata oluştu.
-          success: Yönetici başarıyla oluşturuldu
+          error: There was an error when creating a new admin.
+          success: Admin created successfully
         destroy:
-          success: Yönetici başarıyla silindi
+          success: Admin successfully deleted
         edit:
-          title: Yönetici düzenle
-          update: Güncelleştirme
+          title: Edit admin
+          update: Update
         index:
-          title: Yöneticiler
+          title: Admins
         new:
-          create: yaratmak
-          title: Yeni yönetici
+          create: Create
+          title: New admin
         update:
-          error: Bu yönetici güncellenirken bir hata oluştu.
-          success: Yönetici başarıyla güncellendi
+          error: There was an error when updating this admin.
+          success: Admin updated successfully
       default_pages:
         placeholders:
-          content: Lütfen yönetici panosundaki %{page} statik sayfaya anlamlı içerik ekleyin.
-          title: '%{page}için varsayılan başlık'
+          content: Please add meaningful content to the %{page} static page on the admin dashboard.
+          title: Default title for %{page}
       menu:
-        admins: Yöneticiler
-        dashboard: gösterge paneli
-        organizations: Organizasyonlar
+        admins: Admins
+        dashboard: Dashboard
+        organizations: Organizations
       models:
         admin:
           fields:
-            created_at: Adresinde düzenlendi
-            email: E-posta
-          name: yönetim
+            created_at: Created at
+            email: Email
+          name: Admin
           validations:
-            email_uniqueness: aynı e-postaya sahip başka bir yönetici zaten var
+            email_uniqueness: another admin with the same email already exists
         organization:
           actions:
-            save_and_invite: Kuruluş oluşturun ve yöneticiyi davet edin
+            save_and_invite: Create organization & invite admin
           fields:
-            created_at: Adresinde düzenlendi
-            name: isim
-          name: organizasyon
+            created_at: Created at
+            name: Name
+            smtp_settings: SMTP settings
+          name: Organization
       organizations:
         create:
-          error: Yeni bir organizasyon oluşturulurken bir hata oluştu.
-          success: Organizasyon başarıyla oluşturuldu
+          error: There was an error when creating a new organization.
+          success: Organization created successfully.
         edit:
-          secondary_hosts_hint: Her birini yeni bir satıra girin
+          secondary_hosts_hint: Enter each one of them in a new line
         index:
-          title: Organizasyonlar
+          title: Organizations
         new:
-          reference_prefix_hint: Referans öneki, tüm organizasyonlardaki kaynakları benzersiz şekilde tanımlamak için kullanılır
-          secondary_hosts_hint: Her birini yeni bir satıra girin
-          title: Yeni organizasyon
+          reference_prefix_hint: The reference prefix is used to uniquely identify resources across all organizations
+          secondary_hosts_hint: Enter each one of them in a new line
+          title: New organization
         update:
-          error: Bu organizasyon güncellenirken bir hata oluştu.
-          success: Organizasyon başarıyla güncellendi.
+          error: There was an error when updating this organization.
+          success: Organization updated successfully.
         users_registration_mode:
-          disabled: Erişim yalnızca harici hesaplarla yapılabilir
-          enabled: Kullanıcıların kaydolmasına ve giriş yapmasına izin ver
-          existing: Kullanıcıların kaydolmasına izin verme, ancak mevcut kullanıcıların giriş yapmasına izin ver
+          disabled: Access only can be done with external accounts
+          enabled: Allow users to register and login
+          existing: Don't allow users to register, but allow existing users to login
       shared:
         notices:
-          no_organization_warning_html: Başlamak için bir organizasyon oluşturmanız gerekir. Devam etmeden önce %{guide} okuduğunuzdan emin olun.
-          our_getting_started_guide: başlangıç kılavuzumuz
+          no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.
+          our_getting_started_guide: our getting started guide
       titles:
-        dashboard: gösterge paneli
+        dashboard: Dashboard

--- a/decidim-system/config/locales/uk.yml
+++ b/decidim-system/config/locales/uk.yml
@@ -48,6 +48,7 @@ uk:
           fields:
             created_at: 'Додано:'
             name: Ім'я
+            smtp_settings: SMTP settings
           name: Організація
       organizations:
         create:

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -23,7 +23,14 @@ module Decidim
               organization_admin_email: "f.laguardia@gotham.gov",
               available_locales: ["en"],
               default_locale: "en",
-              users_registration_mode: "enabled"
+              users_registration_mode: "enabled",
+              smtp_settings: {
+                "address" => "mail.gotham.gov",
+                "port" => "25",
+                "user_name" => "f.laguardia",
+                "password" => Decidim::AttributeEncryptor.encrypt("password"),
+                "from" => "decide@gotham.gov"
+              }
             }
           end
 

--- a/decidim-verifications/config/locales/ca.yml
+++ b/decidim-verifications/config/locales/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ ca:
       admin:
         id_documents:
           help:
-            - Els usuaris omplen la informació de la seva identitat i carreguen una còpia del seu document.
-            - Emplenes la informació que es mostra a la imatge penjada.
-            - La informació ha de coincidir amb el que hagi omplert l'usuari.
-            - Si no pots veure la informació amb claredat o no la pots verificar, pots rebutjar la sol·licitud i l'usuari la podrà solucionar.
+          - Els usuaris omplen la informació de la seva identitat i carreguen una còpia del seu document.
+          - Emplenes la informació que es mostra a la imatge penjada.
+          - La informació ha de coincidir amb el que hagi omplert l'usuari.
+          - Si no pots veure la informació amb claredat o no la pots verificar, pots rebutjar la sol·licitud i l'usuari la podrà solucionar.
         postal_letter:
           help:
-            - Els usuaris sol·liciten un codi de verificació que s'enviarà a la seva adreça.
-            - Envies la carta a la seva adreça amb el codi de verificació.
-            - Marques la carta com a enviada.
-            - Una vegada la carta està marcada com a enviada, l'usuari podrà introduir el codi i verificar-se.
+          - Els usuaris sol·liciten un codi de verificació que s'enviarà a la seva adreça.
+          - Envies la carta a la seva adreça amb el codi de verificació.
+          - Marques la carta com a enviada.
+          - Una vegada la carta està marcada com a enviada, l'usuari podrà introduir el codi i verificar-se.
       direct: Directe
       help: Ajuda
       id_documents:
@@ -116,7 +117,7 @@ ca:
               success: S'ha rebutjat la verificació. Es demanarà a l'usuari que modifiqui els seus documents
         authorizations:
           choose:
-            choose_a_type: "Si us plau selecciona com et vols verificar:"
+            choose_a_type: 'Si us plau selecciona com et vols verificar:'
             offline: Presencial
             online: Online
             title: Verifica't utilitzant el teu document d'identitat

--- a/decidim-verifications/config/locales/de.yml
+++ b/decidim-verifications/config/locales/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ de:
       admin:
         id_documents:
           help:
-            - Benutzer geben ihre Identitätsinformationen ein und laden eine Kopie ihres Dokuments hoch.
-            - Sie geben die Informationen ein, die im hochgeladenen Bild vorhanden sind.
-            - Die Informationen sollten mit denen übereinstimmen, die der Benutzer ausgefüllt hat.
-            - Wenn Sie die Informationen nicht klar sehen können oder nicht verifiziert werden können, können Sie die Anfrage ablehnen und der Benutzer kann sie beheben.
+          - Benutzer geben ihre Identitätsinformationen ein und laden eine Kopie ihres Dokuments hoch.
+          - Sie geben die Informationen ein, die im hochgeladenen Bild vorhanden sind.
+          - Die Informationen sollten mit denen übereinstimmen, die der Benutzer ausgefüllt hat.
+          - Wenn Sie die Informationen nicht klar sehen können oder nicht verifiziert werden können, können Sie die Anfrage ablehnen und der Benutzer kann sie beheben.
         postal_letter:
           help:
-            - Benutzer fordern einen Bestätigungscode an, der an ihre Adresse gesendet werden soll.
-            - Sie senden den Brief mit dem Bestätigungscode an seine Adresse.
-            - Sie markieren den Brief als gesendet.
-            - Sobald Sie den Brief als gesendet markiert haben, kann der Benutzer den Code einführen und verifiziert werden.
+          - Benutzer fordern einen Bestätigungscode an, der an ihre Adresse gesendet werden soll.
+          - Sie senden den Brief mit dem Bestätigungscode an seine Adresse.
+          - Sie markieren den Brief als gesendet.
+          - Sobald Sie den Brief als gesendet markiert haben, kann der Benutzer den Code einführen und verifiziert werden.
       direct: Direkte
       help: Hilfe
       id_documents:
@@ -116,7 +117,7 @@ de:
               success: Überprüfung abgelehnt Benutzer wird aufgefordert, ihre Dokumente zu ändern
         authorizations:
           choose:
-            choose_a_type: "Bitte wählen Sie aus, wie Sie verifiziert werden möchten:"
+            choose_a_type: 'Bitte wählen Sie aus, wie Sie verifiziert werden möchten:'
             offline: Offline
             online: Online
             title: Überprüfen Sie sich anhand Ihres Ausweisdokuments

--- a/decidim-verifications/config/locales/es-PY.yml
+++ b/decidim-verifications/config/locales/es-PY.yml
@@ -1,3 +1,4 @@
+---
 es-PY:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ es-PY:
       admin:
         id_documents:
           help:
-            - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
-            - Rellenas la información presente en la imagen subida.
-            - La información debe coincidir con lo que el usuario envió.
-            - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
+          - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
+          - Rellenas la información presente en la imagen subida.
+          - La información debe coincidir con lo que el usuario envió.
+          - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
         postal_letter:
           help:
-            - Los usuarios solicitan que se envíe un código de verificación a su dirección.
-            - Envías la carta a su dirección con el código de verificación.
-            - Marcas la carta como enviada.
-            - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
+          - Los usuarios solicitan que se envíe un código de verificación a su dirección.
+          - Envías la carta a su dirección con el código de verificación.
+          - Marcas la carta como enviada.
+          - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
       direct: Directo
       help: Ayuda
       id_documents:
@@ -116,7 +117,7 @@ es-PY:
               success: Verificación rechazada. Se le pedirá al usuario que modifique sus documentos
         authorizations:
           choose:
-            choose_a_type: "Por favor selecciona como quieres ser verificado:"
+            choose_a_type: 'Por favor selecciona como quieres ser verificado:'
             offline: Presencial
             online: Online
             title: Verifícate utilizando tu documento de identidad
@@ -158,7 +159,7 @@ es-PY:
         authorizations:
           create:
             error: Hubo un problema con su petición
-            success: '¡Gracias! Te enviaremos un código de verificación a tu dirección'
+            success: "¡Gracias! Te enviaremos un código de verificación a tu dirección"
           edit:
             send: Confirmar
             title: Introduce el código de verificación que recibiste
@@ -173,7 +174,7 @@ es-PY:
         authorizations:
           create:
             error: Hubo un problema con tu solicitud
-            success: '¡Gracias! Hemos enviado un SMS a tu teléfono.'
+            success: "¡Gracias! Hemos enviado un SMS a tu teléfono."
           edit:
             send: Confirmar
             title: Introduce el código de verificación que has recibido

--- a/decidim-verifications/config/locales/es.yml
+++ b/decidim-verifications/config/locales/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ es:
       admin:
         id_documents:
           help:
-            - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
-            - Rellenas la información presente en la imagen subida.
-            - La información debe coincidir con lo que el usuario envió.
-            - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
+          - Los usuarios rellenan la información de su identidad y suben una copia de su documento.
+          - Rellenas la información presente en la imagen subida.
+          - La información debe coincidir con lo que el usuario envió.
+          - Si no puedes ver claramente la información o no puedes verificarla, puedes rechazar la solicitud y el usuario podrá corregirla.
         postal_letter:
           help:
-            - Los usuarios solicitan que se envíe un código de verificación a su dirección.
-            - Envías la carta a su dirección con el código de verificación.
-            - Marcas la carta como enviada.
-            - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
+          - Los usuarios solicitan que se envíe un código de verificación a su dirección.
+          - Envías la carta a su dirección con el código de verificación.
+          - Marcas la carta como enviada.
+          - Una vez hayas marcado la carta como enviada, el usuario podrá introducir el código y ser verificado.
       direct: Directo
       help: Ayuda
       id_documents:
@@ -116,7 +117,7 @@ es:
               success: Verificación rechazada. Se le pedirá al usuario que modifique sus documentos
         authorizations:
           choose:
-            choose_a_type: "Por favor selecciona como quieres ser verificado:"
+            choose_a_type: 'Por favor selecciona como quieres ser verificado:'
             offline: Presencial
             online: Online
             title: Verifícate utilizando tu documento de identidad
@@ -158,7 +159,7 @@ es:
         authorizations:
           create:
             error: Hubo un problema con su petición
-            success: '¡Gracias! Te enviaremos un código de verificación a tu dirección'
+            success: "¡Gracias! Te enviaremos un código de verificación a tu dirección"
           edit:
             send: Confirmar
             title: Introduce el código de verificación que recibiste
@@ -173,7 +174,7 @@ es:
         authorizations:
           create:
             error: Hubo un problema con tu solicitud
-            success: '¡Gracias! Hemos enviado un SMS a tu teléfono.'
+            success: "¡Gracias! Hemos enviado un SMS a tu teléfono."
           edit:
             send: Confirmar
             title: Introduce el código de verificación que has recibido

--- a/decidim-verifications/config/locales/eu.yml
+++ b/decidim-verifications/config/locales/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ eu:
       admin:
         id_documents:
           help:
-            - Erabiltzaileek beren identifikazio informazioa bete eta dokumentuaren kopia bat kargatu.
-            - Kargatutako irudian dagoen informazio hau bete behar duzu.
-            - Informazioa edozein erabiltzailek bete duenarekin bat egin beharko luke.
-            - Informazio hori argi eta garbi ikusi ez baduzu edo egiaztatu ezin baduzu, eskaera ukatu egin dezakezu eta erabiltzaileak konpondu ahal izango du.
+          - Erabiltzaileek beren identifikazio informazioa bete eta dokumentuaren kopia bat kargatu.
+          - Kargatutako irudian dagoen informazio hau bete behar duzu.
+          - Informazioa edozein erabiltzailek bete duenarekin bat egin beharko luke.
+          - Informazio hori argi eta garbi ikusi ez baduzu edo egiaztatu ezin baduzu, eskaera ukatu egin dezakezu eta erabiltzaileak konpondu ahal izango du.
         postal_letter:
           help:
-            - Erabiltzaileek egiaztapen-kodea eskatu behar dute euren helbidea bidaltzeko.
-            - Posta-helbidea bere helbidean bidaltzen du egiaztapen-kodearekin.
-            - Bidalitako mezua markatzen du.
-            - Behin bidalitako mezua markatzen duzunean, erabiltzaileak kodea sartu eta egiaztatu egingo du.
+          - Erabiltzaileek egiaztapen-kodea eskatu behar dute euren helbidea bidaltzeko.
+          - Posta-helbidea bere helbidean bidaltzen du egiaztapen-kodearekin.
+          - Bidalitako mezua markatzen du.
+          - Behin bidalitako mezua markatzen duzunean, erabiltzaileak kodea sartu eta egiaztatu egingo du.
       direct: Zuzeneko
       help: Laguntza
       id_documents:
@@ -116,7 +117,7 @@ eu:
               success: Verification rejected. Erabiltzailea bere dokumentuak aldatzeko eskatuko zaio
         authorizations:
           choose:
-            choose_a_type: "Hautatu nola egiaztatu nahi duzun:"
+            choose_a_type: 'Hautatu nola egiaztatu nahi duzun:'
             offline: Offline
             online: Online
             title: Egiaztatu zure identifikazio dokumentua

--- a/decidim-verifications/config/locales/fi-pl.yml
+++ b/decidim-verifications/config/locales/fi-pl.yml
@@ -1,3 +1,4 @@
+---
 fi-pl:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ fi-pl:
       admin:
         id_documents:
           help:
-            - Käyttäjät täyttävät henkilötietonsa ja lähettävät kopion asiakirjastaan.
-            - Sinä täytät ladatussa kuvassa näkyvät tiedot.
-            - Tietojen tulisi vastata niitä tietoja, jotka käyttäjä on syöttänyt.
-            - Jos et voi nähdä tietoja selvästi tai et voi saada niitä vahvistettua, voit hylätä pyynnön, jolloin käyttäjä voi korjata sen.
+          - Käyttäjät täyttävät henkilötietonsa ja lähettävät kopion asiakirjastaan.
+          - Sinä täytät ladatussa kuvassa näkyvät tiedot.
+          - Tietojen tulisi vastata niitä tietoja, jotka käyttäjä on syöttänyt.
+          - Jos et voi nähdä tietoja selvästi tai et voi saada niitä vahvistettua, voit hylätä pyynnön, jolloin käyttäjä voi korjata sen.
         postal_letter:
           help:
-            - Käyttäjät pyytävät vahvistuskoodin lähettämistä heidän osoitteeseensa.
-            - Lähetät kirjeen heidän osoitteeseensa, mikä sisältää vahvistuskoodin.
-            - Sinä merkitset kirjeen lähetetyksi.
-            - Kun olet merkinnyt kirjeen lähetetyksi, käyttäjä voi ottaa syöttää koodin ja vahvistaa tilinsä.
+          - Käyttäjät pyytävät vahvistuskoodin lähettämistä heidän osoitteeseensa.
+          - Lähetät kirjeen heidän osoitteeseensa, mikä sisältää vahvistuskoodin.
+          - Sinä merkitset kirjeen lähetetyksi.
+          - Kun olet merkinnyt kirjeen lähetetyksi, käyttäjä voi ottaa syöttää koodin ja vahvistaa tilinsä.
       direct: Suoraan
       help: Ohjeet
       id_documents:
@@ -116,7 +117,7 @@ fi-pl:
               success: Vahvistus hylätty. Käyttäjää pyydetään muuttamaan asiakirjojaan
         authorizations:
           choose:
-            choose_a_type: "Valitse, kuinka haluat varmistaa henkilöllisyytesi:"
+            choose_a_type: 'Valitse, kuinka haluat varmistaa henkilöllisyytesi:'
             offline: Offline
             online: Online
             title: Varmista henkilöllisyytesi käyttämällä henkilöllisyystodistusta

--- a/decidim-verifications/config/locales/fi.yml
+++ b/decidim-verifications/config/locales/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ fi:
       admin:
         id_documents:
           help:
-            - Käyttäjät täyttävät henkilötietonsa ja lähettävät kopion asiakirjastaan.
-            - Sinä täytät ladatussa kuvassa näkyvät tiedot.
-            - Tietojen tulisi vastata niitä tietoja, jotka käyttäjä on syöttänyt.
-            - Jos et voi nähdä tietoja selvästi tai et voi saada niitä vahvistettua, voit hylätä pyynnön, jolloin käyttäjä voi korjata sen.
+          - Käyttäjät täyttävät henkilötietonsa ja lähettävät kopion asiakirjastaan.
+          - Sinä täytät ladatussa kuvassa näkyvät tiedot.
+          - Tietojen tulisi vastata niitä tietoja, jotka käyttäjä on syöttänyt.
+          - Jos et voi nähdä tietoja selvästi tai et voi saada niitä vahvistettua, voit hylätä pyynnön, jolloin käyttäjä voi korjata sen.
         postal_letter:
           help:
-            - Käyttäjät pyytävät vahvistuskoodin lähettämistä heidän osoitteeseensa.
-            - Lähetät kirjeen heidän osoitteeseensa, mikä sisältää vahvistuskoodin.
-            - Sinä merkitset kirjeen lähetetyksi.
-            - Kun olet merkinnyt kirjeen lähetetyksi, käyttäjä voi ottaa syöttää koodin ja vahvistaa tilinsä.
+          - Käyttäjät pyytävät vahvistuskoodin lähettämistä heidän osoitteeseensa.
+          - Lähetät kirjeen heidän osoitteeseensa, mikä sisältää vahvistuskoodin.
+          - Sinä merkitset kirjeen lähetetyksi.
+          - Kun olet merkinnyt kirjeen lähetetyksi, käyttäjä voi ottaa syöttää koodin ja vahvistaa tilinsä.
       direct: Suoraan
       help: Ohjeet
       id_documents:
@@ -116,7 +117,7 @@ fi:
               success: Vahvistus hylätty. Käyttäjää pyydetään muuttamaan asiakirjojaan
         authorizations:
           choose:
-            choose_a_type: "Valitse, kuinka haluat varmistaa henkilöllisyytesi:"
+            choose_a_type: 'Valitse, kuinka haluat varmistaa henkilöllisyytesi:'
             offline: Offline
             online: Online
             title: Varmista henkilöllisyytesi käyttämällä henkilöllisyystodistusta

--- a/decidim-verifications/config/locales/gl.yml
+++ b/decidim-verifications/config/locales/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ gl:
       admin:
         id_documents:
           help:
-            - Os usuarios encherán a súa información de identidade e cargarán unha copia do seu documento.
-            - Enche a información presente na imaxe cargada.
-            - A información debe coincidir co que o usuario enche.
-            - Se non pode ver claramente a información ou non pode verificala, pode rexeitar a solicitude e o usuario poderá solucionalo.
+          - Os usuarios encherán a súa información de identidade e cargarán unha copia do seu documento.
+          - Enche a información presente na imaxe cargada.
+          - A información debe coincidir co que o usuario enche.
+          - Se non pode ver claramente a información ou non pode verificala, pode rexeitar a solicitude e o usuario poderá solucionalo.
         postal_letter:
           help:
-            - Os usuarios solicitan que se envíe un código de verificación ao seu enderezo.
-            - Envía a carta ao seu enderezo co código de verificación.
-            - Marca a letra como enviada.
-            - Unha vez que marca a letra enviada, o usuario poderá introducir o código e verificarse.
+          - Os usuarios solicitan que se envíe un código de verificación ao seu enderezo.
+          - Envía a carta ao seu enderezo co código de verificación.
+          - Marca a letra como enviada.
+          - Unha vez que marca a letra enviada, o usuario poderá introducir o código e verificarse.
       direct: Directo
       help: Axuda
       id_documents:
@@ -116,7 +117,7 @@ gl:
               success: Verificación rexeitada. Invitará ao usuario a que modifique os seus documentos
         authorizations:
           choose:
-            choose_a_type: "Selecciona como queres verificar:"
+            choose_a_type: 'Selecciona como queres verificar:'
             offline: Desconectado
             online: En liña
             title: Verifica a túa conta usando o teu documento de identidade

--- a/decidim-verifications/config/locales/hu.yml
+++ b/decidim-verifications/config/locales/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ hu:
       admin:
         id_documents:
           help:
-            - A felhasználók kitölthetik az adatlapjukat és feltölthetik dokumentumaikat.
-            - Töltsd ki a feltöltött képen található információkkal.
-            - Az információknak meg kell egyeznie a kitöltött adatokkal.
-            - Ha nem láthatók tisztán az információk vagy nem tudod ellenőrizni, akkor elutasíthatod és visszaküldheted javításra a kérelmet.
+          - A felhasználók kitölthetik az adatlapjukat és feltölthetik dokumentumaikat.
+          - Töltsd ki a feltöltött képen található információkkal.
+          - Az információknak meg kell egyeznie a kitöltött adatokkal.
+          - Ha nem láthatók tisztán az információk vagy nem tudod ellenőrizni, akkor elutasíthatod és visszaküldheted javításra a kérelmet.
         postal_letter:
           help:
-            - A felhasználók a lakcímükre kérik az ellenőrző kódot.
-            - A kódot tartalmazó levelet a lakcímükre küldöd el.
-            - Levél elküldöttként megjelölve.
-            - Miután a levelet megjelölted elküldöttként, a felhasználó a kód segítségével ellenőrizhető lesz.
+          - A felhasználók a lakcímükre kérik az ellenőrző kódot.
+          - A kódot tartalmazó levelet a lakcímükre küldöd el.
+          - Levél elküldöttként megjelölve.
+          - Miután a levelet megjelölted elküldöttként, a felhasználó a kód segítségével ellenőrizhető lesz.
       direct: Közvetlen
       help: Segítség
       id_documents:
@@ -79,7 +80,7 @@ hu:
       dummy_authorization:
         extra_explanation:
           one: A részvétel %{postal_codes} irányítószámú felhasználókra korlátozódik.
-          other: 'A részvétel %{postal_codes} irányítószámú felhasználókra korlátozódik.'
+          other: A részvétel %{postal_codes} irányítószámú felhasználókra korlátozódik.
       id_documents:
         admin:
           config:
@@ -116,7 +117,7 @@ hu:
               success: Ellenőrzés elutasítva. A felhasználónak módosítania kell dokumentumain
         authorizations:
           choose:
-            choose_a_type: "Kérjük, adja meg, hogy miként szeretné ellenőrizni:"
+            choose_a_type: 'Kérjük, adja meg, hogy miként szeretné ellenőrizni:'
             offline: Offline
             online: Online
             title: Ellenőrizze magát személyazonosító okmányával

--- a/decidim-verifications/config/locales/id-ID.yml
+++ b/decidim-verifications/config/locales/id-ID.yml
@@ -1,187 +1,181 @@
-id:
+---
+id-ID:
   activemodel:
     attributes:
       config:
-        available_methods: Metode yang tersedia
+        available_methods: Available methods
         offline: Offline
-        offline_explanation: Petunjuk untuk verifikasi offline
-        online: On line
+        offline_explanation: Instructions for offline verification
+        online: Online
       id_document_information:
-        document_number: Nomor dokumen (dengan huruf)
-        document_type: Jenis dokumen
+        document_number: Document number (with letter)
+        document_type: Type of the document
       id_document_upload:
-        document_number: Nomor dokumen (dengan huruf)
-        document_type: Jenis dokumen Anda
-        user: Pengguna
-        verification_attachment: Salinan hasil pindaian dokumen Anda
+        document_number: Document number (with letter)
+        document_type: Type of your document
+        user: User
+        verification_attachment: Scanned copy of your document
       offline_confirmation:
-        email: Email pengguna
+        email: User email
       postal_letter_address:
-        full_address: Alamat lengkap
+        full_address: Full address
       postal_letter_confirmation:
-        verification_code: Kode verifikasi
+        verification_code: Verification code
       postal_letter_postage:
-        full_address: Alamat lengkap
-        verification_code: Kode verifikasi
+        full_address: Full address
+        verification_code: Verification code
   decidim:
     admin:
       menu:
-        authorization_workflows: Verifikasi
+        authorization_workflows: Verifications
     admin_log:
       organization:
-        update_id_documents_config: "%{user_name} memperbarui konfigurasi verifikasi Dokumen Identitas"
+        update_id_documents_config: "%{user_name} updated the Identity Documents verification configuration"
       user:
-        grant_id_documents_offline_verification: "%{user_name} diverifikasi %{resource_name} menggunakan verifikasi Dokumen Identitas offline"
+        grant_id_documents_offline_verification: "%{user_name} verified %{resource_name} using an offline Identity Documents verification"
     authorization_handlers:
       admin:
         id_documents:
-          help:
-            - Pengguna mengisi informasi identitas mereka dan mengunggah salinan dokumen mereka.
-            - Anda mengisi informasi yang ada di gambar yang diunggah.
-            - Informasi harus sesuai dengan apa pun yang diisi oleh pengguna.
-            - Jika Anda tidak dapat melihat informasi dengan jelas atau Anda tidak dapat memverifikasinya, Anda dapat menolak permintaan dan pengguna akan dapat memperbaikinya.
+          help: '["Users fill in their identity information and upload a copy of their document.", "You fill in the information present in the uploaded image.", "The information should match whatever the user filled in.", "If you can''t clearly see the information or you can''t get it verified, you can reject the request and the user will be able to fix it."]'
         postal_letter:
-          help:
-            - Pengguna meminta kode verifikasi untuk dikirim ke alamat mereka.
-            - Anda mengirim surat ke alamat mereka dengan kode verifikasi.
-            - Anda menandai surat yang dikirim.
-            - Setelah Anda menandai surat yang dikirim, pengguna akan dapat memperkenalkan kode dan diverifikasi.
-      direct: Langsung
-      help: Membantu
+          help: '["Users request a verification code to be sent to their address.", "You send the letter to their address with the verification code.", "You mark the letter as sent.", "Once you mark the letter as sent, the user will be able to introduce the code and get verified."]'
+      direct: Direct
+      help: Help
       id_documents:
-        explanation: Unggah dokumen identitas Anda sehingga kami dapat memeriksa identitas Anda
-        name: Dokumen identitas
-      multistep: Multi-Langkah
-      name: Nama
+        explanation: Upload your identity documents so we can check your identity
+        name: Identity documents
+      multistep: Multi-Step
+      name: Name
       postal_letter:
-        explanation: Kami akan mengirimi Anda surat pos dengan kode yang harus Anda masukkan sehingga kami dapat memverifikasi alamat Anda
-        name: Kode melalui surat pos
+        explanation: We'll send you a postal letter with a code that you'll have to enter so we can verify your address
+        name: Code by postal letter
     verifications:
       authorizations:
         create:
-          error: Ada kesalahan saat membuat otorisasi.
-          success: Anda telah berhasil diotorisasi.
-          unconfirmed: Anda perlu mengkonfirmasi email Anda untuk mengotorisasi diri Anda sendiri.
+          error: There was an error creating the authorization.
+          success: You've been successfully authorized.
+          unconfirmed: You need to confirm your email in order to authorize yourself.
         first_login:
           actions:
-            another_dummy_authorization_handler: Verifikasi terhadap contoh lain dari pengendali otorisasi
-            dummy_authorization_handler: Verifikasi terhadap contoh handler otorisasi
-            dummy_authorization_workflow: Verifikasi terhadap contoh alur kerja otorisasi
-            id_documents: Dapatkan verifikasi dengan mengunggah dokumen identitas Anda
-            postal_letter: Dapatkan verifikasi dengan menerima kode verifikasi melalui surat pos
-          title: Verifikasi identitas Anda
-          verify_with_these_options: 'Ini adalah opsi yang tersedia untuk memverifikasi identitas Anda:'
+            another_dummy_authorization_handler: Verify against another example of authorization handler
+            dummy_authorization_handler: Verify against the example authorization handler
+            dummy_authorization_workflow: Verify against the example authorization workflow
+            id_documents: Get verified by uploading your identity document
+            postal_letter: Get verified by receiving a verification code through postal mail
+          title: Verify your identity
+          verify_with_these_options: 'These are the available options to verify your identity:'
         new:
-          authorize: Kirim
-          authorize_with: Verifikasi dengan %{authorizer}
-        skip_verification: Anda dapat melewati ini untuk sekarang dan %{link}
-        start_exploring: mulai menjelajah
+          authorize: Send
+          authorize_with: Verify with %{authorizer}
+        skip_verification: You can skip this for now and %{link}
+        start_exploring: start exploring
       dummy_authorization:
         extra_explanation:
-          other: 'Partisipasi dibatasi untuk pengguna dengan salah satu kode pos berikut: %{postal_codes}.'
+          one: Participation is restricted to users with the postal code %{postal_codes}.
+          other: 'Participation is restricted to users with any of the following postal codes: %{postal_codes}.'
       id_documents:
         admin:
           config:
             edit:
-              title: Konfigurasi dokumen identitas
-              update: Memperbarui
+              title: Identity documents configuration
+              update: Update
             update:
-              error: Terjadi kesalahan saat memperbarui konfigurasi.
-              success: Konfigurasi berhasil diperbarui
+              error: There was an error updating the configuration.
+              success: Configuration successfully updated
           confirmations:
             create:
-              error: Verifikasi tidak cocok. Coba lagi atau tolak verifikasi sehingga pengguna dapat mengubahnya
-              success: Pengguna berhasil diverifikasi
+              error: Verification doesn't match. Try again or reject the verification so the user can amend it
+              success: User successfully verified
             new:
-              introduce_user_data: Perkenalkan data dalam gambar
-              reject: Menolak
-              verify: Memeriksa
+              introduce_user_data: Introduce the data in the picture
+              reject: Reject
+              verify: Verify
           offline_confirmations:
             create:
-              error: Verifikasi tidak cocok. Coba lagi atau beri tahu pengguna untuk mengubahnya
-              success: Pengguna berhasil diverifikasi
+              error: Verification doesn't match. Try again or tell the user to amend it
+              success: User successfully verified
             new:
-              cancel: Membatalkan
-              introduce_user_data: Perkenalkan email pengguna dan data dokumen
-              verify: Memeriksa
+              cancel: Cancel
+              introduce_user_data: Introduce the user email and the document data
+              verify: Verify
           pending_authorizations:
             index:
               config: Config
-              offline_verification: Verifikasi offline
-              title: Verifikasi online yang tertunda
-              verification_number: 'Verifikasi #%{n}'
+              offline_verification: Offline verification
+              title: Pending online verifications
+              verification_number: 'Verification #%{n}'
           rejections:
             create:
-              success: Verifikasi ditolak. Pengguna akan diminta untuk mengubah dokumennya
+              success: Verification rejected. User will be prompted to amend her documents
         authorizations:
           choose:
-            choose_a_type: "Silakan pilih bagaimana Anda ingin diverifikasi:"
+            choose_a_type: 'Please select how you want to be verified:'
             offline: Offline
-            online: On line
-            title: Verifikasi diri Anda menggunakan dokumen identitas Anda
+            online: Online
+            title: Verify yourself using your identity document
           create:
-            error: Ada masalah saat mengunggah dokumen Anda
-            success: Dokumen berhasil diunggah
+            error: There was a problem uploading your document
+            success: Document uploaded successfully
           edit:
-            being_reviewed: Kami sedang meninjau dokumen Anda. Anda akan segera diverifikasi
-            offline: Gunakan verifikasi offline
-            online: Gunakan verifikasi online
-            rejection_clarity: Pastikan informasinya terlihat jelas di gambar yang diunggah
-            rejection_correctness: Pastikan informasi yang dimasukkan sudah benar
-            rejection_notice: Ada masalah dengan verifikasi Anda. Silakan coba lagi
-            send: Meminta verifikasi lagi
+            being_reviewed: We're reviewing your documents. You'll be verified shortly
+            offline: Use offline verification
+            online: Use online verification
+            rejection_clarity: Make sure the information is clearly visible in the uploaded image
+            rejection_correctness: Make sure the information entered is correct
+            rejection_notice: There was a problem with your verification. Please try again
+            send: Request verification again
           new:
-            send: Meminta verifikasi
-            title: Unggah dokumen identitas Anda
+            send: Request verification
+            title: Upload your identity document
           update:
-            error: Terjadi masalah saat memuat ulang dokumen Anda
-            success: Dokumen berhasil diunggah ulang
+            error: There was a problem reuploading your document
+            success: Document reuploaded successfully
         dni: DNI
         nie: NIE
-        passport: Paspor
+        passport: Passport
       postal_letter:
         admin:
           pending_authorizations:
             index:
-              address: Alamat
-              letter_sent_at: Surat dikirim pada
-              mark_as_sent: Tandai sebagai terkirim
-              not_yet_sent: belum dikirim
-              title: Verifikasi berkelanjutan
-              username: Nama pengguna
-              verification_code: Kode verifikasi
+              address: Address
+              letter_sent_at: Letter sent at
+              mark_as_sent: Mark as sent
+              not_yet_sent: Not yet sent
+              title: Ongoing verifications
+              username: Username
+              verification_code: Verification code
           postages:
             create:
-              error: Kesalahan menandai huruf yang dikirim
-              success: Surat berhasil ditandai sebagai terkirim
+              error: Error marking letter as sent
+              success: Letter successfully marked as sent
         authorizations:
           create:
-            error: Ada masalah dengan permintaan anda
-            success: Terima kasih! Kami akan mengirimkan kode verifikasi ke alamat Anda
+            error: There was a problem with your request
+            success: Thanks! We'll send a verification code to your address
           edit:
-            send: Memastikan
-            title: Perkenalkan kode verifikasi yang Anda terima
-            waiting_for_letter: Kami akan segera mengirim surat ke alamat Anda dengan kode verifikasi Anda
+            send: Confirm
+            title: Introduce the verification code you received
+            waiting_for_letter: We'll be sending a letter to your address with your verification code soon
           new:
-            send: Kirimkan saya surat
-            title: Minta kode verifikasi Anda
+            send: Send me a letter
+            title: Request your verification code
           update:
-            error: Kode verifikasi Anda tidak sesuai dengan kami. Silakan periksa kembali surat yang kami kirimkan kepada Anda
-            success: Selamat. Anda telah berhasil diverifikasi
+            error: Your verification code doesn't match ours. Please double-check the letter we sent to you
+            success: Congratulations. You've been successfully verified
       sms:
         authorizations:
           create:
-            error: Ada masalah dengan permintaan anda
-            success: Terima kasih! Kami telah mengirim SMS ke ponsel Anda.
+            error: There was a problem with your request
+            success: Thanks! We've sent an SMS to your phone.
           edit:
-            send: Memastikan
-            title: Perkenalkan kode verifikasi yang Anda terima
+            send: Confirm
+            title: Introduce the verification code you received
           new:
-            send: Kirimi saya SMS
-            title: Minta kode verifikasi Anda
+            send: Send me an SMS
+            title: Request your verification code
           update:
-            error: Kode verifikasi Anda tidak sesuai dengan kami. Harap periksa kembali SMS yang kami kirimkan kepada Anda.
-            success: Selamat. Anda telah berhasil diverifikasi.
+            error: Your verification code doesn't match ours. Please double-check the SMS we sent you.
+            success: Congratulations. You've been successfully verified.
   errors:
     messages:
-      uppercase_only_letters_numbers: harus semuanya huruf besar dan hanya berisi huruf dan / atau angka
+      uppercase_only_letters_numbers: must be all uppercase and contain only letters and/or numbers

--- a/decidim-verifications/config/locales/it.yml
+++ b/decidim-verifications/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ it:
       admin:
         id_documents:
           help:
-            - Gli utenti inseriscono le loro informazioni di identità e caricano una copia del loro documento.
-            - Inserisci le informazioni presenti nell'immagine caricata.
-            - Le informazioni dovrebbero corrispondere a quello que l'utente ha inserito.
-            - Se non riesci a vedere chiaramente le informazioni o non riesci a verificarle, puoi rifiutare la richiesta e l'utente sarà in grado di risolverlo.
+          - Gli utenti inseriscono le loro informazioni di identità e caricano una copia del loro documento.
+          - Inserisci le informazioni presenti nell'immagine caricata.
+          - Le informazioni dovrebbero corrispondere a quello que l'utente ha inserito.
+          - Se non riesci a vedere chiaramente le informazioni o non riesci a verificarle, puoi rifiutare la richiesta e l'utente sarà in grado di risolverlo.
         postal_letter:
           help:
-            - Gli utenti richiedono un codice di verifica da inviare al loro indirizzo.
-            - Inviate la lettera al loro indirizzo con il codice di verifica.
-            - Hai contrassegnato la lettera come inviata.
-            - Dopo aver contrassegnato la lettera come inviata, l'utente potrà introdurre il codice e essere verificato.
+          - Gli utenti richiedono un codice di verifica da inviare al loro indirizzo.
+          - Inviate la lettera al loro indirizzo con il codice di verifica.
+          - Hai contrassegnato la lettera come inviata.
+          - Dopo aver contrassegnato la lettera come inviata, l'utente potrà introdurre il codice e essere verificato.
       direct: Diretto
       help: Aiuto
       id_documents:
@@ -110,13 +111,13 @@ it:
               config: config
               offline_verification: Verifica offline
               title: Verifiche pendenti
-              verification_number: 'Verifica n. %{n}'
+              verification_number: Verifica n. %{n}
           rejections:
             create:
               success: Verifica respinta. L'utente serà richiesto di modificare i suoi documenti
         authorizations:
           choose:
-            choose_a_type: "Si prega di selezionare come si desidera essere verificato:"
+            choose_a_type: 'Si prega di selezionare come si desidera essere verificato:'
             offline: disconnesso
             online: in linea
             title: Verifica te stesso usando il tuo documento di identità

--- a/decidim-verifications/config/locales/nl.yml
+++ b/decidim-verifications/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ nl:
       admin:
         id_documents:
           help:
-            - Gebruikers vullen hun identiteitsinformatie in en uploaden een kopie van hun document.
-            - U vult de informatie in die in de geüploade afbeelding aanwezig is.
-            - De informatie moet overeenkomen met wat de gebruiker heeft ingevuld.
-            - Als u de informatie niet duidelijk kunt zien of als u de informatie niet kunt verifiëren, kunt u het verzoek afwijzen en kan de gebruiker het probleem oplossen.
+          - Gebruikers vullen hun identiteitsinformatie in en uploaden een kopie van hun document.
+          - U vult de informatie in die in de geüploade afbeelding aanwezig is.
+          - De informatie moet overeenkomen met wat de gebruiker heeft ingevuld.
+          - Als u de informatie niet duidelijk kunt zien of als u de informatie niet kunt verifiëren, kunt u het verzoek afwijzen en kan de gebruiker het probleem oplossen.
         postal_letter:
           help:
-            - Gebruikers vragen een verificatiecode op te sturen naar hun adres.
-            - U stuurt de brief naar hun adres met de verificatiecode.
-            - U markeert de brief zoals verzonden.
-            - Nadat u de brief hebt gemarkeerd als verzonden, kan de gebruiker de code invoeren en worden geverifieerd.
+          - Gebruikers vragen een verificatiecode op te sturen naar hun adres.
+          - U stuurt de brief naar hun adres met de verificatiecode.
+          - U markeert de brief zoals verzonden.
+          - Nadat u de brief hebt gemarkeerd als verzonden, kan de gebruiker de code invoeren en worden geverifieerd.
       direct: direct
       help: Helpen
       id_documents:
@@ -116,7 +117,7 @@ nl:
               success: Verificatie gewijgerd. De gebruiker wordt gevraagd om haar documenten te wijzigen
         authorizations:
           choose:
-            choose_a_type: "Selecteer alstublieft hoe u wilt worden geverifieerd:"
+            choose_a_type: 'Selecteer alstublieft hoe u wilt worden geverifieerd:'
             offline: offline
             online: Online
             title: Verifieer jezelf met je identiteitsdocument

--- a/decidim-verifications/config/locales/pl.yml
+++ b/decidim-verifications/config/locales/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ pl:
       admin:
         id_documents:
           help:
-            - Użytkownicy wypełniają swoje dane osobowe i przesyłają kopię swojego dokumentu.
-            - Wypełniasz informacje zawarte w przesłanym obrazie.
-            - Informacje powinny pasować do tego, co użytkownik wypełnił.
-            - Jeśli nie możesz wyraźnie zobaczyć tych informacji lub nie możesz ich zweryfikować, możesz odrzucić prośbę, a użytkownik będzie mógł to naprawić.
+          - Użytkownicy wypełniają swoje dane osobowe i przesyłają kopię swojego dokumentu.
+          - Wypełniasz informacje zawarte w przesłanym obrazie.
+          - Informacje powinny pasować do tego, co użytkownik wypełnił.
+          - Jeśli nie możesz wyraźnie zobaczyć tych informacji lub nie możesz ich zweryfikować, możesz odrzucić prośbę, a użytkownik będzie mógł to naprawić.
         postal_letter:
           help:
-            - Użytkownicy żądają kodu weryfikacyjnego, który zostanie wysłany na ich adres.
-            - Wysyłasz list na adres z kodem weryfikacyjnym.
-            - Oznacz list jako wysłany.
-            - Po oznaczeniu wysłanej litery użytkownik będzie mógł wprowadzić kod i uzyskać weryfikację.
+          - Użytkownicy żądają kodu weryfikacyjnego, który zostanie wysłany na ich adres.
+          - Wysyłasz list na adres z kodem weryfikacyjnym.
+          - Oznacz list jako wysłany.
+          - Po oznaczeniu wysłanej litery użytkownik będzie mógł wprowadzić kod i uzyskać weryfikację.
       direct: Bezpośredni
       help: Wsparcie
       id_documents:
@@ -78,9 +79,9 @@ pl:
         start_exploring: zacznij odkrywać
       dummy_authorization:
         extra_explanation:
-          one: Udział jest ograniczony do użytkowników, którzy mają kod pocztowy %{postal_codes}.
           few: 'Udział jest ograniczony do użytkowników, którzy mają jeden z następujących kodów pocztowych: %{postal_codes}.'
           many: 'Udział jest ograniczony do użytkowników posiadających jeden z następujących kodów pocztowych: %{postal_codes}.'
+          one: Udział jest ograniczony do użytkowników, którzy mają kod pocztowy %{postal_codes}.
           other: 'Udział jest ograniczony do użytkowników, którzy mają jeden z następujących kodów pocztowych: %{postal_codes}.'
       id_documents:
         admin:
@@ -118,7 +119,7 @@ pl:
               success: Weryfikacja odrzucona. Użytkownik zostanie poproszony o zmianę swoich dokumentów
         authorizations:
           choose:
-            choose_a_type: "Wybierz sposób weryfikacji:"
+            choose_a_type: 'Wybierz sposób weryfikacji:'
             offline: Offline
             online: online
             title: Zweryfikuj się, używając swojego dokumentu tożsamości

--- a/decidim-verifications/config/locales/pt-BR.yml
+++ b/decidim-verifications/config/locales/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ pt-BR:
       admin:
         id_documents:
           help:
-            - Os usuários preenchem suas informações de identidade e carregam uma cópia do documento.
-            - Você preencher as informações presentes na imagem carregada.
-            - A informação deve corresponder ao que o usuário preenchido.
-            - Se você não pode ver claramente a informação ou não conseguir verificá-la, você pode rejeitar a solicitação e o usuário poderá consertá-la.
+          - Os usuários preenchem suas informações de identidade e carregam uma cópia do documento.
+          - Você preencher as informações presentes na imagem carregada.
+          - A informação deve corresponder ao que o usuário preenchido.
+          - Se você não pode ver claramente a informação ou não conseguir verificá-la, você pode rejeitar a solicitação e o usuário poderá consertá-la.
         postal_letter:
           help:
-            - Os usuários solicitaram que um código de verificação seja enviado para o endereço.
-            - Você envia a carta para seu endereço com o código de verificação.
-            - Você marca a carta como enviada.
-            - Depois de marcar a carta como enviada, o usuário poderá introduzir o código e ser verificado.
+          - Os usuários solicitaram que um código de verificação seja enviado para o endereço.
+          - Você envia a carta para seu endereço com o código de verificação.
+          - Você marca a carta como enviada.
+          - Depois de marcar a carta como enviada, o usuário poderá introduzir o código e ser verificado.
       direct: Direto
       help: Ajuda
       id_documents:
@@ -116,7 +117,7 @@ pt-BR:
               success: Verificação rejeitada. O usuário será solicitado a alterar seus documentos
         authorizations:
           choose:
-            choose_a_type: "Por favor, selecione como deseja ser verificado:"
+            choose_a_type: 'Por favor, selecione como deseja ser verificado:'
             offline: desligada
             online: Conectados
             title: Confirme-se usando seu documento de identidade

--- a/decidim-verifications/config/locales/pt.yml
+++ b/decidim-verifications/config/locales/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ pt:
       admin:
         id_documents:
           help:
-            - Os usuários preenchem suas informações de identidade e carregam uma cópia do documento.
-            - Você preencher as informações presentes na imagem carregada.
-            - A informação deve corresponder ao que o usuário preenchido.
-            - Se você não pode ver claramente a informação ou não conseguir verificá-la, você pode rejeitar a solicitação e o usuário poderá consertá-la.
+          - Os usuários preenchem suas informações de identidade e carregam uma cópia do documento.
+          - Você preencher as informações presentes na imagem carregada.
+          - A informação deve corresponder ao que o usuário preenchido.
+          - Se você não pode ver claramente a informação ou não conseguir verificá-la, você pode rejeitar a solicitação e o usuário poderá consertá-la.
         postal_letter:
           help:
-            - Os usuários solicitaram que um código de verificação seja enviado para o endereço.
-            - Você envia a carta para seu endereço com o código de verificação.
-            - Você marca a carta como enviada.
-            - Depois de marcar a carta como enviada, o usuário poderá introduzir o código e ser verificado.
+          - Os usuários solicitaram que um código de verificação seja enviado para o endereço.
+          - Você envia a carta para seu endereço com o código de verificação.
+          - Você marca a carta como enviada.
+          - Depois de marcar a carta como enviada, o usuário poderá introduzir o código e ser verificado.
       direct: Direto
       help: Socorro
       id_documents:
@@ -116,7 +117,7 @@ pt:
               success: Verificação rejeitada. O usuário será solicitado a alterar seus documentos
         authorizations:
           choose:
-            choose_a_type: "Por favor, selecione como deseja ser verificado:"
+            choose_a_type: 'Por favor, selecione como deseja ser verificado:'
             offline: desligada
             online: Conectados
             title: Confirme-se usando seu documento de identidade

--- a/decidim-verifications/config/locales/ru.yml
+++ b/decidim-verifications/config/locales/ru.yml
@@ -102,7 +102,12 @@ ru:
               verify: Подтвердить личность
           offline_confirmations:
             create:
+              error: Verification doesn't match. Try again or tell the user to amend it
               success: Литчность участника успешно подтверждена
+            new:
+              cancel: Cancel
+              introduce_user_data: Introduce the user email and the document data
+              verify: Verify
           pending_authorizations:
             index:
               config: Config

--- a/decidim-verifications/config/locales/sv.yml
+++ b/decidim-verifications/config/locales/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   activemodel:
     attributes:
@@ -36,16 +37,16 @@ sv:
       admin:
         id_documents:
           help:
-            - Användare fyller i sin identitetsinformation och laddar upp en kopia av deras dokument.
-            - Du fyller i informationen som finns i den uppladdade bilden.
-            - Informationen ska matcha vad användaren fyllt i.
-            - Om du inte klart kan se informationen eller du inte kan verifiera den kan du avvisa förfrågan och användaren kommer att kunna åtgärda det.
+          - Användare fyller i sin identitetsinformation och laddar upp en kopia av deras dokument.
+          - Du fyller i informationen som finns i den uppladdade bilden.
+          - Informationen ska matcha vad användaren fyllt i.
+          - Om du inte klart kan se informationen eller du inte kan verifiera den kan du avvisa förfrågan och användaren kommer att kunna åtgärda det.
         postal_letter:
           help:
-            - Användare begär en verifieringskod som ska skickas till deras adress.
-            - Du skickar brevet till deras adress med verifieringskoden.
-            - Du markerar brevet som skickat.
-            - När du markerar brevet som skickat kommer användaren att kunna införa koden och bli verifierad.
+          - Användare begär en verifieringskod som ska skickas till deras adress.
+          - Du skickar brevet till deras adress med verifieringskoden.
+          - Du markerar brevet som skickat.
+          - När du markerar brevet som skickat kommer användaren att kunna införa koden och bli verifierad.
       direct: Direkt
       help: Hjälp
       id_documents:
@@ -116,7 +117,7 @@ sv:
               success: Verifieringen avvisades. Användaren kommer att uppmanas att ändra sina dokument
         authorizations:
           choose:
-            choose_a_type: "Var god välj hur du vill verifieras:"
+            choose_a_type: 'Var god välj hur du vill verifieras:'
             offline: Off-line
             online: Uppkopplad
             title: Verifiera dig själv med ditt identitetsdokument

--- a/decidim-verifications/config/locales/tr-TR.yml
+++ b/decidim-verifications/config/locales/tr-TR.yml
@@ -1,188 +1,181 @@
-tr:
+---
+tr-TR:
   activemodel:
     attributes:
       config:
-        available_methods: Mevcut yöntemler
-        offline: Çevrimdışı
-        offline_explanation: Çevrimdışı doğrulama için talimatlar
-        online: İnternet üzerinden
+        available_methods: Available methods
+        offline: Offline
+        offline_explanation: Instructions for offline verification
+        online: Online
       id_document_information:
-        document_number: Belge numarası (harf ile)
-        document_type: Belgenin türü
+        document_number: Document number (with letter)
+        document_type: Type of the document
       id_document_upload:
-        document_number: Belge numarası (harf ile)
-        document_type: Belgenizin tipi
-        user: kullanıcı
-        verification_attachment: Belgenizin taranmış kopyası
+        document_number: Document number (with letter)
+        document_type: Type of your document
+        user: User
+        verification_attachment: Scanned copy of your document
       offline_confirmation:
-        email: Kullanıcı e-postası
+        email: User email
       postal_letter_address:
-        full_address: Açık adres
+        full_address: Full address
       postal_letter_confirmation:
-        verification_code: Doğrulama kodu
+        verification_code: Verification code
       postal_letter_postage:
-        full_address: Açık adres
-        verification_code: Doğrulama kodu
+        full_address: Full address
+        verification_code: Verification code
   decidim:
     admin:
       menu:
-        authorization_workflows: Doğrulama
+        authorization_workflows: Verifications
     admin_log:
       organization:
-        update_id_documents_config: "%{user_name} Kimlik Belgeleri doğrulama yapılandırmasını güncelledi"
+        update_id_documents_config: "%{user_name} updated the Identity Documents verification configuration"
       user:
-        grant_id_documents_offline_verification: "%{user_name} bir çevrimdışı Kimlik Belgeleri doğrulaması kullanarak %{resource_name} doğrulandı"
+        grant_id_documents_offline_verification: "%{user_name} verified %{resource_name} using an offline Identity Documents verification"
     authorization_handlers:
       admin:
         id_documents:
-          help:
-            - Kullanıcılar kimlik bilgilerini doldurur ve dokümanlarının bir kopyasını yüklerler.
-            - Yüklenen görüntüdeki mevcut bilgileri doldurursunuz.
-            - Bilgi, kullanıcının doldurduğu her şeyle eşleşmelidir.
-            - Bilgileri açıkça göremiyorsanız veya doğrulamıyorsanız, isteği reddedebilirsiniz ve kullanıcı bunu düzeltebilir.
+          help: '["Users fill in their identity information and upload a copy of their document.", "You fill in the information present in the uploaded image.", "The information should match whatever the user filled in.", "If you can''t clearly see the information or you can''t get it verified, you can reject the request and the user will be able to fix it."]'
         postal_letter:
-          help:
-            - Kullanıcılar adreslerine gönderilecek bir doğrulama kodu ister.
-            - Mektubu adreslerine doğrulama koduyla gönderirsiniz.
-            - Mektubu gönderildiği gibi işaretlersiniz.
-            - Mektubu gönderildiği şekilde işaretledikten sonra, kullanıcı kodu tanıtabilir ve doğrulanabilir.
-      direct: direkt
-      help: yardım et
+          help: '["Users request a verification code to be sent to their address.", "You send the letter to their address with the verification code.", "You mark the letter as sent.", "Once you mark the letter as sent, the user will be able to introduce the code and get verified."]'
+      direct: Direct
+      help: Help
       id_documents:
-        explanation: Kimlik belgelerinizi yükleyin, böylece kimliğinizi kontrol edebiliriz
-        name: Kimlik belgeleri
-      multistep: Çok Adım
-      name: isim
+        explanation: Upload your identity documents so we can check your identity
+        name: Identity documents
+      multistep: Multi-Step
+      name: Name
       postal_letter:
-        explanation: Size adresinizi doğrulayabilmemiz için girmeniz gereken bir kod içeren bir posta mektubu göndereceğiz.
-        name: Posta mektubu ile kod
+        explanation: We'll send you a postal letter with a code that you'll have to enter so we can verify your address
+        name: Code by postal letter
     verifications:
       authorizations:
         create:
-          error: Yetkilendirme oluşturulurken bir hata oluştu.
-          success: Başarılı bir şekilde yetkilendirildiniz.
-          unconfirmed: Kendinizi yetkilendirmek için e-postanızı onaylamanız gerekiyor.
+          error: There was an error creating the authorization.
+          success: You've been successfully authorized.
+          unconfirmed: You need to confirm your email in order to authorize yourself.
         first_login:
           actions:
-            another_dummy_authorization_handler: Başka bir yetkilendirme işleyicisi örneğiyle doğrulayın
-            dummy_authorization_handler: Örnek yetkilendirme işleyicisine karşı doğrulayın
-            dummy_authorization_workflow: Örnek yetkilendirme iş akışına karşı doğrulayın
-            id_documents: Kimlik belgenizi yükleyerek doğrulanma
-            postal_letter: Posta koduyla doğrulama kodu alarak doğrulanma
-          title: Kimliginizi dogrulayin
-          verify_with_these_options: 'Bunlar kimliğinizi doğrulamak için kullanılabilecek seçenekler:'
+            another_dummy_authorization_handler: Verify against another example of authorization handler
+            dummy_authorization_handler: Verify against the example authorization handler
+            dummy_authorization_workflow: Verify against the example authorization workflow
+            id_documents: Get verified by uploading your identity document
+            postal_letter: Get verified by receiving a verification code through postal mail
+          title: Verify your identity
+          verify_with_these_options: 'These are the available options to verify your identity:'
         new:
-          authorize: göndermek
-          authorize_with: '%{authorizer}ile doğrulayın'
-        skip_verification: Bunu şimdilik ve %{link}için atlayabilirsiniz.
-        start_exploring: keşfetmeye başla
+          authorize: Send
+          authorize_with: Verify with %{authorizer}
+        skip_verification: You can skip this for now and %{link}
+        start_exploring: start exploring
       dummy_authorization:
         extra_explanation:
-          one: Katılım, posta kodu %{postal_codes}olan kullanıcılarla sınırlıdır.
-          other: 'Katılım, aşağıdaki posta kodlarından herhangi biriyle kullanıcılarla sınırlıdır: %{postal_codes}.'
+          one: Participation is restricted to users with the postal code %{postal_codes}.
+          other: 'Participation is restricted to users with any of the following postal codes: %{postal_codes}.'
       id_documents:
         admin:
           config:
             edit:
-              title: Kimlik belgeleri yapılandırması
-              update: Güncelleştirme
+              title: Identity documents configuration
+              update: Update
             update:
-              error: Yapılandırma güncellenirken bir hata oluştu.
-              success: Yapılandırma başarıyla güncellendi
+              error: There was an error updating the configuration.
+              success: Configuration successfully updated
           confirmations:
             create:
-              error: Doğrulama uyuşmuyor. Tekrar deneyebilir veya doğrulamayı reddedebilir, böylece kullanıcı bunu değiştirebilir
-              success: Kullanıcı başarıyla doğrulandı
+              error: Verification doesn't match. Try again or reject the verification so the user can amend it
+              success: User successfully verified
             new:
-              introduce_user_data: Resimdeki verileri tanıtın
-              reject: reddetmek
-              verify: DOĞRULAYIN
+              introduce_user_data: Introduce the data in the picture
+              reject: Reject
+              verify: Verify
           offline_confirmations:
             create:
-              error: Doğrulama uyuşmuyor. Tekrar dene veya kullanıcıyı değiştirmesini söyle
-              success: Kullanıcı başarıyla doğrulandı
+              error: Verification doesn't match. Try again or tell the user to amend it
+              success: User successfully verified
             new:
-              cancel: İptal etmek
-              introduce_user_data: Kullanıcı e-postasını ve belge verilerini tanıtın
-              verify: DOĞRULAYIN
+              cancel: Cancel
+              introduce_user_data: Introduce the user email and the document data
+              verify: Verify
           pending_authorizations:
             index:
-              config: Yapılandırma
-              offline_verification: Çevrimdışı doğrulama
-              title: Bekleyen çevrimiçi doğrulamalar
-              verification_number: 'Doğrulama #%{n}'
+              config: Config
+              offline_verification: Offline verification
+              title: Pending online verifications
+              verification_number: 'Verification #%{n}'
           rejections:
             create:
-              success: Doğrulama reddedildi. Kullanıcı dokümanlarını değiştirmek için istenecektir
+              success: Verification rejected. User will be prompted to amend her documents
         authorizations:
           choose:
-            choose_a_type: "Lütfen nasıl doğrulanmak istediğinizi seçin:"
-            offline: Çevrimdışı
-            online: İnternet üzerinden
-            title: Kimlik belgenizi kullanarak kendinizi doğrulayın
+            choose_a_type: 'Please select how you want to be verified:'
+            offline: Offline
+            online: Online
+            title: Verify yourself using your identity document
           create:
-            error: Belgenizi yüklerken bir sorun oluştu
-            success: Belge başarıyla yüklendi
+            error: There was a problem uploading your document
+            success: Document uploaded successfully
           edit:
-            being_reviewed: Belgelerini inceliyoruz. Kısa bir süre sonra doğrulanacaksınız
-            offline: Çevrimdışı doğrulamayı kullan
-            online: Çevrimiçi doğrulamayı kullan
-            rejection_clarity: Yüklenen görselde bilgilerin net bir şekilde göründüğünden emin olun.
-            rejection_correctness: Girilen bilgilerin doğru olduğundan emin olun.
-            rejection_notice: Doğrulamanızla ilgili bir sorun oluştu. Lütfen tekrar deneyin
-            send: Doğrulamayı tekrar isteyin
+            being_reviewed: We're reviewing your documents. You'll be verified shortly
+            offline: Use offline verification
+            online: Use online verification
+            rejection_clarity: Make sure the information is clearly visible in the uploaded image
+            rejection_correctness: Make sure the information entered is correct
+            rejection_notice: There was a problem with your verification. Please try again
+            send: Request verification again
           new:
-            send: Doğrulama isteğinde bulun
-            title: Kimlik belgenizi yükleyin
+            send: Request verification
+            title: Upload your identity document
           update:
-            error: Belgenizi yeniden yüklerken bir sorun oluştu
-            success: Belge başarıyla yeniden yüklendi
+            error: There was a problem reuploading your document
+            success: Document reuploaded successfully
         dni: DNI
         nie: NIE
-        passport: Pasaport
+        passport: Passport
       postal_letter:
         admin:
           pending_authorizations:
             index:
-              address: Adres
-              letter_sent_at: Gönderdiği mektup
-              mark_as_sent: Gönderildiği gibi işaretle
-              not_yet_sent: Henüz gönderilmedi
-              title: Devam eden doğrulamalar
-              username: Kullanıcı adı
-              verification_code: Doğrulama kodu
+              address: Address
+              letter_sent_at: Letter sent at
+              mark_as_sent: Mark as sent
+              not_yet_sent: Not yet sent
+              title: Ongoing verifications
+              username: Username
+              verification_code: Verification code
           postages:
             create:
-              error: Gönderilen mektup işaretlenirken hata oluştu
-              success: Mektup başarıyla gönderildi olarak işaretlendi
+              error: Error marking letter as sent
+              success: Letter successfully marked as sent
         authorizations:
           create:
-            error: İsteğiniz ile ilgili bir sorun vardı
-            success: Teşekkürler! Adresinize bir doğrulama kodu göndereceğiz
+            error: There was a problem with your request
+            success: Thanks! We'll send a verification code to your address
           edit:
-            send: Onaylamak
-            title: Aldığınız doğrulama kodunu tanıtın
-            waiting_for_letter: Yakında doğrulama kodunuzla adresinize bir mektup gönderiyoruz
+            send: Confirm
+            title: Introduce the verification code you received
+            waiting_for_letter: We'll be sending a letter to your address with your verification code soon
           new:
-            send: Bana bir mektup gönder
-            title: Doğrulama kodunuzu isteyin
+            send: Send me a letter
+            title: Request your verification code
           update:
-            error: Doğrulama kodunuz bizimkilerle uyuşmuyor. Lütfen size gönderdiğimiz mektubu iki kez kontrol edin
-            success: Tebrikler. Başarıyla doğrulandı
+            error: Your verification code doesn't match ours. Please double-check the letter we sent to you
+            success: Congratulations. You've been successfully verified
       sms:
         authorizations:
           create:
-            error: İsteğiniz ile ilgili bir sorun vardı
-            success: Teşekkürler! Telefonunuza bir SMS gönderdik.
+            error: There was a problem with your request
+            success: Thanks! We've sent an SMS to your phone.
           edit:
-            send: Onaylamak
-            title: Aldığınız doğrulama kodunu tanıtın
+            send: Confirm
+            title: Introduce the verification code you received
           new:
-            send: Bana bir SMS gönder
-            title: Doğrulama kodunuzu isteyin
+            send: Send me an SMS
+            title: Request your verification code
           update:
-            error: Doğrulama kodunuz bizimkilerle uyuşmuyor. Lütfen size gönderdiğimiz SMS'i tekrar kontrol edin.
-            success: Tebrikler. Başarıyla doğrulandı.
+            error: Your verification code doesn't match ours. Please double-check the SMS we sent you.
+            success: Congratulations. You've been successfully verified.
   errors:
     messages:
-      uppercase_only_letters_numbers: tüm büyük harf olmalı ve sadece harf ve / veya sayı içermelidir
+      uppercase_only_letters_numbers: must be all uppercase and contain only letters and/or numbers

--- a/decidim-verifications/config/locales/uk.yml
+++ b/decidim-verifications/config/locales/uk.yml
@@ -102,7 +102,12 @@ uk:
               verify: Підтвердити
           offline_confirmations:
             create:
+              error: Verification doesn't match. Try again or tell the user to amend it
               success: Особу учасника успішно підтверджено
+            new:
+              cancel: Cancel
+              introduce_user_data: Introduce the user email and the document data
+              verify: Verify
           pending_authorizations:
             index:
               config: Config


### PR DESCRIPTION
* Add smtp settings to organizations

* Add Jsonb attributes

* add form to store smtp settings

* Fix trailing whitespace

* Remove smtp_settings as mandatory field

* Add attribute encyptor

* Move smpt_settings to a partial

* Encrypt smtp_settings password

* Add missing translation

* Use encrypted smtp_password

* Fix missing space inside curly braces

* Add after_action for mailers to set smtp

* Fix factory block definition

* Fix decidim-admin test

* fix register organization spec to use smtp

* Add changelog entry

* Fix trailing whitespace

* Change encrypted password logic

* Change factory smtp_settings

* fix application mailer

* Add missing translations

* Return nil on empty string

* Add jsonb_attribute types

* Change mailer settings merge

* Remove unnecesary variable

* Use new jsonb_attributes with type

* Fix codeclimate issues

* Fix jsonb_attributes spec

* fix style

* Reject empty values from SMTP settings

* Fix changelog

* Normalize locales

* Add changelog entry

* Remove byebug

#### :pushpin: Related Issues
- Related to #669 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add tests
