### PR TITLE
Add a "Return" button in the FO to get back to indexes

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -1,4 +1,10 @@
 <div class="row accountability result-view">
+
+  <%= link_to :back, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back_from_child") %>
+  <% end %>
+
   <div class="small-12 columns">
     <%= render partial: "decidim/accountability/results/nav_breadcrumb", locals: { category: result.parent.try(:category) || result.category } %>
   </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -1,6 +1,6 @@
 <div class="row accountability result-view">
 
-  <%= link_to :back, class: "muted-link" do %>
+  <%= link_to result.parent, class: "muted-link" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back_from_child") %>
   <% end %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -1,10 +1,5 @@
 <div class="row accountability result-view">
 
-  <%= link_to result.parent, class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small" %>
-    <%= t(".back_from_child") %>
-  <% end %>
-
   <div class="small-12 columns">
     <%= render partial: "decidim/accountability/results/nav_breadcrumb", locals: { category: result.parent.try(:category) || result.category } %>
   </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
@@ -1,4 +1,10 @@
 <div class="row accountability result-view">
+
+  <%= link_to :results, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
+
   <div class="small-12 columns">
     <%= render partial: "decidim/accountability/results/nav_breadcrumb", locals: { category: result.try(:category) } %>
   </div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
@@ -1,6 +1,6 @@
 <div class="row accountability result-view">
 
-  <%= link_to :results, class: "muted-link" do %>
+  <%= link_to results_path(filter: { category_id: result.try(:category), scope_id: current_scope }), class: "muted-link" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_show_parent.html.erb
@@ -1,10 +1,5 @@
 <div class="row accountability result-view">
 
-  <%= link_to results_path(filter: { category_id: result.try(:category), scope_id: current_scope }), class: "muted-link" do %>
-    <%= icon "chevron-left", class: "icon--small" %>
-    <%= t(".back") %>
-  <% end %>
-
   <div class="small-12 columns">
     <%= render partial: "decidim/accountability/results/nav_breadcrumb", locals: { category: result.try(:category) } %>
   </div>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -155,10 +155,6 @@ en:
           global: Global execution
         search:
           search: Search for actions
-        show_parent:
-          back: Back to list
-        show_leaf:
-          back_from_child: Back to parent
         show:
           back: Back to list
           back_from_child: Back to parent
@@ -178,6 +174,10 @@ en:
             version_number: Version number
             version_number_out_of_total: "%{current_version} out of %{total_count}"
             votes: Supports
+        show_leaf:
+          back_from_child: Back to parent
+        show_parent:
+          back: Back to list
         timeline:
           title: Project evolution
       versions:

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -155,7 +155,13 @@ en:
           global: Global execution
         search:
           search: Search for actions
+        show_parent:
+          back: Back to list
+        show_leaf:
+          back_from_child: Back to parent
         show:
+          back: Back to list
+          back_from_child: Back to parent
           stats:
             attendees: Attendees
             back_to_result: Go back to result

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -172,10 +172,6 @@ en:
             version_number: Version number
             version_number_out_of_total: "%{current_version} out of %{total_count}"
             votes: Supports
-        show_leaf:
-          back_from_child: Back to parent
-        show_parent:
-          back: Back to list
         timeline:
           title: Project evolution
       versions:

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -156,8 +156,6 @@ en:
         search:
           search: Search for actions
         show:
-          back: Back to list
-          back_from_child: Back to parent
           stats:
             attendees: Attendees
             back_to_result: Go back to result

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -95,6 +95,7 @@ describe "Explore results", versioning: true, type: :system do
 
   describe "show" do
     let(:path) { decidim_participatory_process_accountability.result_path(id: result.id, participatory_process_slug: participatory_process.slug, component_id: component.id) }
+
     let(:results_count) { 1 }
     let(:result) { results.first }
 
@@ -103,6 +104,55 @@ describe "Explore results", versioning: true, type: :system do
       expect(page).to have_i18n_content(result.description)
       expect(page).to have_content(result.reference)
       expect(page).to have_content("#{result.progress.to_i}%")
+    end
+
+    context "when result has children" do
+      let(:back_path) do
+        decidim_participatory_process_accountability.results_path(
+          participatory_process_slug: participatory_process.slug, component_id: component.id, filter: { category_id: category.id, scope_id: scope.id }
+        )
+      end
+
+      it "shows a back to parent link" do
+        byebug
+        expect(page).to have_link(class: "muted-link", href: back_path)
+      end
+
+      context "when clicking back to parent link" do
+        before do
+          click_link(class: "muted-link", href: back_path)
+        end
+
+        it "redirect the user to parent result" do
+          expect(page).to redirect_to back_path
+        end
+      end
+
+    end
+
+    context "when result has no children" do
+      let(:back_path) { decidim_participatory_process_accountability.result_path(id: result.parent, participatory_process_slug: participatory_process.slug, component_id: component.id) }
+
+      let(:results_count) { 2 }
+      let(:result_parent) { results[1] }
+
+      before do
+        result.parent = result_parent
+      end
+
+      it "shows a 'Back to list' link" do
+        expect(page).to have_link(class: "muted-link", href: back_path)
+      end
+
+      context "when clicking 'back to list' link" do
+        before do
+          click_link(class: "muted-link", href: back_path)
+        end
+
+        it "redirect the user to parent result" do
+          expect(page).to redirect_to back_path
+        end
+      end
     end
 
     context "when it has no versions" do

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -106,55 +106,6 @@ describe "Explore results", versioning: true, type: :system do
       expect(page).to have_content("#{result.progress.to_i}%")
     end
 
-    context "when result has children" do
-      let(:back_path) do
-        decidim_participatory_process_accountability.results_path(
-          participatory_process_slug: participatory_process.slug, component_id: component.id, filter: { category_id: category.id, scope_id: scope.id }
-        )
-      end
-
-      it "shows a back to parent link" do
-        byebug
-        expect(page).to have_link(class: "muted-link", href: back_path)
-      end
-
-      context "when clicking back to parent link" do
-        before do
-          click_link(class: "muted-link", href: back_path)
-        end
-
-        it "redirect the user to parent result" do
-          expect(page).to redirect_to back_path
-        end
-      end
-
-    end
-
-    context "when result has no children" do
-      let(:back_path) { decidim_participatory_process_accountability.result_path(id: result.parent, participatory_process_slug: participatory_process.slug, component_id: component.id) }
-
-      let(:results_count) { 2 }
-      let(:result_parent) { results[1] }
-
-      before do
-        result.parent = result_parent
-      end
-
-      it "shows a 'Back to list' link" do
-        expect(page).to have_link(class: "muted-link", href: back_path)
-      end
-
-      context "when clicking 'back to list' link" do
-        before do
-          click_link(class: "muted-link", href: back_path)
-        end
-
-        it "redirect the user to parent result" do
-          expect(page).to redirect_to back_path
-        end
-      end
-    end
-
     context "when it has no versions" do
       before do
         result.versions.destroy_all

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -18,7 +18,7 @@
   <div class="columns medium-7 mediumlarge-8">
     <div class="row column view-header">
 
-      <%= link_to :posts, class: "muted-link" do %>
+      <%= link_to :posts, class: "title-action__action button small hollow" do %>
         <%= icon "chevron-left", class: "icon--small" %>
         <%= t(".back") %>
       <% end %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -17,6 +17,12 @@
 <div class="row">
   <div class="columns medium-7 mediumlarge-8">
     <div class="row column view-header">
+
+      <%= link_to :posts, class: "muted-link" do %>
+        <%= icon "chevron-left", class: "icon--small" %>
+        <%= t(".back") %>
+      <% end %>
+
       <h2 class="heading2"><%= translated_attribute post.title %></h2>
       <%= cell "decidim/author", present(post.author), from: post %>
     </div>

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
             title: title
       posts:
         show:
+          back: Back to list
           view: View
         sidebar_blog:
           comments: comments

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -68,14 +68,10 @@ en:
     events:
       blogs:
         post_created:
-          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}"
-            that you are following.
-          email_outro: You have received this notification because you are following
-            "%{participatory_space_title}". You can unfollow it from the previous
-            link.
+          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New post published in %{participatory_space_title}
-          notification_title: The post <a href="%{resource_path}">%{resource_title}</a>
-            has been published in %{participatory_space_title}
+          notification_title: The post <a href="%{resource_path}">%{resource_title}</a> has been published in %{participatory_space_title}
     pages:
       home:
         statistics:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -68,10 +68,14 @@ en:
     events:
       blogs:
         post_created:
-          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}" that you are following.
-          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_intro: The post "%{resource_title}" has been published in "%{participatory_space_title}"
+            that you are following.
+          email_outro: You have received this notification because you are following
+            "%{participatory_space_title}". You can unfollow it from the previous
+            link.
           email_subject: New post published in %{participatory_space_title}
-          notification_title: The post <a href="%{resource_path}">%{resource_title}</a> has been published in %{participatory_space_title}
+          notification_title: The post <a href="%{resource_path}">%{resource_title}</a>
+            has been published in %{participatory_space_title}
     pages:
       home:
         statistics:

--- a/decidim-blogs/config/locales/fr.yml
+++ b/decidim-blogs/config/locales/fr.yml
@@ -49,6 +49,7 @@ fr:
             title: titre
       posts:
         show:
+          back: Retourner à la liste
           view: Voir
         sidebar_blog:
           comments: Commentaires

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -50,7 +50,6 @@ describe "Explore posts", type: :system do
     it "shows the back button" do
       expect(page).to have_link(href: "#{main_component_path(component)}posts")
     end
-
   end
 
   describe "most commented" do

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -47,6 +47,10 @@ describe "Explore posts", type: :system do
       expect(page).to have_content(post.author.name)
       expect(page).to have_content(post.created_at.day)
     end
+    it "shows the back button" do
+      expect(page).to have_link(href: "#{main_component_path(component)}posts")
+    end
+
   end
 
   describe "most commented" do

--- a/decidim-budgets/config/locales/fr.yml
+++ b/decidim-budgets/config/locales/fr.yml
@@ -150,7 +150,7 @@ fr:
           added: Vous avez déjà voté
         show:
           budget: Budget
-          view_all_projects: Voir tous les projets
+          view_all_projects: Retourner à la liste
     components:
       budgets:
         actions:

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -14,6 +14,10 @@
 %>
 
 <div class="row column view-header">
+  <%= link_to :debates, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
   <h2 class="heading2" <%= "id=#{translate_helper_for(element: :title, model: debate)}" %>>
     <%== present(debate).title %>
   </h2>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -14,7 +14,7 @@
 %>
 
 <div class="row column view-header">
-  <%= link_to :debates, class: "muted-link" do %>
+  <%= link_to :debates, class: "title-action__action button small hollow" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -105,6 +105,8 @@ en:
           close_window: Close window
           share: Share
           share_link: Share link
+        show:
+          back: Back to list
       last_activity:
         new_debate_at_html: "<span>New debate at %{link}</span>"
       models:

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -69,8 +69,10 @@ en:
             name: Debate
       admin_log:
         debate:
-          create: "%{user_name} created the %{resource_name} debate on the %{space_name} space"
-          update: "%{user_name} updated the %{resource_name} debate on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} debate on the %{space_name}
+            space"
+          update: "%{user_name} updated the %{resource_name} debate on the %{space_name}
+            space"
       debates:
         count:
           debates_count:
@@ -123,32 +125,46 @@ en:
             email_intro: |-
               Hi,
               A new debate "%{resource_title}" has been created on the %{space_title} participatory space, check it out and contribute:
-            email_outro: You have received this notification because you are following the %{space_title} participatory space. You can stop receiving notifications following the previous link.
+            email_outro: You have received this notification because you are following
+              the %{space_title} participatory space. You can stop receiving notifications
+              following the previous link.
             email_subject: New debate "%{resource_title}" on %{space_title}
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was created on <a href="%{space_path}">%{space_title}</a>.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              debate was created on <a href="%{space_path}">%{space_title}</a>.
           user_followers:
             email_intro: |-
               Hi,
               %{author_name} %{author_nickname}, who you are following, has created a new debate "%{resource_title}". Check it out and contribute:
-            email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+            email_outro: You have received this notification because you are following
+              %{author_nickname}. You can stop receiving notifications following the
+              previous link.
             email_subject: New debate "%{resource_title}" by %{author_nickname}
-            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> created the <a href="%{resource_path}">%{resource_title}</a> debate.
+            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+              created the <a href="%{resource_path}">%{resource_title}</a> debate.
         creation_disabled:
-          email_intro: 'Debate creation is no longer active in %{participatory_space_title}. You can still participate in open debates from this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'Debate creation is no longer active in %{participatory_space_title}.
+            You can still participate in open debates from this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Debate creation disabled in %{participatory_space_title}
           notification_title: Debate creation is now disabled in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         creation_enabled:
-          email_intro: 'You can now start new debates in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can now start new debates in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Debates now available in %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">new debates</a>
+            in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         commented_debates:
           conditions:
           - Choose an open debate to take part in
-          description: This badge is granted when you actively participate in the different debates by leaving your comments.
+          description: This badge is granted when you actively participate in the
+            different debates by leaving your comments.
           description_another: This participant has taken part in %{score} debates.
           description_own: You have participated in %{score} debates.
           name: Debates

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -69,10 +69,8 @@ en:
             name: Debate
       admin_log:
         debate:
-          create: "%{user_name} created the %{resource_name} debate on the %{space_name}
-            space"
-          update: "%{user_name} updated the %{resource_name} debate on the %{space_name}
-            space"
+          create: "%{user_name} created the %{resource_name} debate on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} debate on the %{space_name} space"
       debates:
         count:
           debates_count:
@@ -125,46 +123,32 @@ en:
             email_intro: |-
               Hi,
               A new debate "%{resource_title}" has been created on the %{space_title} participatory space, check it out and contribute:
-            email_outro: You have received this notification because you are following
-              the %{space_title} participatory space. You can stop receiving notifications
-              following the previous link.
+            email_outro: You have received this notification because you are following the %{space_title} participatory space. You can stop receiving notifications following the previous link.
             email_subject: New debate "%{resource_title}" on %{space_title}
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              debate was created on <a href="%{space_path}">%{space_title}</a>.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> debate was created on <a href="%{space_path}">%{space_title}</a>.
           user_followers:
             email_intro: |-
               Hi,
               %{author_name} %{author_nickname}, who you are following, has created a new debate "%{resource_title}". Check it out and contribute:
-            email_outro: You have received this notification because you are following
-              %{author_nickname}. You can stop receiving notifications following the
-              previous link.
+            email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
             email_subject: New debate "%{resource_title}" by %{author_nickname}
-            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
-              created the <a href="%{resource_path}">%{resource_title}</a> debate.
+            notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> created the <a href="%{resource_path}">%{resource_title}</a> debate.
         creation_disabled:
-          email_intro: 'Debate creation is no longer active in %{participatory_space_title}.
-            You can still participate in open debates from this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'Debate creation is no longer active in %{participatory_space_title}. You can still participate in open debates from this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Debate creation disabled in %{participatory_space_title}
           notification_title: Debate creation is now disabled in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         creation_enabled:
-          email_intro: 'You can now start new debates in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can now start new debates in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Debates now available in %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">new debates</a>
-            in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">new debates</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         commented_debates:
           conditions:
           - Choose an open debate to take part in
-          description: This badge is granted when you actively participate in the
-            different debates by leaving your comments.
+          description: This badge is granted when you actively participate in the different debates by leaving your comments.
           description_another: This participant has taken part in %{score} debates.
           description_own: You have participated in %{score} debates.
           name: Debates

--- a/decidim-debates/config/locales/fr.yml
+++ b/decidim-debates/config/locales/fr.yml
@@ -72,6 +72,8 @@ fr:
           create: "%{user_name} a créé le débat %{resource_name} sur l'espace %{space_name}"
           update: "%{user_name} a mis à jour le débat %{resource_name} sur l'espace %{space_name}"
       debates:
+        show:
+          back: Retourner à la liste
         count:
           debates_count:
             one: "%{count} débat"

--- a/decidim-debates/spec/system/show_spec.rb
+++ b/decidim-debates/spec/system/show_spec.rb
@@ -14,7 +14,6 @@ describe "show", type: :system do
   end
 
   context "when shows the debate component" do
-
     it "shows the debate title" do
       expect(page).to have_content debate.title[I18n.locale.to_s]
     end
@@ -22,11 +21,9 @@ describe "show", type: :system do
     it "shows the back button" do
       expect(page).to have_link(href: "#{main_component_path(component)}debates")
     end
-
   end
 
   context "when clicking the back button" do
-
     before do
       visit_component
       click_link(href: "#{main_component_path(component)}debates")
@@ -35,6 +32,5 @@ describe "show", type: :system do
     it "redirect the user to index debates" do
       expect(page).to have_current_path("#{main_component_path(component)}debates")
     end
-
   end
 end

--- a/decidim-debates/spec/system/show_spec.rb
+++ b/decidim-debates/spec/system/show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "show", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "debates" }
+
+  let!(:debate) { create(:debate, component: component) }
+
+  before do
+    visit_component
+    click_link debate.title[I18n.locale.to_s], class: "card__link"
+  end
+
+  context "when shows the debate component" do
+
+    it "shows the debate title" do
+      expect(page).to have_content debate.title[I18n.locale.to_s]
+    end
+
+    it "shows the back button" do
+      expect(page).to have_link(href: "#{main_component_path(component)}debates")
+    end
+
+  end
+
+  context "when clicking the back button" do
+
+    before do
+      visit_component
+      click_link(href: "#{main_component_path(component)}debates")
+    end
+
+    it "redirect the user to index debates" do
+      expect(page).to have_current_path("#{main_component_path(component)}debates")
+    end
+
+  end
+end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -16,7 +16,7 @@ edit_link(
 %>
 
 <div class="row column view-header">
-  <%= link_to :meetings, class: "muted-link" do %>
+  <%= link_to :meetings, class: "title-action__action button small hollow" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -16,6 +16,10 @@ edit_link(
 %>
 
 <div class="row column view-header">
+  <%= link_to :meetings, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
   <h2 class="heading2"><%= present(meeting).title(links: true) %></h2>
   <% if meeting.organizer.present? %>
     <%= cell "decidim/author", present(meeting.organizer) %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -367,6 +367,7 @@ en:
           confirm: Confirm
         show:
           attendees: Attendees count
+          back: Back to list
           contributions: Contributions count
           going: Going
           join: Join meeting

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -39,10 +39,8 @@ en:
         meeting_agenda:
           attributes:
             base:
-              too_many_minutes: The duration of the items exceed the meeting duration
-                by %{count} minutes
-              too_many_minutes_child: The duration of the item childs exceed the agenda
-                item "%{parent_title}" parent duration by %{count} minutes
+              too_many_minutes: The duration of the items exceed the meeting duration by %{count} minutes
+              too_many_minutes_child: The duration of the item childs exceed the agenda item "%{parent_title}" parent duration by %{count} minutes
         meeting_registration_invite:
           attributes:
             email:
@@ -51,8 +49,7 @@ en:
       decidim/meetings/close_meeting_event: Meeting closed
       decidim/meetings/create_meeting_event: Meeting
       decidim/meetings/meeting_registrations_enabled_event: Registrations enabled
-      decidim/meetings/meeting_registrations_over_percentage_event: Registrations
-        over limit
+      decidim/meetings/meeting_registrations_over_percentage_event: Registrations over limit
       decidim/meetings/upcoming_meeting_event: Upcoming meeting
       decidim/meetings/update_meeting_event: Meeting updated
   activerecord:
@@ -88,8 +85,7 @@ en:
             comments_max_length: Comments max length
             default_registration_terms: Default registration terms
             enable_pads_creation: Enable pads creation
-            resources_permissions_enabled: Actions permissions can be set for each
-              meeting
+            resources_permissions_enabled: Actions permissions can be set for each meeting
           step:
             announcement: Announcement
             comments_blocked: Comments blocked
@@ -97,85 +93,53 @@ en:
       meetings:
         meeting_closed:
           affected_user:
-            email_intro: 'Your meeting "%{resource_title}" was closed. You can read
-              the conclusions from its page:'
-            email_outro: You have received this notification because you organized
-              the "%{resource_title}" meeting.
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
             email_subject: The "%{resource_title}" meeting was closed
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              meeting was closed.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
           follower:
-            email_intro: 'The "%{resource_title}" meeting was closed. You can read
-              the conclusions from its page:'
-            email_outro: You have received this notification because you are following
-              the "%{resource_title}" meeting. You can unfollow it from the previous
-              link.
+            email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
+            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
             email_subject: The "%{resource_title}" meeting was closed
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              meeting was closed.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
         meeting_created:
-          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}"
-            that you are following.
-          email_outro: You have received this notification because you are following
-            "%{participatory_space_title}". You can unfollow it from the previous
-            link.
+          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New meeting added to %{participatory_space_title}
-          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a>
-            has been added to %{participatory_space_title}
+          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         meeting_registration_confirmed:
-          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a>
-            has been confirmed. Your registration code is %{registration_code}.
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
-          email_intro: The allocated slots for the "%{resource_title}" meeting are
-            over %{percentage}%.
-          email_outro: You have received this notification because you are an admin
-            of the meeting's participatory space.
-          email_subject: The allocated slots for the "%{resource_title}" meeting are
-            over %{percentage}%
-          notification_title: The allocated slots for the <a href="%{resource_path}">%{resource_title}</a>
-            meeting are over %{percentage}%.
+          email_intro: The allocated slots for the "%{resource_title}" meeting are over %{percentage}%.
+          email_outro: You have received this notification because you are an admin of the meeting's participatory space.
+          email_subject: The allocated slots for the "%{resource_title}" meeting are over %{percentage}%
+          notification_title: The allocated slots for the <a href="%{resource_path}">%{resource_title}</a> meeting are over %{percentage}%.
         meeting_updated:
-          email_intro: 'The "%{resource_title}" meeting was updated. You can read
-            the new version from its page:'
-          email_outro: You have received this notification because you are following
-            the "%{resource_title}" meeting. You can unfollow it from the previous
-            link.
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting was updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            meeting was updated.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
         registration_code_validated:
-          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}"
-            meeting has been validated.
-          email_outro: You have received this notification because your registration
-            code for the "%{resource_title}" meeting has been validated.
-          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}"
-            meeting has been validated
-          notification_title: Your registration code "%{registration_code}" for the
-            <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
+          email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
+          notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
         registrations_enabled:
-          email_intro: 'The "%{resource_title}" meeting has enabled registrations.
-            You can register yourself on its page:'
-          email_outro: You have received this notification because you are following
-            the "%{resource_title}" meeting. You can unfollow it from the previous
-            link.
+          email_intro: 'The "%{resource_title}" meeting has enabled registrations. You can register yourself on its page:'
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting has enabled registrations.
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            meeting has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting has enabled registrations.
         upcoming_meeting:
           email_intro: The "%{resource_title}" meeting will start in less than 48h.
-          email_outro: You have received this notification because you are following
-            the "%{resource_title}" meeting. You can unfollow it from the previous
-            link.
+          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting will start in less than 48h.
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            meeting will start in less than 48h.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
     gamification:
       badges:
         attended_meetings:
           conditions:
           - Register for the meetings you want to attend
-          description: This badge is granted when you attend several face-to-face
-            meetings.
+          description: This badge is granted when you attend several face-to-face meetings.
           description_another: This participant has attended %{score} meetings.
           description_own: You have attended %{score} meetings.
           name: Attended meetings
@@ -233,9 +197,7 @@ en:
         invite_join_meeting_mailer:
           invite:
             decline: Decline invitation
-            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join
-              a meeting at %{application}. You can decline or accept it through the
-              links below."
+            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join a meeting at %{application}. You can decline or accept it through the links below."
             join: Join meeting '%{meeting_title}'
         invites:
           create:
@@ -245,8 +207,7 @@ en:
             attendee_type: Attendee type
             existing_user: Existing participant
             invite: Invite
-            invite_explanation: The participant will be invited to join the meeting
-              and to the organization as well.
+            invite_explanation: The participant will be invited to join the meeting and to the organization as well.
             non_user: Non existing participant
             select_user: Select participant
           index:
@@ -258,8 +219,7 @@ en:
             filter_by: Filter by
             invite_attendee: Invite attendee
             invites: Invites
-            registrations_disabled: You can't invite an attendee because the registrations
-              are disabled.
+            registrations_disabled: You can't invite an attendee because the registrations are disabled.
             search: Search
         meeting_closes:
           edit:
@@ -337,31 +297,21 @@ en:
             success: Registration code successfully validated.
       admin_log:
         invite:
-          create: "%{user_name} invited %{attendee_name} to join %{resource_name}
-            meeting on the %{space_name} space"
-          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name}
-            meeting on the %{space_name} space"
-          update: "%{user_name} invited %{attendee_name} to join %{resource_name}
-            meeting on the %{space_name} space"
+          create: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
+          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
         meeting:
-          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name}
-            space"
-          create: "%{user_name} created the %{resource_name} meeting on the %{space_name}
-            space"
-          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name}
-            space"
-          export_registrations: "%{user_name} exported the registrations of the %{resource_name}
-            meeting on the %{space_name} space"
-          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name}
-            space"
+          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} meeting on the %{space_name} space"
+          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name} space"
+          export_registrations: "%{user_name} exported the registrations of the %{resource_name} meeting on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name} space"
           value_types:
             organizer_presenter:
               not_found: 'The organizer was not found on the database (ID: %{id})'
         minutes:
-          create: "%{user_name} created the minutes of the meeting %{resource_name}
-            on the %{space_name} space"
-          update: "%{user_name} updated the minutes of the meeting %{resource_name}
-            on the %{space_name} space"
+          create: "%{user_name} created the minutes of the meeting %{resource_name} on the %{space_name} space"
+          update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
       calendar_modal:
         calendar_url: Calendar URL
         close_window: Close window
@@ -410,10 +360,8 @@ en:
           meeting_minutes: Meeting Minutes
           related_information: Related Information
         meetings:
-          no_meetings_warning: No meetings match your search criteria or there isn't
-            any meeting scheduled.
-          upcoming_meetings_warning: Currently, there are no scheduled meetings, but
-            here you can find all the past meetings listed.
+          no_meetings_warning: No meetings match your search criteria or there isn't any meeting scheduled.
+          upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.
         registration_confirm:
           cancel: Cancel
           confirm: Confirm
@@ -457,8 +405,7 @@ en:
       read_more: "(read more)"
       registration_mailer:
         confirmation:
-          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a>
-            has been confirmed.
+          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a> has been confirmed.
           details: You will find the meeting's details in the attachment.
           registration_code: Your registration code is %{code}.
       registrations:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -39,8 +39,10 @@ en:
         meeting_agenda:
           attributes:
             base:
-              too_many_minutes: The duration of the items exceed the meeting duration by %{count} minutes
-              too_many_minutes_child: The duration of the item childs exceed the agenda item "%{parent_title}" parent duration by %{count} minutes
+              too_many_minutes: The duration of the items exceed the meeting duration
+                by %{count} minutes
+              too_many_minutes_child: The duration of the item childs exceed the agenda
+                item "%{parent_title}" parent duration by %{count} minutes
         meeting_registration_invite:
           attributes:
             email:
@@ -49,7 +51,8 @@ en:
       decidim/meetings/close_meeting_event: Meeting closed
       decidim/meetings/create_meeting_event: Meeting
       decidim/meetings/meeting_registrations_enabled_event: Registrations enabled
-      decidim/meetings/meeting_registrations_over_percentage_event: Registrations over limit
+      decidim/meetings/meeting_registrations_over_percentage_event: Registrations
+        over limit
       decidim/meetings/upcoming_meeting_event: Upcoming meeting
       decidim/meetings/update_meeting_event: Meeting updated
   activerecord:
@@ -85,7 +88,8 @@ en:
             comments_max_length: Comments max length
             default_registration_terms: Default registration terms
             enable_pads_creation: Enable pads creation
-            resources_permissions_enabled: Actions permissions can be set for each meeting
+            resources_permissions_enabled: Actions permissions can be set for each
+              meeting
           step:
             announcement: Announcement
             comments_blocked: Comments blocked
@@ -93,53 +97,85 @@ en:
       meetings:
         meeting_closed:
           affected_user:
-            email_intro: 'Your meeting "%{resource_title}" was closed. You can read the conclusions from its page:'
-            email_outro: You have received this notification because you organized the "%{resource_title}" meeting.
+            email_intro: 'Your meeting "%{resource_title}" was closed. You can read
+              the conclusions from its page:'
+            email_outro: You have received this notification because you organized
+              the "%{resource_title}" meeting.
             email_subject: The "%{resource_title}" meeting was closed
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              meeting was closed.
           follower:
-            email_intro: 'The "%{resource_title}" meeting was closed. You can read the conclusions from its page:'
-            email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+            email_intro: 'The "%{resource_title}" meeting was closed. You can read
+              the conclusions from its page:'
+            email_outro: You have received this notification because you are following
+              the "%{resource_title}" meeting. You can unfollow it from the previous
+              link.
             email_subject: The "%{resource_title}" meeting was closed
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              meeting was closed.
         meeting_created:
-          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
-          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}"
+            that you are following.
+          email_outro: You have received this notification because you are following
+            "%{participatory_space_title}". You can unfollow it from the previous
+            link.
           email_subject: New meeting added to %{participatory_space_title}
-          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
+          notification_title: The meeting <a href="%{resource_path}">%{resource_title}</a>
+            has been added to %{participatory_space_title}
         meeting_registration_confirmed:
-          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a> has been confirmed. Your registration code is %{registration_code}.
+          notification_title: Your registration for the meeting <a href="%{resource_url}">%{resource_title}</a>
+            has been confirmed. Your registration code is %{registration_code}.
         meeting_registrations_over_percentage:
-          email_intro: The allocated slots for the "%{resource_title}" meeting are over %{percentage}%.
-          email_outro: You have received this notification because you are an admin of the meeting's participatory space.
-          email_subject: The allocated slots for the "%{resource_title}" meeting are over %{percentage}%
-          notification_title: The allocated slots for the <a href="%{resource_path}">%{resource_title}</a> meeting are over %{percentage}%.
+          email_intro: The allocated slots for the "%{resource_title}" meeting are
+            over %{percentage}%.
+          email_outro: You have received this notification because you are an admin
+            of the meeting's participatory space.
+          email_subject: The allocated slots for the "%{resource_title}" meeting are
+            over %{percentage}%
+          notification_title: The allocated slots for the <a href="%{resource_path}">%{resource_title}</a>
+            meeting are over %{percentage}%.
         meeting_updated:
-          email_intro: 'The "%{resource_title}" meeting was updated. You can read the new version from its page:'
-          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_intro: 'The "%{resource_title}" meeting was updated. You can read
+            the new version from its page:'
+          email_outro: You have received this notification because you are following
+            the "%{resource_title}" meeting. You can unfollow it from the previous
+            link.
           email_subject: The "%{resource_title}" meeting was updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was updated.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            meeting was updated.
         registration_code_validated:
-          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated.
-          email_outro: You have received this notification because your registration code for the "%{resource_title}" meeting has been validated.
-          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}" meeting has been validated
-          notification_title: Your registration code "%{registration_code}" for the <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
+          email_intro: Your registration code "%{registration_code}" for the "%{resource_title}"
+            meeting has been validated.
+          email_outro: You have received this notification because your registration
+            code for the "%{resource_title}" meeting has been validated.
+          email_subject: Your registration code "%{registration_code}" for the "%{resource_title}"
+            meeting has been validated
+          notification_title: Your registration code "%{registration_code}" for the
+            <a href="%{resource_path}">%{resource_title}</a> meeting has been validated.
         registrations_enabled:
-          email_intro: 'The "%{resource_title}" meeting has enabled registrations. You can register yourself on its page:'
-          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_intro: 'The "%{resource_title}" meeting has enabled registrations.
+            You can register yourself on its page:'
+          email_outro: You have received this notification because you are following
+            the "%{resource_title}" meeting. You can unfollow it from the previous
+            link.
           email_subject: The "%{resource_title}" meeting has enabled registrations.
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting has enabled registrations.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            meeting has enabled registrations.
         upcoming_meeting:
           email_intro: The "%{resource_title}" meeting will start in less than 48h.
-          email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
+          email_outro: You have received this notification because you are following
+            the "%{resource_title}" meeting. You can unfollow it from the previous
+            link.
           email_subject: The "%{resource_title}" meeting will start in less than 48h.
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            meeting will start in less than 48h.
     gamification:
       badges:
         attended_meetings:
           conditions:
           - Register for the meetings you want to attend
-          description: This badge is granted when you attend several face-to-face meetings.
+          description: This badge is granted when you attend several face-to-face
+            meetings.
           description_another: This participant has attended %{score} meetings.
           description_own: You have attended %{score} meetings.
           name: Attended meetings
@@ -197,7 +233,9 @@ en:
         invite_join_meeting_mailer:
           invite:
             decline: Decline invitation
-            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join a meeting at %{application}. You can decline or accept it through the links below."
+            invited_you_to_join_a_meeting: "%{invited_by} has invited you to join
+              a meeting at %{application}. You can decline or accept it through the
+              links below."
             join: Join meeting '%{meeting_title}'
         invites:
           create:
@@ -207,7 +245,8 @@ en:
             attendee_type: Attendee type
             existing_user: Existing participant
             invite: Invite
-            invite_explanation: The participant will be invited to join the meeting and to the organization as well.
+            invite_explanation: The participant will be invited to join the meeting
+              and to the organization as well.
             non_user: Non existing participant
             select_user: Select participant
           index:
@@ -219,7 +258,8 @@ en:
             filter_by: Filter by
             invite_attendee: Invite attendee
             invites: Invites
-            registrations_disabled: You can't invite an attendee because the registrations are disabled.
+            registrations_disabled: You can't invite an attendee because the registrations
+              are disabled.
             search: Search
         meeting_closes:
           edit:
@@ -297,21 +337,31 @@ en:
             success: Registration code successfully validated.
       admin_log:
         invite:
-          create: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
-          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name} meeting on the %{space_name} space"
-          update: "%{user_name} invited %{attendee_name} to join %{resource_name} meeting on the %{space_name} space"
+          create: "%{user_name} invited %{attendee_name} to join %{resource_name}
+            meeting on the %{space_name} space"
+          deleted: "%{user_name} uninvited %{attendee_name} from joining %{resource_name}
+            meeting on the %{space_name} space"
+          update: "%{user_name} invited %{attendee_name} to join %{resource_name}
+            meeting on the %{space_name} space"
         meeting:
-          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name} space"
-          create: "%{user_name} created the %{resource_name} meeting on the %{space_name} space"
-          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name} space"
-          export_registrations: "%{user_name} exported the registrations of the %{resource_name} meeting on the %{space_name} space"
-          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name} space"
+          close: "%{user_name} closed the %{resource_name} meeting on the %{space_name}
+            space"
+          create: "%{user_name} created the %{resource_name} meeting on the %{space_name}
+            space"
+          delete: "%{user_name} deleted the %{resource_name} meeting on the %{space_name}
+            space"
+          export_registrations: "%{user_name} exported the registrations of the %{resource_name}
+            meeting on the %{space_name} space"
+          update: "%{user_name} updated the %{resource_name} meeting on the %{space_name}
+            space"
           value_types:
             organizer_presenter:
               not_found: 'The organizer was not found on the database (ID: %{id})'
         minutes:
-          create: "%{user_name} created the minutes of the meeting %{resource_name} on the %{space_name} space"
-          update: "%{user_name} updated the minutes of the meeting %{resource_name} on the %{space_name} space"
+          create: "%{user_name} created the minutes of the meeting %{resource_name}
+            on the %{space_name} space"
+          update: "%{user_name} updated the minutes of the meeting %{resource_name}
+            on the %{space_name} space"
       calendar_modal:
         calendar_url: Calendar URL
         close_window: Close window
@@ -360,8 +410,10 @@ en:
           meeting_minutes: Meeting Minutes
           related_information: Related Information
         meetings:
-          no_meetings_warning: No meetings match your search criteria or there isn't any meeting scheduled.
-          upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.
+          no_meetings_warning: No meetings match your search criteria or there isn't
+            any meeting scheduled.
+          upcoming_meetings_warning: Currently, there are no scheduled meetings, but
+            here you can find all the past meetings listed.
         registration_confirm:
           cancel: Cancel
           confirm: Confirm
@@ -405,7 +457,8 @@ en:
       read_more: "(read more)"
       registration_mailer:
         confirmation:
-          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a> has been confirmed.
+          confirmed_html: Your registration for the meeting <a href="%{url}">%{title}</a>
+            has been confirmed.
           details: You will find the meeting's details in the attachment.
           registration_code: Your registration code is %{code}.
       registrations:

--- a/decidim-meetings/config/locales/fr.yml
+++ b/decidim-meetings/config/locales/fr.yml
@@ -8,7 +8,8 @@ fr:
         title: Titre
       close_meeting:
         attendees_count: Nombre de participants
-        attending_organizations: Liste des organisations qui ont participé à cette rencontre
+        attending_organizations: Liste des organisations qui ont participé à cette
+          rencontre
         closing_report: Compte rendu
         contributions_count: Nombre de contributions
         proposal_ids: Propositions élaborées lors de la rencontre
@@ -39,8 +40,10 @@ fr:
         meeting_agenda:
           attributes:
             base:
-              too_many_minutes: La durée des éléments dépasse la durée de la réunion de %{count} minutes
-              too_many_minutes_child: La durée du sous-événement dépasse la durée de l'événement concerné "%{parent_title}" de %{count} minutes
+              too_many_minutes: La durée des éléments dépasse la durée de la réunion
+                de %{count} minutes
+              too_many_minutes_child: La durée du sous-événement dépasse la durée
+                de l'événement concerné "%{parent_title}" de %{count} minutes
         meeting_registration_invite:
           attributes:
             email:
@@ -49,7 +52,8 @@ fr:
       decidim/meetings/close_meeting_event: Rencontre terminée
       decidim/meetings/create_meeting_event: Rencontre
       decidim/meetings/meeting_registrations_enabled_event: Inscriptions activées
-      decidim/meetings/meeting_registrations_over_percentage_event: Les inscriptions ont atteint la limite fixée
+      decidim/meetings/meeting_registrations_over_percentage_event: Les inscriptions
+        ont atteint la limite fixée
       decidim/meetings/upcoming_meeting_event: Prochaine rencontre
       decidim/meetings/update_meeting_event: Rencontre mise à jour
   activerecord:
@@ -82,10 +86,12 @@ fr:
           global:
             announcement: Annonce
             comments_enabled: Activer le module de commentaire
-            comments_max_length: Nombre de caractères maximum des commentaires (Mettre 0 pour laisser la valeur par défaut)
+            comments_max_length: Nombre de caractères maximum des commentaires (Mettre
+              0 pour laisser la valeur par défaut)
             default_registration_terms: Conditions d'inscription par défaut
             enable_pads_creation: Activer la création de pads
-            resources_permissions_enabled: Les autorisations d'actions peuvent être définies pour chaque réunion
+            resources_permissions_enabled: Les autorisations d'actions peuvent être
+              définies pour chaque réunion
           step:
             announcement: Annonce
             comments_blocked: Commentaires bloqués
@@ -93,57 +99,92 @@ fr:
       meetings:
         meeting_closed:
           affected_user:
-            email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
-            email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+            email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez
+              en lire le compte rendu sur sa page :'
+            email_outro: Vous avez reçu cette notification, car vous suivez la rencontre
+              "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien
+              précédent.
             email_subject: La rencontre "%{resource_title}" est terminée
-            notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
+            notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a>
+              est terminée.
           follower:
-            email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez en lire le compte rendu sur sa page :'
-            email_outro: Vous avez reçu cette notification parce que vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+            email_intro: 'La rencontre "%{resource_title}" est terminée. Vous pouvez
+              en lire le compte rendu sur sa page :'
+            email_outro: Vous avez reçu cette notification parce que vous suivez la
+              rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir
+              du lien précédent.
             email_subject: La rencontre "%{resource_title}" est terminée
-            notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> est terminée.
+            notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a>
+              est terminée.
         meeting_created:
-          email_intro: La rencontre "%{resource_title}" a été ajoutée à "%{participatory_space_title}" que vous suivez.
-          email_outro: Vous avez reçu cette notification parce que vous suivez "%{participatory_space_title}". Vous pouvez arrêter le suivi à partir du lien précédent.
+          email_intro: La rencontre "%{resource_title}" a été ajoutée à "%{participatory_space_title}"
+            que vous suivez.
+          email_outro: Vous avez reçu cette notification parce que vous suivez "%{participatory_space_title}".
+            Vous pouvez arrêter le suivi à partir du lien précédent.
           email_subject: Nouvelle rencontre ajoutée à %{participatory_space_title}
-          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> a été ajoutée à %{participatory_space_title}
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a>
+            a été ajoutée à %{participatory_space_title}
         meeting_registration_confirmed:
-          notification_title: Votre inscription à la rencontre <a href="%{resource_url}">%{resource_title}</a> a> est confirmée. Votre code d'enregistrement est %{registration_code}.
+          notification_title: Votre inscription à la rencontre <a href="%{resource_url}">%{resource_title}</a>
+            a> est confirmée. Votre code d'enregistrement est %{registration_code}.
         meeting_registrations_over_percentage:
-          email_intro: Le nombre de places occupées par la rencontre "%{resource_title}" est supérieur à %{percentage}%.
-          email_outro: Vous avez reçu cette notification parce que vous êtes administrateur de la concertation à laquelle est associée la rencontre.
-          email_subject: Les places réservées pour la rencontre "%{resource_title}" dépassent %{percentage}%
-          notification_title: Les <a href="%{resource_path}">%{resource_title}</a> salles de rencontre sont occupées à plus de %{percentage}%.
+          email_intro: Le nombre de places occupées par la rencontre "%{resource_title}"
+            est supérieur à %{percentage}%.
+          email_outro: Vous avez reçu cette notification parce que vous êtes administrateur
+            de la concertation à laquelle est associée la rencontre.
+          email_subject: Les places réservées pour la rencontre "%{resource_title}"
+            dépassent %{percentage}%
+          notification_title: Les <a href="%{resource_path}">%{resource_title}</a>
+            salles de rencontre sont occupées à plus de %{percentage}%.
         meeting_updated:
-          email_intro: 'La rencontre "%{resource_title}" a été mise à jour. Vous pouvez accéder à la nouvelle version depuis sa page :'
-          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
+          email_intro: 'La rencontre "%{resource_title}" a été mise à jour. Vous pouvez
+            accéder à la nouvelle version depuis sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre
+            "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien
+            précédent.
           email_subject: La rencontre "%{resource_title}" a été mise à jour
-          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> a été mise à jour.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a>
+            a été mise à jour.
         registration_code_validated:
-          email_intro: Votre code d'enregistrement "%{registration_code}" pour la réunion "%{resource_title}" a été validé.
-          email_outro: Vous avez reçu cette notification parce que votre code d'enregistrement pour la réunion "%{resource_title}" a été validé.
-          email_subject: Votre code d'enregistrement "%{registration_code}" pour la réunion "%{resource_title}" a été validé
-          notification_title: Votre code d'enregistrement "%{registration_code}" pour la réunion <a href="%{resource_path}">%{resource_title}</a> a été validé.
+          email_intro: Votre code d'enregistrement "%{registration_code}" pour la
+            réunion "%{resource_title}" a été validé.
+          email_outro: Vous avez reçu cette notification parce que votre code d'enregistrement
+            pour la réunion "%{resource_title}" a été validé.
+          email_subject: Votre code d'enregistrement "%{registration_code}" pour la
+            réunion "%{resource_title}" a été validé
+          notification_title: Votre code d'enregistrement "%{registration_code}" pour
+            la réunion <a href="%{resource_path}">%{resource_title}</a> a été validé.
         registrations_enabled:
-          email_intro: 'Les inscriptions pour la rencontre "%{resource_title}" sont ouvertes. Vous pouvez vous inscrire sur sa page :'
-          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
-          email_subject: Les inscriptions pour la rencontre "%{resource_title}" sont ouvertes.
-          notification_title: Les inscriptions pour la rencontre <a href="%{resource_path}">%{resource_title}</a> sont ouvertes.
+          email_intro: 'Les inscriptions pour la rencontre "%{resource_title}" sont
+            ouvertes. Vous pouvez vous inscrire sur sa page :'
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre
+            "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien
+            précédent.
+          email_subject: Les inscriptions pour la rencontre "%{resource_title}" sont
+            ouvertes.
+          notification_title: Les inscriptions pour la rencontre <a href="%{resource_path}">%{resource_title}</a>
+            sont ouvertes.
         upcoming_meeting:
           email_intro: La rencontre "%{resource_title}" commencera dans moins de 48h.
-          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien précédent.
-          email_subject: La rencontre "%{resource_title}" commencera dans moins de 48h.
-          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a> débutera dans moins de 48h.
+          email_outro: Vous avez reçu cette notification, car vous suivez la rencontre
+            "%{resource_title}". Vous pouvez arrêter de la suivre à partir du lien
+            précédent.
+          email_subject: La rencontre "%{resource_title}" commencera dans moins de
+            48h.
+          notification_title: La rencontre <a href="%{resource_path}">%{resource_title}</a>
+            débutera dans moins de 48h.
     gamification:
       badges:
         attended_meetings:
           conditions:
           - Inscrivez-vous aux rencontres auxquelles vous souhaitez participer
-          description: Ce badge est attribué lorsque vous participez à plusieurs rencontres en face à face.
+          description: Ce badge est attribué lorsque vous participez à plusieurs rencontres
+            en face à face.
           description_another: Cet utilisateur a participé à %{score} rencontres.
           description_own: Vous avez assisté à %{score} rencontres.
           name: Assister aux rencontres
-          next_level_in: Assister à %{score} plus de rencontres pour atteindre le prochain niveau!
+          next_level_in: Assister à %{score} plus de rencontres pour atteindre le
+            prochain niveau!
           unearned_another: Cet utilisateur n'a encore assisté à aucune réunion.
           unearned_own: Vous n'avez encore assisté à aucune réunion.
     meetings:
@@ -189,7 +230,8 @@ fr:
             create: Créer
             title: Nouvel ordre du jour
           update:
-            invalid: Un problème est survenu lors de la mise à jour de cet ordre du jour
+            invalid: Un problème est survenu lors de la mise à jour de cet ordre du
+              jour
             success: Ordre du jour mis à jour avec succès
         exports:
           meetings: Rencontres
@@ -197,7 +239,9 @@ fr:
         invite_join_meeting_mailer:
           invite:
             decline: Refuser l'invitation
-            invited_you_to_join_a_meeting: "%{invited_by} vous a invité à une rencontre sur %{application}. Vous pouvez confirmer votre présence en cliquant sur le lien ci-dessous."
+            invited_you_to_join_a_meeting: "%{invited_by} vous a invité à une rencontre
+              sur %{application}. Vous pouvez confirmer votre présence en cliquant
+              sur le lien ci-dessous."
             join: Rejoignez la rencontre '%{meeting_title}'
         invites:
           create:
@@ -207,7 +251,8 @@ fr:
             attendee_type: Type de participant
             existing_user: Utilisateur existant
             invite: Inviter
-            invite_explanation: L'utilisateur sera invité à se joindre à la réunion et à l'organisation.
+            invite_explanation: L'utilisateur sera invité à se joindre à la réunion
+              et à l'organisation.
             non_user: Utilisateur non existant
             select_user: Sélectionner un utilisateur
           index:
@@ -219,7 +264,8 @@ fr:
             filter_by: Filtrer par
             invite_attendee: Inviter un participant
             invites: Invitations
-            registrations_disabled: Vous ne pouvez pas inviter un participant car les invitations sont désactivées.
+            registrations_disabled: Vous ne pouvez pas inviter un participant car
+              les invitations sont désactivées.
             search: Chercher
         meeting_closes:
           edit:
@@ -280,7 +326,8 @@ fr:
             validate: Valider
             validate_registration_code: Valider le code d'enregistrement
           form:
-            available_slots_help: Laisser à 0 si le nombre de places disponibles n'est pas limité.
+            available_slots_help: Laisser à 0 si le nombre de places disponibles n'est
+              pas limité.
             invites: Invitations
             registration_form: Formulaire d'inscription
             registrations_count:
@@ -290,28 +337,40 @@ fr:
             reserved_slots_less_than: Doit être inférieur ou égal à %{count}
             title: Inscriptions
           update:
-            invalid: Il y a eu un problème lors de l'enregistrement des paramètres d'inscription.
+            invalid: Il y a eu un problème lors de l'enregistrement des paramètres
+              d'inscription.
             success: Les paramètres d'inscription ont été enregistrés avec succès.
           validate_registration_code:
             invalid: Ce code d'enregistrement est invalide.
             success: Le code d'enregistrement a été validé avec succès.
       admin_log:
         invite:
-          create: "%{user_name} a invité %{attendee_name} à rejoindre la réunion %{resource_name} sur l'espace %{space_name}"
-          deleted: "%{user_name} a supprimé l'invitation de %{attendee_name} à rejoindre la réunion %{resource_name} sur l'espace %{space_name}"
-          update: "%{user_name} a invité %{attendee_name} à rejoindre la réunion %{resource_name} sur l'espace %{space_name}"
+          create: "%{user_name} a invité %{attendee_name} à rejoindre la réunion %{resource_name}
+            sur l'espace %{space_name}"
+          deleted: "%{user_name} a supprimé l'invitation de %{attendee_name} à rejoindre
+            la réunion %{resource_name} sur l'espace %{space_name}"
+          update: "%{user_name} a invité %{attendee_name} à rejoindre la réunion %{resource_name}
+            sur l'espace %{space_name}"
         meeting:
-          close: "%{user_name} a fermé la rencontre %{resource_name} sur l'espace %{space_name}"
-          create: "%{user_name} a créé la rencontre %{resource_name} sur l'espace %{space_name}"
-          delete: "%{user_name} a supprimé la rencontre %{resource_name} sur l'espace %{space_name}"
-          export_registrations: "%{user_name} a exporté les inscriptions de la rencontre %{resource_name} sur l'espace %{space_name}"
-          update: "%{user_name} a mis à jour la rencontre %{resource_name} sur l'espace %{space_name}"
+          close: "%{user_name} a fermé la rencontre %{resource_name} sur l'espace
+            %{space_name}"
+          create: "%{user_name} a créé la rencontre %{resource_name} sur l'espace
+            %{space_name}"
+          delete: "%{user_name} a supprimé la rencontre %{resource_name} sur l'espace
+            %{space_name}"
+          export_registrations: "%{user_name} a exporté les inscriptions de la rencontre
+            %{resource_name} sur l'espace %{space_name}"
+          update: "%{user_name} a mis à jour la rencontre %{resource_name} sur l'espace
+            %{space_name}"
           value_types:
             organizer_presenter:
-              not_found: 'L''organisateur n''a pas été trouvé dans la base de données (ID: %{id})'
+              not_found: 'L''organisateur n''a pas été trouvé dans la base de données
+                (ID: %{id})'
         minutes:
-          create: "%{user_name} a créé le compte rendu de la rencontre %{resource_name} sur l'espace %{space_name}"
-          update: "%{user_name} a mis à jour le compte rendu de la rencontre %{resource_name} sur l'espace %{space_name}"
+          create: "%{user_name} a créé le compte rendu de la rencontre %{resource_name}
+            sur l'espace %{space_name}"
+          update: "%{user_name} a mis à jour le compte rendu de la rencontre %{resource_name}
+            sur l'espace %{space_name}"
       calendar_modal:
         calendar_url: URL du calendrier
         close_window: Fermer la fenêtre
@@ -360,13 +419,16 @@ fr:
           meeting_minutes: Retranscription de la rencontre
           related_information: Retranscription média
         meetings:
-          no_meetings_warning: Aucune rencontre ne correspond à vos critères de recherche ou aucune rencontre n'est prévue.
-          upcoming_meetings_warning: À l'heure actuelle, il n'y a pas de rencontres planifiées. Ici vous trouverez une liste de toutes les rencontres passées.
+          no_meetings_warning: Aucune rencontre ne correspond à vos critères de recherche
+            ou aucune rencontre n'est prévue.
+          upcoming_meetings_warning: À l'heure actuelle, il n'y a pas de rencontres
+            planifiées. Ici vous trouverez une liste de toutes les rencontres passées.
         registration_confirm:
           cancel: Annuler
           confirm: Confirmer
         show:
           attendees: Nombre de participants
+          back: Retourner à la liste
           contributions: Décompte des contributions
           going: J'y vais
           join: Participer à la rencontre
@@ -404,7 +466,8 @@ fr:
       read_more: "(Voir la suite)"
       registration_mailer:
         confirmation:
-          confirmed_html: Votre inscription pour la rencontre <a href="%{url}">%{title}</a> a été confirmée.
+          confirmed_html: Votre inscription pour la rencontre <a href="%{url}">%{title}</a>
+            a été confirmée.
           details: Vous trouverez les détails de la rencontre dans la pièce jointe.
           registration_code: Votre code d'enregistrement est %{code}.
       registrations:

--- a/decidim-meetings/spec/system/show_spec.rb
+++ b/decidim-meetings/spec/system/show_spec.rb
@@ -14,7 +14,6 @@ describe "show", type: :system do
   end
 
   context "when shows the meeting component" do
-
     it "shows the meeting title" do
       expect(page).to have_content meeting.title[I18n.locale.to_s]
     end
@@ -22,11 +21,9 @@ describe "show", type: :system do
     it "shows the back button" do
       expect(page).to have_link(href: "#{main_component_path(component)}meetings")
     end
-
   end
 
   context "when clicking the back button" do
-
     before do
       visit_component
       click_link(href: "#{main_component_path(component)}meetings")
@@ -35,6 +32,5 @@ describe "show", type: :system do
     it "redirect the user to index meetings" do
       expect(page).to have_current_path("#{main_component_path(component)}meetings")
     end
-
   end
 end

--- a/decidim-meetings/spec/system/show_spec.rb
+++ b/decidim-meetings/spec/system/show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "show", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "meetings" }
+
+  let!(:meeting) { create(:meeting, component: component) }
+
+  before do
+    visit_component
+    click_link meeting.title[I18n.locale.to_s], class: "card__link"
+  end
+
+  context "when shows the meeting component" do
+
+    it "shows the meeting title" do
+      expect(page).to have_content meeting.title[I18n.locale.to_s]
+    end
+
+    it "shows the back button" do
+      expect(page).to have_link(href: "#{main_component_path(component)}meetings")
+    end
+
+  end
+
+  context "when clicking the back button" do
+
+    before do
+      visit_component
+      click_link(href: "#{main_component_path(component)}meetings")
+    end
+
+    it "redirect the user to index meetings" do
+      expect(page).to have_current_path("#{main_component_path(component)}meetings")
+    end
+
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -33,6 +33,12 @@
 <% end %>
 <%= emendation_announcement_for @proposal %>
 <div class="row column view-header">
+
+  <%= link_to :proposals, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
+
   <h2 class="heading2" <%= "id=#{translate_helper_for(element: :title, model: @proposal)}" %>>
     <%= present(@proposal).title(links: true, html_escape: true) %></h2>
   <% unless component_settings.participatory_texts_enabled? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -34,7 +34,7 @@
 <%= emendation_announcement_for @proposal %>
 <div class="row column view-header">
 
-  <%= link_to :proposals, class: "muted-link" do %>
+  <%= link_to :proposals, class: "title-action__action button small hollow" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -709,6 +709,7 @@ en:
           creation_date: 'Creation: %{date}'
           view_proposal: View proposal
         show:
+          back: Back to list
           back_to: Back to
           edit_proposal: Edit proposal
           endorsements_list: List of Endorsements

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -27,7 +27,8 @@ en:
       proposal_answer:
         answer: Answer
       proposals_copy:
-        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
+        copy_proposals: I understand that this will import all proposals from the
+          selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
       proposals_import:
         import_proposals: Import proposals
@@ -37,7 +38,8 @@ en:
         participatory_text:
           attributes:
             document:
-              invalid_document_type: 'Invalid document type. Accepted formats are: %{valid_mime_types}'
+              invalid_document_type: 'Invalid document type. Accepted formats are:
+                %{valid_mime_types}'
         proposal:
           attributes:
             attachment:
@@ -88,7 +90,8 @@ en:
             amendments_enabled: Amendments enabled
             announcement: Announcement
             attachments_allowed: Allow attachments
-            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond
+              threshold
             collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Comments enabled
             comments_max_length: Comments max length
@@ -98,14 +101,19 @@ en:
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Proposal answering enabled
-            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
+            proposal_edit_before_minutes: Proposals can be edited by authors before
+              this many minutes passes
             proposal_length: Maximum proposal body length
             proposal_limit: Proposal limit per participant
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
-            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
-            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
-            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
-            resources_permissions_enabled: Actions permissions can be set for each proposal
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help
+              text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help
+              text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help
+              text
+            resources_permissions_enabled: Actions permissions can be set for each
+              proposal
             threshold_per_proposal: Threshold per proposal
             vote_limit: Support limit per participant
           step:
@@ -119,7 +127,8 @@ en:
             suggested_hashtags: Hashtags suggested to participants for new proposals
             votes_blocked: Supports blocked
             votes_enabled: Supports enabled
-            votes_hidden: Supports hidden (if supports are enabled, checking this will hide the number of supports)
+            votes_hidden: Supports hidden (if supports are enabled, checking this
+              will hide the number of supports)
             votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
       proposal_created:
@@ -128,131 +137,226 @@ en:
           email_intro: Email intro
           email_subject: Email subject
           moderation_url: Moderation url
-        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans
+          <a href="%{resource_path}">%{resource_title}</a>a>a
         url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been accepted to access as a contributor
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor
+            of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            has been <strong>accepted to access as a contributor</strong> of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been rejected to access as a contributor
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor
+            of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            has been <strong>rejected to access as a contributor</strong> of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} requested access as a contributor. You can
+            <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
+            requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to
+            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been accepted as a contributor of %{resource_title}.
-          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          notification_title: You have been <strong>accepted to access as a contributor</strong>
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a
+            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to
+            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been rejected as a contributor of %{resource_title}.
-          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          notification_title: You have been <strong>rejected to access as a contributor</strong>
+            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+            withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative
+            draft.
+          email_outro: You have received this notification because you are a collaborator
+            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title}
+            collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
+            <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a>
+            collaborative draft.
         creation_enabled:
-          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can now create new proposals in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposals now available in %{participatory_space_title}
-          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now put forward <a href="%{resource_path}">new
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can endorse proposals in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposals endorsing has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">endorsing
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
-            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You
+              can read the answer in this page:'
+            email_outro: You have received this notification because you are an author
+              of "%{resource_title}".
             email_subject: Your proposal has been accepted
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
-          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
+              has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати
+            відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
+            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
-            email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
-            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" has been accepted. You
+              can read the answer in this page:'
+            email_outro: You have received this notification because you are following
+              "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following has been accepted
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
-          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              proposal has been accepted.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a>
+            було прийнято.
         proposal_endorsed:
-          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
-          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following,
+            has just endorsed the "%{resource_title}" proposal and we think it may
+            be interesting to you. Check it out and contribute:'
+          email_outro: You have received this notification because you are following
+            %{endorser_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: "%{endorser_nickname} has endorsed a new proposal"
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name}
+            %{endorser_nickname}</a>.
         proposal_evaluating:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
-            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated.
+              You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author
+              of "%{resource_title}".
             email_subject: Your proposal is being evaluated
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
-          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
+              is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете
+            перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
+            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
-            email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
-            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" is currently being evaluated.
+              You can check for an answer in this page:'
+            email_outro: You have received this notification because you are following
+              "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following is being evaluated
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
-          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              proposal is being evaluated.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a>
+            розглядається.
         proposal_mentioned:
-          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
-          email_outro: You have received this notification because you are an author of "%{resource_title}".
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned
+            <a href="%{resource_path}">in this space</a> in the comments.
+          email_outro: You have received this notification because you are an author
+            of "%{resource_title}".
           email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
-          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been
+            mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
-          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: '%{author_name} %{author_nickname}, who you are following,
+            has published a new proposal called "%{resource_title}". Check it out
+            and contribute:'
+          email_outro: You have received this notification because you are following
+            %{author_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: New proposal "%{resource_title}" by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
-          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}"
+            that you are following.
+          email_outro: You have received this notification because you are following
+            "%{participatory_space_title}". You can stop receiving notifications following
+            the previous link.
           email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
-          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a>
+            has been added to %{participatory_space_title}
         proposal_rejected:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
-            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You
+              can read the answer in this page:'
+            email_outro: You have received this notification because you are an author
+              of "%{resource_title}".
             email_subject: Your proposal been rejected
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
-          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
+              has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати
+            відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
+            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
-            email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
-            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" has been rejected. You
+              can read the answer in this page:'
+            email_outro: You have received this notification because you are following
+              "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following has been rejected
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
-          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              proposal has been rejected.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a>
+            було відхилено.
         proposal_update_category:
-          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out in this page:'
-          email_outro: You have received this notification because you are the author of the proposal.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}",
+            check it out in this page:'
+          email_outro: You have received this notification because you are the author
+            of the proposal.
           email_subject: The %{resource_title} proposal category has been updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'You can support proposals in %{participatory_space_title}! Start participating in this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
+          email_intro: 'You can support proposals in %{participatory_space_title}!
+            Start participating in this page:'
+          email_outro: You have received this notification because you are following
+            %{participatory_space_title}. You can stop receiving notifications following
+            the previous link.
           email_subject: Proposal support has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">supporting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">supporting
+            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals enabled
-          - Try to make proposals that can be carried out. This way they are more likely to be accepted.
-          description: This badge is granted when you actively participate with new proposals and these are accepted.
+          - Choose the participation space of your interest with submission for proposals
+            enabled
+          - Try to make proposals that can be carried out. This way they are more
+            likely to be accepted.
+          description: This badge is granted when you actively participate with new
+            proposals and these are accepted.
           description_another: This participant had %{score} accepted proposals.
           description_own: You got %{score} proposals accepted.
           name: Accepted proposals
@@ -267,14 +371,18 @@ en:
           description_another: This participant has given support to %{score} proposals.
           description_own: You have given support to %{score} proposals.
           name: Proposal supports
-          next_level_in: Give support to %{score} more proposals to reach the next level!
-          unearned_another: This participant hasn't given support to any proposals yet.
+          next_level_in: Give support to %{score} more proposals to reach the next
+            level!
+          unearned_another: This participant hasn't given support to any proposals
+            yet.
           unearned_own: You have given support to no proposals yet.
         proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals enabled
+          - Choose the participation space of your interest with submission for proposals
+            enabled
           - Create a new proposal
-          description: This badge is granted when you actively participate with new proposals.
+          description: This badge is granted when you actively participate with new
+            proposals.
           description_another: This participant has created %{score} proposals.
           description_own: You have created %{score} proposals.
           name: Proposals
@@ -332,9 +440,11 @@ en:
             success: All participatory text drafts have been discarded.
           import:
             invalid: The form is invalid!
-            success: Congratulations, the following sections have been converted to proposals. Now you can review and adjust them before publishing.
+            success: Congratulations, the following sections have been converted to
+              proposals. Now you can review and adjust them before publishing.
           index:
-            info_1: The following sections have been converted to proposals. Now you can review and adjust them before publishing.
+            info_1: The following sections have been converted to proposals. Now you
+              can review and adjust them before publishing.
             publish_document: Publish document
             save_draft: Save draft
             title: PREVIEW PARTICIPATORY TEXT
@@ -343,7 +453,8 @@ en:
               md: Markdown
               odt: Odt
             bottom_hint: "(You will be able to preview and sort document sections)"
-            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: %{valid_mime_types}'
+            document_legend: 'Add a document lesser than 2MB, each section until 3
+              levels deep will be parsed into Proposals. Suported formats are: %{valid_mime_types}'
             title: ADD DOCUMENT
             upload_document: Upload document
           publish:
@@ -405,14 +516,16 @@ en:
             invalid: 'These proposals already had the %{category} category: %{proposals}.'
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
+            success: 'Proposals successfully updated to the %{category} category:
+              %{proposals}.'
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals
             success: "%{number} proposals successfully imported"
           new:
             create: Import proposals
-            no_components: There are no other proposal components in this participatory space to import the proposals from.
+            no_components: There are no other proposal components in this participatory
+              space to import the proposals from.
             select_component: Please select a component
             select_states: Check the status of the proposals to import
         proposals_merges:
@@ -431,11 +544,15 @@ en:
             proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
-          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
-          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name}
+            space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name}
+            space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on
+            the %{space_name} space"
         proposal_note:
-          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} left a private note on the %{resource_name} proposal
+            on the %{space_name} space"
       answers:
         accepted: Accepted
         evaluating: Evaluating
@@ -464,7 +581,8 @@ en:
           publish:
             error: There was a problem publishing the collaborative draft.
             irreversible_action_modal:
-              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
+              body: After publishing the draft as a proposal, the draft won't be editable
+                anymore. The proposal won't accept new authors or contributions.
               cancel: Cancel
               ok: Publish as a Proposal
               title: The following action is irreversible
@@ -473,7 +591,8 @@ en:
           withdraw:
             error: There was a problem closing the collaborative draft.
             irreversible_action_modal:
-              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
+              body: After closing the draft, the draft won't be editable anymore.
+                The draft won't accept new authors or contributions.
               cancel: Cancel
               ok: Withdraw the collaborative draft
               title: The following action is irreversible
@@ -546,7 +665,11 @@ en:
           hidden_authors_count:
             one: and %{count} more person
             other: and %{count} more people
-          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
+          info-message: This is a <strong>collaborative draft</strong> for a proposal.
+            This means that you can help their authors to shape the proposal using
+            the comment section below or improve it directly by requesting access
+            to edit it. Once the authors grant you access, youl'll be able to make
+            changes to this draft.
           of_versions: "(of %{number})"
           publish: Publish
           publish_info: Publish this version of the draft or
@@ -638,7 +761,8 @@ en:
             other: "%{count} proposals"
         dynamic_map_instructions:
           primary: You can move the point on the map.
-          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
+          secondary: Don't forget to click on the "Update Position" button before
+            publishing your proposal.
         edit:
           address: Address (don't forget to specify the city)
           attachment_legend: "(Optional) Add an attachment"
@@ -700,8 +824,12 @@ en:
           modify: Modify the proposal
           not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
-            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            one: You will be able to edit this proposal during the first minute after
+              the proposal is published. Once this time window passes, you will not
+              be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count}
+              minutes after the proposal is published. Once this time window passes,
+              you will not be able to edit the proposal.
           publish: Publish
           title: Publish your proposal
           update_pos: Update the position
@@ -716,13 +844,16 @@ en:
           hidden_endorsers_count:
             one: and %{count} more person
             other: and %{count} more people
-          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
+          link_to_collaborative_draft_help_text: This proposal is the result of a
+            collaborative draft. Review the history
           link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'
           report: Report
-          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind,
+            as long as you have not received any support. The proposal is not deleted,
+            it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure you want to withdraw this proposal?
           withdraw_proposal: Withdraw proposal
         tags:
@@ -753,13 +884,16 @@ en:
           can_accumulate_supports_beyond_threshold:
             description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: You must distribute a minimum of %{votes} supports among different proposals.
+            description: You must distribute a minimum of %{votes} supports among
+              different proposals.
             given_enough_votes: You've given enough supports.
-            supports_remaining: You have to support %{remaining_votes} more proposals for your supports to be taken into account.
+            supports_remaining: You have to support %{remaining_votes} more proposals
+              for your supports to be taken into account.
           proposal_limit:
             description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: In order to be validated proposals need to reach %{limit} supports
+            description: In order to be validated proposals need to reach %{limit}
+              supports
           title: 'Supports are subject to the following rules:'
           vote_limit:
             description: You can support up to %{limit} proposals.
@@ -801,7 +935,8 @@ en:
           version_index: Version %{index}
       withdraw:
         errors:
-          has_supports: This proposal can not be withdrawn because it already has supports.
+          has_supports: This proposal can not be withdrawn because it already has
+            supports.
     resource_links:
       copied_from_component:
         proposal_proposal: Related proposals

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -27,8 +27,7 @@ en:
       proposal_answer:
         answer: Answer
       proposals_copy:
-        copy_proposals: I understand that this will import all proposals from the
-          selected component to the current one and that this action can't be reversed.
+        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
         origin_component_id: Component to copy the proposals from
       proposals_import:
         import_proposals: Import proposals
@@ -38,8 +37,7 @@ en:
         participatory_text:
           attributes:
             document:
-              invalid_document_type: 'Invalid document type. Accepted formats are:
-                %{valid_mime_types}'
+              invalid_document_type: 'Invalid document type. Accepted formats are: %{valid_mime_types}'
         proposal:
           attributes:
             attachment:
@@ -90,8 +88,7 @@ en:
             amendments_enabled: Amendments enabled
             announcement: Announcement
             attachments_allowed: Allow attachments
-            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond
-              threshold
+            can_accumulate_supports_beyond_threshold: Can accumulate supports beyond threshold
             collaborative_drafts_enabled: Collaborative drafts enabled
             comments_enabled: Comments enabled
             comments_max_length: Comments max length
@@ -101,19 +98,14 @@ en:
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
             proposal_answering_enabled: Proposal answering enabled
-            proposal_edit_before_minutes: Proposals can be edited by authors before
-              this many minutes passes
+            proposal_edit_before_minutes: Proposals can be edited by authors before this many minutes passes
             proposal_length: Maximum proposal body length
             proposal_limit: Proposal limit per participant
             proposal_wizard_step_1_help_text: Proposal wizard "Create" step help text
-            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help
-              text
-            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help
-              text
-            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help
-              text
-            resources_permissions_enabled: Actions permissions can be set for each
-              proposal
+            proposal_wizard_step_2_help_text: Proposal wizard "Compare" step help text
+            proposal_wizard_step_3_help_text: Proposal wizard "Complete" step help text
+            proposal_wizard_step_4_help_text: Proposal wizard "Publish" step help text
+            resources_permissions_enabled: Actions permissions can be set for each proposal
             threshold_per_proposal: Threshold per proposal
             vote_limit: Support limit per participant
           step:
@@ -127,8 +119,7 @@ en:
             suggested_hashtags: Hashtags suggested to participants for new proposals
             votes_blocked: Supports blocked
             votes_enabled: Supports enabled
-            votes_hidden: Supports hidden (if supports are enabled, checking this
-              will hide the number of supports)
+            votes_hidden: Supports hidden (if supports are enabled, checking this will hide the number of supports)
             votes_weight_enabled: Up / Down / Neutral votes enabled
     events:
       proposal_created:
@@ -137,226 +128,131 @@ en:
           email_intro: Email intro
           email_subject: Email subject
           moderation_url: Moderation url
-        notification_title: Il y a une nouvelle proposition de %{author_name} dans
-          <a href="%{resource_path}">%{resource_title}</a>a>a
+        notification_title: Il y a une nouvelle proposition de %{author_name} dans <a href="%{resource_path}">%{resource_title}</a>a>a
         url: 'url de commentaire : %{resource_url}'
       proposals:
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} has been accepted to access as a contributor
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been accepted to access as a contributor
-            of the %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            has been <strong>accepted to access as a contributor</strong> of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} has been rejected to access as a contributor
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{requester_name} has been rejected to access as a contributor
-            of the %{resource_title} collaborative draft."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            has been <strong>rejected to access as a contributor</strong> of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} requested access as a contributor. You can
-            <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft page.'
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
-          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a>
-            requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft. Please <strong>accept or reject the request</strong>.
+          notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: You have been accepted to access as a contributor of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to
-            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been accepted as a contributor of %{resource_title}.
-          notification_title: You have been <strong>accepted to access as a contributor</strong>
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
+          notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: You have been rejected to access as a contributor of the <a
-            href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to
-            become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
           email_subject: You have been rejected as a contributor of %{resource_title}.
-          notification_title: You have been <strong>rejected to access as a contributor</strong>
-            of the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
+          notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
-            withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative
-            draft.
-          email_outro: You have received this notification because you are a collaborator
-            of <a href="%{resource_path}">%{resource_title}</a>.
-          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title}
-            collaborative draft."
-          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a>
-            <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a>
-            collaborative draft.
+          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
+          notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:
-          email_intro: 'You can now create new proposals in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can now create new proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposals now available in %{participatory_space_title}
-          notification_title: You can now put forward <a href="%{resource_path}">new
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now put forward <a href="%{resource_path}">new proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         endorsing_enabled:
-          email_intro: 'You can endorse proposals in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can endorse proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposals endorsing has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">endorsing
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">endorsing proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
         proposal_accepted:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" has been accepted. You
-              can read the answer in this page:'
-            email_outro: You have received this notification because you are an author
-              of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
             email_subject: Your proposal has been accepted
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
-              has been accepted.
-          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати
-            відповідь на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
-            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been accepted.
+          email_intro: 'Пропозиція "%{resource_title}" була прийнята. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, була прийнята
           follower:
-            email_intro: 'The proposal "%{resource_title}" has been accepted. You
-              can read the answer in this page:'
-            email_outro: You have received this notification because you are following
-              "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" has been accepted. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following has been accepted
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              proposal has been accepted.
-          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a>
-            було прийнято.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been accepted.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було прийнято.
         proposal_endorsed:
-          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following,
-            has just endorsed the "%{resource_title}" proposal and we think it may
-            be interesting to you. Check it out and contribute:'
-          email_outro: You have received this notification because you are following
-            %{endorser_nickname}. You can stop receiving notifications following the
-            previous link.
+          email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed the "%{resource_title}" proposal and we think it may be interesting to you. Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.
           email_subject: "%{endorser_nickname} has endorsed a new proposal"
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name}
-            %{endorser_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
         proposal_evaluating:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated.
-              You can check for an answer in this page:'
-            email_outro: You have received this notification because you are an author
-              of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
             email_subject: Your proposal is being evaluated
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
-              is being evaluated.
-          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете
-            перевірити наявність відповіді на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
-            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is being evaluated.
+          email_intro: 'Пропозиція "%{resource_title}" зараз розглядається. Ви можете перевірити наявність відповіді на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, зараз розглядається
           follower:
-            email_intro: 'The proposal "%{resource_title}" is currently being evaluated.
-              You can check for an answer in this page:'
-            email_outro: You have received this notification because you are following
-              "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" is currently being evaluated. You can check for an answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following is being evaluated
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              proposal is being evaluated.
-          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a>
-            розглядається.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal is being evaluated.
+          notification_title: Пропозиція <a href="%{resource_path}">%{resource_title}</a> розглядається.
         proposal_mentioned:
-          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned
-            <a href="%{resource_path}">in this space</a> in the comments.
-          email_outro: You have received this notification because you are an author
-            of "%{resource_title}".
+          email_intro: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          email_outro: You have received this notification because you are an author of "%{resource_title}".
           email_subject: Your proposal "%{mentioned_proposal_title}" has been mentioned
-          notification_title: Your proposal "%{mentioned_proposal_title}" has been
-            mentioned <a href="%{resource_path}">in this space</a> in the comments.
+          notification_title: Your proposal "%{mentioned_proposal_title}" has been mentioned <a href="%{resource_path}">in this space</a> in the comments.
         proposal_published:
-          email_intro: '%{author_name} %{author_nickname}, who you are following,
-            has published a new proposal called "%{resource_title}". Check it out
-            and contribute:'
-          email_outro: You have received this notification because you are following
-            %{author_nickname}. You can stop receiving notifications following the
-            previous link.
+          email_intro: '%{author_name} %{author_nickname}, who you are following, has published a new proposal called "%{resource_title}". Check it out and contribute:'
+          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         proposal_published_for_space:
-          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}"
-            that you are following.
-          email_outro: You have received this notification because you are following
-            "%{participatory_space_title}". You can stop receiving notifications following
-            the previous link.
+          email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
-          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a>
-            has been added to %{participatory_space_title}
+          notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         proposal_rejected:
           affected_user:
-            email_intro: 'Your proposal "%{resource_title}" has been rejected. You
-              can read the answer in this page:'
-            email_outro: You have received this notification because you are an author
-              of "%{resource_title}".
+            email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
             email_subject: Your proposal been rejected
-            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a>
-              has been rejected.
-          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати
-            відповідь на сторінці:'
-          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}".
-            Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has been rejected.
+          email_intro: 'Пропозиція "%{resource_title}" була відхилена. Ви можете прочитати відповідь на сторінці:'
+          email_outro: Ви отримали це сповіщення, тому що ви стежите за "%{resource_title}". Ви можете припинити стежити за ним, перейшовши за наведеним вище посиланням.
           email_subject: Пропозиція, за якою ви стежите, була відхилена
           follower:
-            email_intro: 'The proposal "%{resource_title}" has been rejected. You
-              can read the answer in this page:'
-            email_outro: You have received this notification because you are following
-              "%{resource_title}". You can unfollow it from the previous link.
+            email_intro: 'The proposal "%{resource_title}" has been rejected. You can read the answer in this page:'
+            email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you're following has been rejected
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-              proposal has been rejected.
-          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a>
-            було відхилено.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has been rejected.
+          notification_title: Пропозицію <a href="%{resource_path}">%{resource_title}</a> було відхилено.
         proposal_update_category:
-          email_intro: 'An admin has updated the category of your proposal "%{resource_title}",
-            check it out in this page:'
-          email_outro: You have received this notification because you are the author
-            of the proposal.
+          email_intro: 'An admin has updated the category of your proposal "%{resource_title}", check it out in this page:'
+          email_outro: You have received this notification because you are the author of the proposal.
           email_subject: The %{resource_title} proposal category has been updated
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
-            proposal category has been updated by an admin.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal category has been updated by an admin.
         voting_enabled:
-          email_intro: 'You can support proposals in %{participatory_space_title}!
-            Start participating in this page:'
-          email_outro: You have received this notification because you are following
-            %{participatory_space_title}. You can stop receiving notifications following
-            the previous link.
+          email_intro: 'You can support proposals in %{participatory_space_title}! Start participating in this page:'
+          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: Proposal support has started for %{participatory_space_title}
-          notification_title: You can now start <a href="%{resource_path}">supporting
-            proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
+          notification_title: You can now start <a href="%{resource_path}">supporting proposals</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a>
     gamification:
       badges:
         accepted_proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals
-            enabled
-          - Try to make proposals that can be carried out. This way they are more
-            likely to be accepted.
-          description: This badge is granted when you actively participate with new
-            proposals and these are accepted.
+          - Choose the participation space of your interest with submission for proposals enabled
+          - Try to make proposals that can be carried out. This way they are more likely to be accepted.
+          description: This badge is granted when you actively participate with new proposals and these are accepted.
           description_another: This participant had %{score} accepted proposals.
           description_own: You got %{score} proposals accepted.
           name: Accepted proposals
@@ -371,18 +267,14 @@ en:
           description_another: This participant has given support to %{score} proposals.
           description_own: You have given support to %{score} proposals.
           name: Proposal supports
-          next_level_in: Give support to %{score} more proposals to reach the next
-            level!
-          unearned_another: This participant hasn't given support to any proposals
-            yet.
+          next_level_in: Give support to %{score} more proposals to reach the next level!
+          unearned_another: This participant hasn't given support to any proposals yet.
           unearned_own: You have given support to no proposals yet.
         proposals:
           conditions:
-          - Choose the participation space of your interest with submission for proposals
-            enabled
+          - Choose the participation space of your interest with submission for proposals enabled
           - Create a new proposal
-          description: This badge is granted when you actively participate with new
-            proposals.
+          description: This badge is granted when you actively participate with new proposals.
           description_another: This participant has created %{score} proposals.
           description_own: You have created %{score} proposals.
           name: Proposals
@@ -440,11 +332,9 @@ en:
             success: All participatory text drafts have been discarded.
           import:
             invalid: The form is invalid!
-            success: Congratulations, the following sections have been converted to
-              proposals. Now you can review and adjust them before publishing.
+            success: Congratulations, the following sections have been converted to proposals. Now you can review and adjust them before publishing.
           index:
-            info_1: The following sections have been converted to proposals. Now you
-              can review and adjust them before publishing.
+            info_1: The following sections have been converted to proposals. Now you can review and adjust them before publishing.
             publish_document: Publish document
             save_draft: Save draft
             title: PREVIEW PARTICIPATORY TEXT
@@ -453,8 +343,7 @@ en:
               md: Markdown
               odt: Odt
             bottom_hint: "(You will be able to preview and sort document sections)"
-            document_legend: 'Add a document lesser than 2MB, each section until 3
-              levels deep will be parsed into Proposals. Suported formats are: %{valid_mime_types}'
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into Proposals. Suported formats are: %{valid_mime_types}'
             title: ADD DOCUMENT
             upload_document: Upload document
           publish:
@@ -516,16 +405,14 @@ en:
             invalid: 'These proposals already had the %{category} category: %{proposals}.'
             select_a_category: Please select a category
             select_a_proposal: Please select a proposal
-            success: 'Proposals successfully updated to the %{category} category:
-              %{proposals}.'
+            success: 'Proposals successfully updated to the %{category} category: %{proposals}.'
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals
             success: "%{number} proposals successfully imported"
           new:
             create: Import proposals
-            no_components: There are no other proposal components in this participatory
-              space to import the proposals from.
+            no_components: There are no other proposal components in this participatory space to import the proposals from.
             select_component: Please select a component
             select_states: Check the status of the proposals to import
         proposals_merges:
@@ -544,15 +431,11 @@ en:
             proposals: Proposals
       admin_log:
         proposal:
-          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name}
-            space"
-          create: "%{user_name} created the %{resource_name} proposal on the %{space_name}
-            space as an official proposal"
-          update: "%{user_name} updated the %{resource_name} official proposal on
-            the %{space_name} space"
+          answer: "%{user_name} answered the %{resource_name} proposal on the %{space_name} space"
+          create: "%{user_name} created the %{resource_name} proposal on the %{space_name} space as an official proposal"
+          update: "%{user_name} updated the %{resource_name} official proposal on the %{space_name} space"
         proposal_note:
-          create: "%{user_name} left a private note on the %{resource_name} proposal
-            on the %{space_name} space"
+          create: "%{user_name} left a private note on the %{resource_name} proposal on the %{space_name} space"
       answers:
         accepted: Accepted
         evaluating: Evaluating
@@ -581,8 +464,7 @@ en:
           publish:
             error: There was a problem publishing the collaborative draft.
             irreversible_action_modal:
-              body: After publishing the draft as a proposal, the draft won't be editable
-                anymore. The proposal won't accept new authors or contributions.
+              body: After publishing the draft as a proposal, the draft won't be editable anymore. The proposal won't accept new authors or contributions.
               cancel: Cancel
               ok: Publish as a Proposal
               title: The following action is irreversible
@@ -591,8 +473,7 @@ en:
           withdraw:
             error: There was a problem closing the collaborative draft.
             irreversible_action_modal:
-              body: After closing the draft, the draft won't be editable anymore.
-                The draft won't accept new authors or contributions.
+              body: After closing the draft, the draft won't be editable anymore. The draft won't accept new authors or contributions.
               cancel: Cancel
               ok: Withdraw the collaborative draft
               title: The following action is irreversible
@@ -665,11 +546,7 @@ en:
           hidden_authors_count:
             one: and %{count} more person
             other: and %{count} more people
-          info-message: This is a <strong>collaborative draft</strong> for a proposal.
-            This means that you can help their authors to shape the proposal using
-            the comment section below or improve it directly by requesting access
-            to edit it. Once the authors grant you access, youl'll be able to make
-            changes to this draft.
+          info-message: This is a <strong>collaborative draft</strong> for a proposal. This means that you can help their authors to shape the proposal using the comment section below or improve it directly by requesting access to edit it. Once the authors grant you access, youl'll be able to make changes to this draft.
           of_versions: "(of %{number})"
           publish: Publish
           publish_info: Publish this version of the draft or
@@ -761,8 +638,7 @@ en:
             other: "%{count} proposals"
         dynamic_map_instructions:
           primary: You can move the point on the map.
-          secondary: Don't forget to click on the "Update Position" button before
-            publishing your proposal.
+          secondary: Don't forget to click on the "Update Position" button before publishing your proposal.
         edit:
           address: Address (don't forget to specify the city)
           attachment_legend: "(Optional) Add an attachment"
@@ -824,12 +700,8 @@ en:
           modify: Modify the proposal
           not_geocoded: Your address has not been geocoded, the preview is not available.
           proposal_edit_before_minutes:
-            one: You will be able to edit this proposal during the first minute after
-              the proposal is published. Once this time window passes, you will not
-              be able to edit the proposal.
-            other: You will be able to edit this proposal during the first %{count}
-              minutes after the proposal is published. Once this time window passes,
-              you will not be able to edit the proposal.
+            one: You will be able to edit this proposal during the first minute after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
+            other: You will be able to edit this proposal during the first %{count} minutes after the proposal is published. Once this time window passes, you will not be able to edit the proposal.
           publish: Publish
           title: Publish your proposal
           update_pos: Update the position
@@ -844,16 +716,13 @@ en:
           hidden_endorsers_count:
             one: and %{count} more person
             other: and %{count} more people
-          link_to_collaborative_draft_help_text: This proposal is the result of a
-            collaborative draft. Review the history
+          link_to_collaborative_draft_help_text: This proposal is the result of a collaborative draft. Review the history
           link_to_collaborative_draft_text: See the collaborative draft
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_in_evaluation_reason: This proposal is being evaluated
           proposal_rejected_reason: 'This proposal has been rejected because:'
           report: Report
-          withdraw_btn_hint: You can withdraw your proposal if you change your mind,
-            as long as you have not received any support. The proposal is not deleted,
-            it will appear in the list of withdrawn proposals.
+          withdraw_btn_hint: You can withdraw your proposal if you change your mind, as long as you have not received any support. The proposal is not deleted, it will appear in the list of withdrawn proposals.
           withdraw_confirmation: Are you sure you want to withdraw this proposal?
           withdraw_proposal: Withdraw proposal
         tags:
@@ -884,16 +753,13 @@ en:
           can_accumulate_supports_beyond_threshold:
             description: Each proposal can accumulate more than %{limit} supports
           minimum_votes_per_user:
-            description: You must distribute a minimum of %{votes} supports among
-              different proposals.
+            description: You must distribute a minimum of %{votes} supports among different proposals.
             given_enough_votes: You've given enough supports.
-            supports_remaining: You have to support %{remaining_votes} more proposals
-              for your supports to be taken into account.
+            supports_remaining: You have to support %{remaining_votes} more proposals for your supports to be taken into account.
           proposal_limit:
             description: You can create up to %{limit} proposals.
           threshold_per_proposal:
-            description: In order to be validated proposals need to reach %{limit}
-              supports
+            description: In order to be validated proposals need to reach %{limit} supports
           title: 'Supports are subject to the following rules:'
           vote_limit:
             description: You can support up to %{limit} proposals.
@@ -935,8 +801,7 @@ en:
           version_index: Version %{index}
       withdraw:
         errors:
-          has_supports: This proposal can not be withdrawn because it already has
-            supports.
+          has_supports: This proposal can not be withdrawn because it already has supports.
     resource_links:
       copied_from_component:
         proposal_proposal: Related proposals

--- a/decidim-proposals/config/locales/fr.yml
+++ b/decidim-proposals/config/locales/fr.yml
@@ -697,6 +697,7 @@ fr:
           creation_date: 'Création : %{date}'
           view_proposal: Voir la proposition
         show:
+          back: Retourner à la liste
           back_to: Retour à
           edit_proposal: Modifier la proposition
           endorsements_list: Liste des soutiens

--- a/decidim-proposals/spec/system/show_spec.rb
+++ b/decidim-proposals/spec/system/show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "show", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "proposals" }
+
+  let!(:proposal) { create(:proposal, component: component) }
+
+  before do
+    visit_component
+    click_link proposal.title[I18n.locale.to_s], class: "card__link"
+  end
+
+  context "when shows the proposal component" do
+
+    it "shows the proposal title" do
+      expect(page).to have_content proposal.title[I18n.locale.to_s]
+    end
+
+    it "shows the back button" do
+      expect(page).to have_link(href: "#{main_component_path(component)}proposals")
+    end
+
+  end
+
+  context "when clicking the back button" do
+
+    before do
+      visit_component
+      click_link(href: "#{main_component_path(component)}proposals")
+    end
+
+    it "redirect the user to index proposals" do
+      expect(page).to have_current_path("#{main_component_path(component)}proposals")
+    end
+
+  end
+end

--- a/decidim-proposals/spec/system/show_spec.rb
+++ b/decidim-proposals/spec/system/show_spec.rb
@@ -14,7 +14,6 @@ describe "show", type: :system do
   end
 
   context "when shows the proposal component" do
-
     it "shows the proposal title" do
       expect(page).to have_content proposal.title[I18n.locale.to_s]
     end
@@ -22,11 +21,9 @@ describe "show", type: :system do
     it "shows the back button" do
       expect(page).to have_link(href: "#{main_component_path(component)}proposals")
     end
-
   end
 
   context "when clicking the back button" do
-
     before do
       visit_component
       click_link(href: "#{main_component_path(component)}proposals")
@@ -35,6 +32,5 @@ describe "show", type: :system do
     it "redirect the user to index proposals" do
       expect(page).to have_current_path("#{main_component_path(component)}proposals")
     end
-
   end
 end

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="row column view-header">
-  <%= link_to :sortitions, class: "muted-link" do %>
+  <%= link_to :sortitions, class: "title-action__action button small hollow" do %>
     <%= icon "chevron-left", class: "icon--small" %>
     <%= t(".back") %>
   <% end %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/show.html.erb
@@ -11,6 +11,10 @@
 </div>
 
 <div class="row column view-header">
+  <%= link_to :sortitions, class: "muted-link" do %>
+    <%= icon "chevron-left", class: "icon--small" %>
+    <%= t(".back") %>
+  <% end %>
   <h2 class="heading2"><%= translated_attribute sortition.title %></h2>
   <div class="author-data">
     <%= render partial: "sortition_author", locals: { sortition: sortition } %>

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
         show:
           algorithm: Sortition's algorithm code
           any_category: from all categories
+          back: Back to list
           cancelled: Cancelled sortition
           candidate_proposal_ids: Sortition proposals order and IDs
           candidate_proposals_info: 'The sortition was carried out among the following proposals (%{category_label}), with the following IDs (in bold the selected proposals)  '

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -4,16 +4,10 @@ en:
     attributes:
       sortition:
         additional_info: Sortition information
-        decidim_category_id: Categories of the set of proposals in which you want
-          to apply the draw
+        decidim_category_id: Categories of the set of proposals in which you want to apply the draw
         decidim_proposals_component_id: Proposals set
-        dice: Result of die roll. Roll a 6-sided die, or look for another random way
-          to generate a number from 1 to 6, and enter here the resulting number in
-          front of some witnesses. This contributes to the quality and guarantees
-          of the randomness of the result
-        target_items: Number of proposals to be selected (indicates the number of
-          proposals you want to be selected by drawing lots of the group of proposals
-          you have previously chosen)
+        dice: Result of die roll. Roll a 6-sided die, or look for another random way to generate a number from 1 to 6, and enter here the resulting number in front of some witnesses. This contributes to the quality and guarantees of the randomness of the result
+        target_items: Number of proposals to be selected (indicates the number of proposals you want to be selected by drawing lots of the group of proposals you have previously chosen)
         title: Title
         witnesses: Witnesses
     models:
@@ -33,14 +27,10 @@ en:
     events:
       sortitions:
         sortition_created:
-          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}"
-            that you are following.
-          email_outro: You have received this notification because you are following
-            "%{participatory_space_title}". You can unfollow it from the previous
-            link.
+          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
+          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New sortition added to %{participatory_space_title}
-          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a>
-            has been added to %{participatory_space_title}
+          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
     pages:
       home:
         statistics:
@@ -91,12 +81,7 @@ en:
           index:
             title: Sortitions
           new:
-            confirm: By pressing the next button Decidim will record the date and
-              time (with precision of seconds) and together with the dice roll, this
-              information will be used to generate a random selection. The action
-              will be irreversible, once the button is clicked the result of this
-              draw will be published, together with the data entered in this form
-              and can not be modified, please check the content carefully
+            confirm: By pressing the next button Decidim will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
             create: Create
             title: New sortition
           show:
@@ -143,23 +128,10 @@ en:
           back: Back to list
           cancelled: Cancelled sortition
           candidate_proposal_ids: Sortition proposals order and IDs
-          candidate_proposals_info: 'The sortition was carried out among the following
-            proposals (%{category_label}), with the following IDs (in bold the selected
-            proposals)  '
+          candidate_proposals_info: 'The sortition was carried out among the following proposals (%{category_label}), with the following IDs (in bold the selected proposals)  '
           category: from the %{category} category
           dice_result: "(1) Dice result"
-          introduction: 'This page contains the results of the sortition %{reference}.
-            By means of this sortition, %{target_items} number of results have been
-            selected randomly and with an equal probability distribution from the
-            set of proposals displayed bellow. Together with the results, the information
-            displayed on this page provides all the information required to maximize
-            guarantees and to reproduce the results. The key to the quality of this
-            sortition is the double randomness provided by a the rolling of a dice(verified
-            by witnesses) and the precise time of the sortition that provides input
-            for an algorithm that generates a random selection. The time-seed for
-            the sortition is so accurate (seconds) that it is impossible to control
-            by humans thus providing a double "uncontrollable" input to guarantee
-            a fair result.  '
+          introduction: 'This page contains the results of the sortition %{reference}. By means of this sortition, %{target_items} number of results have been selected randomly and with an equal probability distribution from the set of proposals displayed bellow. Together with the results, the information displayed on this page provides all the information required to maximize guarantees and to reproduce the results. The key to the quality of this sortition is the double randomness provided by a the rolling of a dice(verified by witnesses) and the precise time of the sortition that provides input for an algorithm that generates a random selection. The time-seed for the sortition is so accurate (seconds) that it is impossible to control by humans thus providing a double "uncontrollable" input to guarantee a fair result.  '
           mathematical_result: Result (1) x (2)
           proposals_selected_by_sortition: Proposals selected by sortition
           sortition_reproducibility_details: Sortition reproducibility details

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -4,10 +4,16 @@ en:
     attributes:
       sortition:
         additional_info: Sortition information
-        decidim_category_id: Categories of the set of proposals in which you want to apply the draw
+        decidim_category_id: Categories of the set of proposals in which you want
+          to apply the draw
         decidim_proposals_component_id: Proposals set
-        dice: Result of die roll. Roll a 6-sided die, or look for another random way to generate a number from 1 to 6, and enter here the resulting number in front of some witnesses. This contributes to the quality and guarantees of the randomness of the result
-        target_items: Number of proposals to be selected (indicates the number of proposals you want to be selected by drawing lots of the group of proposals you have previously chosen)
+        dice: Result of die roll. Roll a 6-sided die, or look for another random way
+          to generate a number from 1 to 6, and enter here the resulting number in
+          front of some witnesses. This contributes to the quality and guarantees
+          of the randomness of the result
+        target_items: Number of proposals to be selected (indicates the number of
+          proposals you want to be selected by drawing lots of the group of proposals
+          you have previously chosen)
         title: Title
         witnesses: Witnesses
     models:
@@ -27,10 +33,14 @@ en:
     events:
       sortitions:
         sortition_created:
-          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
-          email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
+          email_intro: The sortition "%{resource_title}" has been added to "%{participatory_space_title}"
+            that you are following.
+          email_outro: You have received this notification because you are following
+            "%{participatory_space_title}". You can unfollow it from the previous
+            link.
           email_subject: New sortition added to %{participatory_space_title}
-          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
+          notification_title: The sortition <a href="%{resource_path}">%{resource_title}</a>
+            has been added to %{participatory_space_title}
     pages:
       home:
         statistics:
@@ -81,7 +91,12 @@ en:
           index:
             title: Sortitions
           new:
-            confirm: By pressing the next button Decidim will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
+            confirm: By pressing the next button Decidim will record the date and
+              time (with precision of seconds) and together with the dice roll, this
+              information will be used to generate a random selection. The action
+              will be irreversible, once the button is clicked the result of this
+              draw will be published, together with the data entered in this form
+              and can not be modified, please check the content carefully
             create: Create
             title: New sortition
           show:
@@ -128,10 +143,23 @@ en:
           back: Back to list
           cancelled: Cancelled sortition
           candidate_proposal_ids: Sortition proposals order and IDs
-          candidate_proposals_info: 'The sortition was carried out among the following proposals (%{category_label}), with the following IDs (in bold the selected proposals)  '
+          candidate_proposals_info: 'The sortition was carried out among the following
+            proposals (%{category_label}), with the following IDs (in bold the selected
+            proposals)  '
           category: from the %{category} category
           dice_result: "(1) Dice result"
-          introduction: 'This page contains the results of the sortition %{reference}. By means of this sortition, %{target_items} number of results have been selected randomly and with an equal probability distribution from the set of proposals displayed bellow. Together with the results, the information displayed on this page provides all the information required to maximize guarantees and to reproduce the results. The key to the quality of this sortition is the double randomness provided by a the rolling of a dice(verified by witnesses) and the precise time of the sortition that provides input for an algorithm that generates a random selection. The time-seed for the sortition is so accurate (seconds) that it is impossible to control by humans thus providing a double "uncontrollable" input to guarantee a fair result.  '
+          introduction: 'This page contains the results of the sortition %{reference}.
+            By means of this sortition, %{target_items} number of results have been
+            selected randomly and with an equal probability distribution from the
+            set of proposals displayed bellow. Together with the results, the information
+            displayed on this page provides all the information required to maximize
+            guarantees and to reproduce the results. The key to the quality of this
+            sortition is the double randomness provided by a the rolling of a dice(verified
+            by witnesses) and the precise time of the sortition that provides input
+            for an algorithm that generates a random selection. The time-seed for
+            the sortition is so accurate (seconds) that it is impossible to control
+            by humans thus providing a double "uncontrollable" input to guarantee
+            a fair result.  '
           mathematical_result: Result (1) x (2)
           proposals_selected_by_sortition: Proposals selected by sortition
           sortition_reproducibility_details: Sortition reproducibility details

--- a/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
@@ -25,7 +25,6 @@ describe "show", type: :system do
     it "shows the back button" do
       expect(page).to have_link(href: "#{main_component_path(component)}sortitions")
     end
-
   end
 
   context "when sortition result" do
@@ -67,7 +66,6 @@ describe "show", type: :system do
   end
 
   context "when clicking the back button" do
-
     before do
       visit_component
       click_link(href: "#{main_component_path(component)}sortitions")
@@ -76,6 +74,5 @@ describe "show", type: :system do
     it "redirect the user to index sortitions" do
       expect(page).to have_current_path("#{main_component_path(component)}sortitions")
     end
-
   end
 end

--- a/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
@@ -21,6 +21,11 @@ describe "show", type: :system do
     it "shows the sortition witnesses" do
       expect(page).to have_content(sortition.witnesses[:en])
     end
+
+    it "shows the back button" do
+      expect(page).to have_link(href: "#{main_component_path(component)}sortitions")
+    end
+
   end
 
   context "when sortition result" do
@@ -59,5 +64,18 @@ describe "show", type: :system do
     it "shows the cancel reasons" do
       expect(page).to have_content(sortition.cancel_reason[:en])
     end
+  end
+
+  context "when clicking the back button" do
+
+    before do
+      visit_component
+      click_link(href: "#{main_component_path(component)}sortitions")
+    end
+
+    it "redirect the user to index sortitions" do
+      expect(page).to have_current_path("#{main_component_path(component)}sortitions")
+    end
+
   end
 end


### PR DESCRIPTION
# Add a return button in the FO

Add a "back to the list" button on the FO allowing user to go back to the component list

#### :tophat: What? Why?


As a user, when clicking on a card on the Index, I want to be able to return to the list of cards (index) easily.

This button should be available on the cards of :
- Proposals
- News
- Meetings
- Sortitions
- Debates

#### :clipboard: Tasks

- [x] Implement back link into components show page
- [x] Add tests


#### :pushpin: Related Issues
https://meta.decidim.org/processes/roadmap/f/122/proposals/14938
