### PR TITLE
Fix meetings displaying when process is not published

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -57,7 +57,7 @@ module Decidim
 
     def public_participatory_spaces
       @public_participatory_spaces ||= Decidim.participatory_space_manifests.flat_map do |manifest|
-        manifest.participatory_spaces.call(self).public_spaces
+        manifest.participatory_spaces.call(self).public_spaces.published
       end
     end
 

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -37,5 +37,15 @@ module Decidim
         expect(subject).not_to be_valid
       end
     end
+
+    describe "retrieve public participatory spaces" do
+      let(:participatory_spaces) { create_list(:participatory_process, 5, organization: organization, published_at: 2.days.ago) }
+      let(:unpublished_participatory_space) { create(:participatory_process, organization: organization, published_at: nil) }
+      let(:public_participatory_spaces) { organization.public_participatory_spaces }
+
+      it "returns only published public participatory spaces" do
+        expect(participatory_spaces).to contain_exactly(*participatory_spaces)
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -46,6 +46,10 @@ module Decidim
       it "returns only published public participatory spaces" do
         expect(participatory_spaces).to contain_exactly(*participatory_spaces)
       end
+
+      it "doesn't return unpublished public participatory spaces" do
+        expect(participatory_spaces).not_to include(*unpublished_participatory_space)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Meetings of an unpublished Participatory process are displayed on the "Upcoming events" section of the Homepage.

#### :clipboard: Subtasks
- [x] Filter by published participatory spaces
- [x] Add tests

#### Related to

* Issue: OpenSourcePolitics/decidim#882

#### Reproduce bug

**To reproduce :** 

- Create a PP
- Create Meetings component
- Create a meeting
- Activate the "Upcoming events" on the Homepage
- See error