### PR TITLE
Image responsive helper - OpenSourcePolitics/decidim#846

### DIFF
--- a/decidim-core/app/helpers/decidim/image_responsive_helper.rb
+++ b/decidim-core/app/helpers/decidim/image_responsive_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A Helper to render image according to the device screen
+  module ImageResponsiveHelper
+    def image_responsive(image, options = {})
+      content_tag(:picture) do
+        concat content_tag(:source, nil, media: "(max-width: 768px)", srcset: image.url(:xs)) if image.version_exists? :xs
+        concat content_tag(:source, nil, media: "(max-width: 992px)", srcset: image.url(:md)) if image.version_exists? :md
+        concat image_tag(image.url, options)
+      end
+    end
+  end
+end

--- a/decidim-core/app/uploaders/decidim/banner_image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/banner_image_uploader.rb
@@ -5,5 +5,12 @@ module Decidim
   class BannerImageUploader < ImageUploader
     process resize_to_limit: [1200, 600]
     process quality: 60
+
+    version :md do
+      process resize_to_limit: [815, 315]
+    end
+    version :xs do
+      process resize_to_limit: [560, 315]
+    end
   end
 end

--- a/decidim-core/spec/helpers/decidim/image_responsive_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/image_responsive_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  include CarrierWave::Test::Matchers
+  describe ImageResponsiveHelper, type: :helper do
+    describe "#image_responsive" do
+      let(:participatory_process) { create(:participatory_process) }
+
+      it "includes picture html tag " do
+        expect(helper.image_responsive(participatory_process.banner_image)).to include("<picture>")
+        expect(helper.image_responsive(participatory_process.banner_image)).to include("<source media=\"(max-width: 768px)\" srcset=\"/uploads/decidim/participatory_process/banner_image/#{participatory_process.id}/xs_city2.jpeg\"></source>")
+        expect(helper.image_responsive(participatory_process.banner_image)).to include("<source media=\"(max-width: 992px)\" srcset=\"/uploads/decidim/participatory_process/banner_image/#{participatory_process.id}/md_city2.jpeg\"></source>")
+      end
+
+      it "displays a fallback img tag" do
+        expect(helper.image_responsive(participatory_process.banner_image)).to include("<img src=\"/uploads/decidim/participatory_process/banner_image/#{participatory_process.id}/city2.jpeg\" />")
+      end
+
+      context "when there is a missing version" do
+        before do
+          BannerImageUploader.versions.delete(:xs)
+        end
+
+        it "doesn't display the concerned version" do
+          expect(helper.image_responsive(participatory_process.banner_image)).to include("<picture>")
+          expect(helper.image_responsive(participatory_process.banner_image)).to include("<source media=\"(max-width: 992px)\" srcset=\"/uploads/decidim/participatory_process/banner_image/#{participatory_process.id}/md_city2.jpeg\"></source>")
+          expect(helper.image_responsive(participatory_process.banner_image)).not_to include("<source media=\"(max-width: 768px)\" srcset=\"/uploads/decidim/participatory_process/banner_image/#{participatory_process.id}/xs_city2.jpeg\"></source>")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Image responsive helper

#### :tophat: What? Why?

Image helper which allows to implement responsive image tag. This helper display the most adapted 
image version according to the user screen.

According to the mozilla definition, the Picture tag behaviour allows to display image even if the browser doesn't support this tag : 

> If no matches are found—or the browser doesn't support the <picture> element—the URL of the <img> element's src attribute is selected. The selected image is then presented in the space occupied by the <img> element.

The html tag used for this helper is supported by multiple browsers (cf: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)

#### :pushpin: Related Issues
- Fixes OpenSourcePolitics/decidim#846

#### :clipboard: Subtasks
- [x] Add Image Responsive Helper
- [x] Add tests


#### :camera: Screenshots

This helper works on several browsers (screenshot from Browserstack according to the review) 

* edge-79:beta
<img width="1100" alt="edge-79-beta" src="https://user-images.githubusercontent.com/26109239/74144438-01f71300-4bfd-11ea-9cde-62ca19d26ba3.png">

* ie-11:latest
<img width="876" alt="ie11-latest" src="https://user-images.githubusercontent.com/26109239/74144685-7a5dd400-4bfd-11ea-95ca-87d4b35d96bf.png">

* firefox-72:latest
<img width="677" alt="firefox-72" src="https://user-images.githubusercontent.com/26109239/74145163-754d5480-4bfe-11ea-95f5-b694be15998a.png">

* safari:5.1 doesn't support the picture tag but display the original source
<img width="453" alt="safari-5 1" src="https://user-images.githubusercontent.com/26109239/74145382-f9074100-4bfe-11ea-8eba-3ed5179c9b50.png">




