### PR TITLE
Inverse blocks on login modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Upgrade note:
 
 **Changed**:
 
+- **decidim-core**: Inverse blocks on the login modal so the user experience is more intuitive. [\#730](https://github.com/OpenSourcePolitics/decidim/pull/730)
 - **decidim-budgets**: Improve the display of budget voting [\#509](https://github.com/OpenSourcePolitics/decidim/pull/509)
 - **decidim-admin**: Change admin moderations manager [\#4717](https://github.com/decidim/decidim/pull/4717)
 - **decidim-proposals** Allow to change participatory texts title without uploading file. [\#4801](https://github.com/decidim/decidim/pull/4801)

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons_mini.html.erb
@@ -1,9 +1,6 @@
 <% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
   <div class="row">
     <div class="columns medium-8 medium-centered">
-      <span class="register__separator">
-        <span class="register__separator__text"><%= t("or", scope: "decidim.devise.shared.omniauth_buttons") %></span>
-      </span>
       <div class="text-center">
         <%- Decidim::User.omniauth_providers.each do |provider| %>
           <% if social_provider_enabled? provider %>
@@ -15,6 +12,9 @@
           <% end %>
         <% end %>
       </div>
+      <span class="register__separator">
+        <span class="register__separator__text"><%= t("or", scope: "decidim.devise.shared.omniauth_buttons") %></span>
+      </span>
     </div>
   </div>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -2,37 +2,37 @@
   <div class="reveal__header">
     <h3 class="reveal__title"><%= t(".please_sign_in") %></h3>
     <button class="close-button" data-close aria-label="Close modal"
-      type="button">
+            type="button">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <% if current_organization.sign_in_enabled? %>
+    <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
     <div class="row">
       <div class="columns medium-8 medium-centered">
-          <%= decidim_form_for(Decidim::User.new, as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
-            <div>
-              <div class="field">
-                <%= f.email_field :email, autofocus: true %>
-              </div>
-              <div class="field">
-                <%= f.password_field :password, autocomplete: "off" %>
-              </div>
+        <%= decidim_form_for(Decidim::User.new, as: :user, url: session_path(:user), html: { class: "register-form new_user" }) do |f| %>
+          <div>
+            <div class="field">
+              <%= f.email_field :email, autofocus: true %>
             </div>
-            <div class="actions">
-              <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+            <div class="field">
+              <%= f.password_field :password, autocomplete: "off" %>
             </div>
-          <% end %>
-          <% if current_organization.sign_up_enabled? %>
-            <p class="text-center">
-              <%= link_to t(".sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
-            </p>
-          <% end %>
+          </div>
+          <div class="actions">
+            <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+          </div>
+        <% end %>
+        <% if current_organization.sign_up_enabled? %>
           <p class="text-center">
-            <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(:user) %>
+            <%= link_to t(".sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
           </p>
+        <% end %>
+        <p class="text-center">
+          <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(:user) %>
+        </p>
       </div>
     </div>
-    <%= render "decidim/devise/shared/omniauth_buttons_mini" %>
   <% else %>
     <div class="row">
       <div class="columns medium-8 medium-centered">


### PR DESCRIPTION
#### :tophat: What? Why?
Inverse blocks on the login modal so the user experience is more intuitive.

#### :pushpin: Related Issues
- Fixes #722

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
<img width="670" alt="Capture d’écran 2019-07-01 à 13 51 46" src="https://user-images.githubusercontent.com/20232956/60435054-de043580-9c08-11e9-8795-bf30ce61f224.png">

### :ghost: GIF (optional)
![Description](https://media.giphy.com/media/3oEjHYX9are0lyAtG0/giphy.gif)
