### PR TITLE
Surveys for unregistered users (#4996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ end
 - **decidim-system**: Add custom SMTP settings for multitenant [#4698](https://github.com/decidim/decidim/pull/4698)
 - **decidim-proposals**: Add proposal answers to the proposal export [#5139](https://github.com/decidim/decidim/pull/5139)
 - **decidim-core**: Provide "good" password rules [#5106](https://github.com/decidim/decidim/pull/5106)
+- **decidim-surveys**: Added a setting to surveys to allow unregistered (aka: anonymous) users to answer a survey. [\#4996](https://github.com/decidim/decidim/pull/4996)
 
 **Changed**:
 

--- a/decidim-budgets/config/locales/fr.yml
+++ b/decidim-budgets/config/locales/fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   activemodel:
     attributes:
@@ -140,7 +141,7 @@ fr:
         project:
           add: Ajouter
           count:
-            one: '%{count} vote'
+            one: "%{count} vote"
             other: "%{count} votes"
           remove: Supprimer
           view: Voir
@@ -193,7 +194,7 @@ fr:
         success: Votre vote a été annulé avec succès
     resource_links:
       included_proposals:
-        project_proposal: 'Propositions inspirant le projet'
+        project_proposal: Propositions inspirant le projet
   index:
     confirmed_orders_count: Nombre de votes
   total_budget: Budget total

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -24,16 +24,20 @@ module Decidim
         broadcast(:ok)
       end
 
+      attr_reader :form
+
       private
 
       def answer_questionnaire
         Answer.transaction do
-          @form.answers.each do |form_answer|
+          form.answers.each do |form_answer|
             answer = Answer.new(
               user: @current_user,
               questionnaire: @questionnaire,
               question: form_answer.question,
-              body: form_answer.body
+              body: form_answer.body,
+              session_token: form.context.session_token,
+              ip_hash: form.context.ip_hash
             )
 
             form_answer.selected_choices.each do |choice|

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -8,7 +8,9 @@ module Decidim
       attribute :user_group_id, Integer
 
       attribute :tos_agreement, Boolean
+
       validates :tos_agreement, allow_nil: false, acceptance: true
+      validate :session_token_in_context
 
       # Private: Create the answers from the questionnaire questions
       #
@@ -17,6 +19,12 @@ module Decidim
         self.answers = model.questions.map do |question|
           AnswerForm.from_model(Decidim::Forms::Answer.new(question: question))
         end
+      end
+
+      def session_token_in_context
+        return if context&.session_token
+
+        errors.add(:tos_agreement, I18n.t("activemodel.errors.models.questionnaire.request_invalid"))
       end
     end
   end

--- a/decidim-forms/app/models/decidim/forms/answer.rb
+++ b/decidim-forms/app/models/decidim/forms/answer.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::DataPortability
       include Decidim::NewsletterParticipant
 
-      belongs_to :user, class_name: "Decidim::User", foreign_key: "decidim_user_id"
+      belongs_to :user, class_name: "Decidim::User", foreign_key: "decidim_user_id", optional: true
       belongs_to :questionnaire, class_name: "Questionnaire", foreign_key: "decidim_questionnaire_id"
       belongs_to :question, class_name: "Question", foreign_key: "decidim_question_id"
 
@@ -45,7 +45,7 @@ module Decidim
       private
 
       def user_questionnaire_same_organization
-        return if user&.organization == questionnaire.questionnaire_for&.organization
+        return if user.nil? || user&.organization == questionnaire.questionnaire_for&.organization
 
         errors.add(:user, :invalid)
       end

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -16,7 +16,8 @@ module Decidim
 
       # Public: returns whether the questionnaire is answered by the user or not.
       def answered_by?(user)
-        answers.where(user: user).any? if questions.present?
+        query = user.is_a?(String) ? { session_token: user } : { user: user }
+        answers.where(query).any? if questions.present?
       end
     end
   end

--- a/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
+++ b/decidim-forms/app/queries/decidim/forms/questionnaire_user_answers.rb
@@ -21,7 +21,7 @@ module Decidim
       # Finds and group answers by user for each questionnaire's question.
       def query
         answers = Answer.where(questionnaire: @questionnaire)
-        answers.sort_by { |answer| answer.question.position }.group_by(&:user).values
+        answers.sort_by { |answer| answer.question.position }.group_by { |a| a.user || a.session_token }.values
       end
     end
   end

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -19,8 +19,8 @@
     <div class="card">
       <div class="card__content">
         <% if allow_answers? %>
-          <% if current_user %>
-            <% if questionnaire.answered_by?(current_user) %>
+          <% if visitor_can_answer? %>
+            <% if visitor_already_answered? %>
               <div class="section">
                 <div class="callout success">
                   <h5><%= t(".questionnaire_answered.title") %></h5>
@@ -39,6 +39,7 @@
                 <% end %>
 
                 <%= decidim_form_for(@form, url: update_url, method: :post, html: { class: "form answer-questionnaire" }) do |form| %>
+                  <%= invisible_captcha %>
                   <% @form.answers.each_with_index do |answer, answer_idx| %>
                     <div class="row column">
                       <%= fields_for "questionnaire[answers][#{answer_idx}]", answer do |answer_form| %>

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
             choices:
               missing: are not complete
               too_many: are too many
+        questionnaire:
+          request_invalid: There's been an error handling the request. Please try again
   decidim:
     forms:
       admin:
@@ -81,3 +83,7 @@ en:
       user_answers_serializer:
         created_at: Answered on
         id: Answer ID
+        ip_hash: Ip Hash
+        registered: Registered
+        unregistered: Unregistered
+        user_status: User status

--- a/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
+++ b/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddSessionTokenToDecidimFormsAnswers < ActiveRecord::Migration[5.2]
+  class Answer < ApplicationRecord
+    self.table_name = :decidim_forms_answers
+  end
+
+  def change
+    add_column :decidim_forms_answers, :session_token, :string, null: false, default: ""
+    add_index :decidim_forms_answers, :session_token
+
+    Answer.find_each do |answer|
+      answer.session_token = Digest::MD5.hexdigest("#{answer.decidim_user_id}-#{Rails.application.secrets.secret_key_base}")
+      answer.save!
+    end
+  end
+end

--- a/decidim-forms/db/migrate/20190930094710_add_ip_hash_to_decidim_form_answers.rb
+++ b/decidim-forms/db/migrate/20190930094710_add_ip_hash_to_decidim_form_answers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIpHashToDecidimFormAnswers < ActiveRecord::Migration[5.2]
+  class Answer < ApplicationRecord
+    self.table_name = :decidim_forms_answers
+  end
+
+  def change
+    add_column :decidim_forms_answers, :ip_hash, :string
+    add_index :decidim_forms_answers, :ip_hash
+  end
+end

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -18,6 +18,8 @@ module Decidim
           serialized.update(
             answer_translated_attribute_name(:id) => answer.id,
             answer_translated_attribute_name(:created_at) => answer.created_at.to_s(:db),
+            answer_translated_attribute_name(:ip_hash) => answer.ip_hash,
+            answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer.decidim_user_id.present? ? "registered" : "unregistered"),
             "#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer)
           )
         end

--- a/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
@@ -6,11 +6,18 @@ module Decidim
   module Forms
     describe QuestionnaireForm do
       subject do
-        described_class.from_model(questionnaire)
+        described_class.from_model(questionnaire).with_context(context)
       end
 
       let!(:questionnaire) { create(:questionnaire) }
       let!(:question) { create(:questionnaire_question, questionnaire: questionnaire) }
+      let(:current_user) { create(:user) }
+      let(:session_token) { "some-token" }
+      let(:context) do
+        {
+          session_token: session_token
+        }
+      end
 
       it "builds empty answers for each question" do
         expect(subject.answers.length).to eq(1)
@@ -20,12 +27,22 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
-      context "when tos_agreement is not accepted" do
+      context "when tos_agreement is accepted" do
         before do
           subject.tos_agreement = true
         end
 
-        it { is_expected.to be_valid }
+        context "and no token is present" do
+          let(:session_token) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "and token is present" do
+          let(:ip_hash) { nil }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       def answer
         enforce_permission_to :join, :meeting, meeting: meeting
 
-        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params)
+        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token: session_token)
 
         JoinMeeting.call(meeting, current_user, @form) do
           on(:ok) do

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -201,7 +201,8 @@ module Decidim::Meetings
     context "when the registration form is a questionnaire" do
       let!(:questionnaire) { create(:questionnaire) }
       let!(:question) { create(:questionnaire_question, questionnaire: questionnaire) }
-      let(:registration_form) { Decidim::Forms::QuestionnaireForm.from_model(questionnaire) }
+      let(:session_token) { "some-token" }
+      let(:registration_form) { Decidim::Forms::QuestionnaireForm.from_model(questionnaire).with_context(session_token: session_token) }
 
       context "and the registration form is invalid" do
         it "broadcast invalid_form" do

--- a/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::Forms::Concerns::HasQuestionnaire
       helper Decidim::Surveys::SurveyHelper
 
-      delegate :allow_answers?, to: :current_settings
+      delegate :allow_answers?, :allow_unregistered?, to: :current_settings
 
       before_action :check_permissions
 

--- a/decidim-surveys/app/permissions/decidim/surveys/permissions.rb
+++ b/decidim-surveys/app/permissions/decidim/surveys/permissions.rb
@@ -4,7 +4,7 @@ module Decidim
   module Surveys
     class Permissions < Decidim::DefaultPermissions
       def permissions
-        return permission_action unless user
+        return permission_action unless user || context[:current_settings].allow_unregistered?
 
         return Decidim::Surveys::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
         return permission_action if permission_action.scope != :public

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
             announcement: Announcement
           step:
             allow_answers: Allow answers
+            allow_unregistered: Allow unregistered users to answer the survey
+            allow_unregistered_help: If active, no login will be required in order to answer the survey. This may lead to poor or unreliable data and it will be more vulnerable to automated attacks. Use with caution!
             announcement: Announcement
     events:
       surveys:
@@ -54,4 +56,5 @@ en:
       surveys:
         answer:
           invalid: There was a problem answering the survey.
+          spam_detected: There was a problem answering the form. Maybe you've been too quick, can you try again?
           success: Survey successfully answered.

--- a/decidim-surveys/config/locales/fr.yml
+++ b/decidim-surveys/config/locales/fr.yml
@@ -23,6 +23,7 @@ fr:
             announcement: Annonce
           step:
             allow_answers: Autoriser les réponses
+            allow_unregistered: Autoriser les utilisateurs non enregistrés à répondre
             announcement: Annonce
     events:
       surveys:

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -44,7 +44,7 @@ Decidim.register_component(:surveys) do |component|
     answers = Decidim::Forms::Answer.where(questionnaire: surveys.map(&:questionnaire))
     answers = answers.where("created_at >= ?", start_at) if start_at.present?
     answers = answers.where("created_at <= ?", end_at) if end_at.present?
-    answers.group(:decidim_user_id).count.size
+    answers.group(:session_token).count.size
   end
 
   # These actions permissions can be configured in the admin panel
@@ -56,6 +56,7 @@ Decidim.register_component(:surveys) do |component|
 
   component.settings(:step) do |settings|
     settings.attribute :allow_answers, type: :boolean, default: false
+    settings.attribute :allow_unregistered, type: :boolean, default: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
   end
 

--- a/decidim-surveys/spec/system/unregistered_user_survey_spec.rb
+++ b/decidim-surveys/spec/system/unregistered_user_survey_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Answer a survey", type: :system do
+  InvisibleCaptcha.honeypots = [:honeypot_id]
+  InvisibleCaptcha.visual_honeypots = true
+
+  let(:manifest_name) { "surveys" }
+
+  let(:title) do
+    {
+      "en" => "Survey's title",
+      "ca" => "Títol de l'enquesta'",
+      "es" => "Título de la encuesta"
+    }
+  end
+  let(:description) do
+    {
+      "en" => "<p>Survey's content</p>",
+      "ca" => "<p>Contingut de l'enquesta</p>",
+      "es" => "<p>Contenido de la encuesta</p>"
+    }
+  end
+  let!(:questionnaire) { create(:questionnaire, title: title, description: description) }
+  let!(:survey) { create(:survey, component: component, questionnaire: questionnaire) }
+  let!(:question) { create(:questionnaire_question, questionnaire: questionnaire, position: 0) }
+
+  include_context "with a component"
+
+  context "when the survey doesn't allow answers" do
+    it "does not allow answering the survey" do
+      visit_component
+
+      expect(page).to have_i18n_content(questionnaire.title, upcase: true)
+      expect(page).to have_i18n_content(questionnaire.description)
+
+      expect(page).to have_no_i18n_content(question.body)
+
+      expect(page).to have_content("The form is closed and cannot be answered.")
+    end
+  end
+
+  context "when the survey allow answers" do
+    before do
+      component.update!(
+        step_settings: {
+          component.participatory_space.active_step.id => {
+            allow_answers: true,
+            allow_unregistered: true
+          }
+        }
+      )
+    end
+
+    it "allows answering the questionnaire" do
+      visit_component
+
+      expect(page).to have_i18n_content(questionnaire.title, upcase: true)
+      expect(page).to have_i18n_content(questionnaire.description)
+
+      fill_in question.body["en"], with: "My first answer"
+
+      check "questionnaire_tos_agreement"
+
+      accept_confirm { click_button "Submit" }
+
+      within ".success.flash" do
+        expect(page).to have_content("successfully")
+      end
+
+      # Unregistered users are tracked with their session_id so they won't be allowed to repeat easily
+      expect(page).to have_content("You have already answered this form.")
+      expect(page).to have_no_i18n_content(question.body)
+    end
+
+    context "and honeypot is filled" do
+      it "fails with spam complain" do
+        visit_component
+        fill_in question.body["en"], with: "My first answer"
+        fill_in "honeypot_id", with: "I am a robot"
+
+        check "questionnaire_tos_agreement"
+
+        accept_confirm { click_button "Submit" }
+
+        within ".alert.flash" do
+          expect(page).to have_content("problem")
+        end
+      end
+    end
+
+    def questionnaire_public_path
+      main_component_path(component)
+    end
+  end
+end


### PR DESCRIPTION
* Add allow_unregistered option to surveys component

* locales for allow_unregistered settings action

* relax permissions to allow answers withou users

* Add session token to answer for grouping anonymous answers

* check if an unregistered user has already answered the questionnaire

* add unregistered users test

* rubocop happiness

* change test to match new locale messages

* add changelog entry [ci skip]

* unregisterd users settings warning

* add ip hash to unregistered surveys

* add invisible_captcha to forms

* Add user status to answers export

* remove unused key

* avoid NULL column

* use current instead of now

* refactor questionnaire validation for unregistered users

* simplify questionnaire validation and fix meetings reuse

* fix meetings tests