### PR TITLE
Feature cd44 export proposals

### DIFF
--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -12,7 +12,11 @@ module Decidim
       collection = export_manifest.collection.call(component)
       serializer = export_manifest.serializer
 
-      export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer).export
+      export_data = if serializer == Decidim::Proposals::ProposalSerializer
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).admin_export
+                    else
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).export
+                    end
 
       ExportMailer.export(user, name, export_data).deliver_now
     end

--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -24,6 +24,21 @@ module Decidim
         ExportData.new(data, "csv")
       end
 
+      # Public: Exports a CSV serialized version of the collection using the
+      # provided serializer and following the previously described strategy.
+      # It injects some informations as author's data which can only be exported by admin
+      #
+      # Returns an ExportData instance.
+      def admin_export(col_sep = Decidim.default_csv_col_sep)
+        data = ::CSV.generate(headers: admin_headers, write_headers: true, col_sep: col_sep) do |csv|
+          admin_processed_collection.each do |resource|
+            csv << admin_headers.map { |header| resource[header] }
+          end
+        end
+
+        ExportData.new(data, "csv")
+      end
+
       private
 
       def headers
@@ -32,9 +47,21 @@ module Decidim
         processed_collection.first.keys
       end
 
+      def admin_headers
+        return [] if admin_processed_collection.empty?
+
+        admin_processed_collection.first.keys
+      end
+
       def processed_collection
         @processed_collection ||= collection.map do |resource|
           flatten(@serializer.new(resource).serialize)
+        end
+      end
+
+      def admin_processed_collection
+        @admin_processed_collection ||= collection.map do |resource|
+          flatten(@serializer.new(resource, false).serialize)
         end
       end
 

--- a/decidim-core/lib/decidim/exporters/excel.rb
+++ b/decidim-core/lib/decidim/exporters/excel.rb
@@ -44,6 +44,37 @@ module Decidim
 
         ExportData.new(output.string, "xls")
       end
+
+      # Public: Exports a file in an Excel readable format.
+      #
+      # Returns an ExportData instance.
+      def admin_export
+        book = Spreadsheet::Workbook.new
+        sheet = book.create_worksheet
+        sheet.name = "Export"
+
+        sheet.row(0).default_format = Spreadsheet::Format.new(
+          weight: :bold,
+          pattern: 1,
+          pattern_fg_color: :xls_color_14,
+          horizontal_align: :center
+        )
+
+        sheet.row(0).replace admin_headers
+
+        admin_headers.length.times.each do |index|
+          sheet.column(index).width = 20
+        end
+
+        admin_processed_collection.each_with_index do |resource, index|
+          sheet.row(index + 1).replace(admin_headers.map { |header| resource[header] })
+        end
+
+        output = StringIO.new
+        book.write output
+
+        ExportData.new(output.string, "xls")
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/exporters/json.rb
+++ b/decidim-core/lib/decidim/exporters/json.rb
@@ -18,6 +18,19 @@ module Decidim
 
         ExportData.new(data, "json")
       end
+
+      # Public: Generates a JSON representation of a collection and a
+      # Serializer.
+      # It injects some informations as author's data which can only be exported by admin
+      #
+      # Returns an ExportData with the export.
+      def admin_export
+        data = ::JSON.pretty_generate(@collection.map do |resource|
+          @serializer.new(resource, false).serialize
+        end)
+
+        ExportData.new(data, "json")
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/exporters/csv_spec.rb
+++ b/decidim-core/spec/lib/exporters/csv_spec.rb
@@ -9,8 +9,9 @@ module Decidim
 
     let(:serializer) do
       Class.new do
-        def initialize(resource)
+        def initialize(resource, public_scope = true)
           @resource = resource
+          @public_scope = public_scope
         end
 
         def serialize
@@ -35,6 +36,26 @@ module Decidim
         exported = subject.export.read
         data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
         expect(data[0]["serialized_name/ca"]).to eq("foocat")
+      end
+
+      it "defines processed_collection only" do
+        subject.export
+        expect(subject.instance_variable_get(:@processed_collection)).not_to eq(nil)
+        expect(subject.instance_variable_get(:@admin_processed_collection)).to eq(nil)
+      end
+    end
+
+    describe "admin export" do
+      it "exports the collection using the right serializer" do
+        exported = subject.admin_export.read
+        data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
+        expect(data[0]["serialized_name/ca"]).to eq("foocat")
+      end
+
+      it "defines admin_processed_collection only" do
+        subject.admin_export
+        expect(subject.instance_variable_get(:@processed_collection)).to eq(nil)
+        expect(subject.instance_variable_get(:@admin_processed_collection)).not_to eq(nil)
       end
     end
   end

--- a/decidim-core/spec/lib/exporters/excel_spec.rb
+++ b/decidim-core/spec/lib/exporters/excel_spec.rb
@@ -9,8 +9,9 @@ module Decidim
 
     let(:serializer) do
       Class.new do
-        def initialize(resource)
+        def initialize(resource, public_scope = true)
           @resource = resource
+          @public_scope = public_scope
         end
 
         def serialize
@@ -46,6 +47,35 @@ module Decidim
 
         expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
         expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
+      end
+
+      it "defines processed_collection only" do
+        subject.export
+        expect(subject.instance_variable_get(:@processed_collection)).not_to eq(nil)
+        expect(subject.instance_variable_get(:@admin_processed_collection)).to eq(nil)
+      end
+    end
+
+    describe "admin export" do
+      it "exports the collection using the right serializer" do
+        exported = StringIO.new(subject.admin_export.read)
+        book = Spreadsheet.open(exported)
+        worksheet = book.worksheet(0)
+        expect(worksheet.rows.length).to eq(3)
+
+        headers = worksheet.rows[0]
+        expect(headers).to eq(["id", "serialized_name/ca", "serialized_name/es", "other_ids", "float", "date"])
+        expect(worksheet.rows[1][0..4]).to eq([1, "foocat", "fooes", "1, 2, 3", 1.66])
+        expect(worksheet.rows[1].datetime(5)).to eq(Time.zone.local(2017, 10, 1, 5, 0))
+
+        expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
+        expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
+      end
+
+      it "defines admin_processed_collection only" do
+        subject.admin_export
+        expect(subject.instance_variable_get(:@processed_collection)).to eq(nil)
+        expect(subject.instance_variable_get(:@admin_processed_collection)).not_to eq(nil)
       end
     end
   end

--- a/decidim-core/spec/lib/exporters/json_spec.rb
+++ b/decidim-core/spec/lib/exporters/json_spec.rb
@@ -8,8 +8,9 @@ module Decidim
 
     let(:serializer) do
       Class.new do
-        def initialize(resource)
+        def initialize(resource, public_scope = true)
           @resource = resource
+          @public_scope = public_scope
         end
 
         def serialize
@@ -28,6 +29,14 @@ module Decidim
     describe "export" do
       it "exports the collection using the right serializer" do
         json = JSON.parse(subject.export.read)
+        expect(json[0]).to eq("id" => 1, "serialized_name" => "foo")
+        expect(json[1]).to eq("id" => 2, "serialized_name" => "bar")
+      end
+    end
+
+    describe "admin export" do
+      it "exports the collection using the right serializer" do
+        json = JSON.parse(subject.admin_export.read)
         expect(json[0]).to eq("id" => 1, "serialized_name" => "foo")
         expect(json[1]).to eq("id" => 2, "serialized_name" => "bar")
       end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -139,6 +139,7 @@ module Decidim
           subject do
             described_class.new(proposal, false)
           end
+
           let(:serialized) { subject.serialize }
 
           it "serializes author's data" do
@@ -194,7 +195,6 @@ module Decidim
               expect(serialized[:author_group][:id]).to be_empty
             end
           end
-
         end
       end
     end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -181,6 +181,20 @@ module Decidim
             end
           end
 
+          context "when author is the organization" do
+            let(:proposal) { create(:proposal, :accepted, :official) }
+
+            it "data in author are empty" do
+              expect(serialized[:author][:name]).to be_empty
+              expect(serialized[:author][:id]).to be_empty
+            end
+
+            it "data in author group are not empty" do
+              expect(serialized[:author_group][:name]).to be_empty
+              expect(serialized[:author_group][:id]).to be_empty
+            end
+          end
+
         end
       end
     end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -189,7 +189,7 @@ module Decidim
               expect(serialized[:author][:id]).to be_empty
             end
 
-            it "data in author group are not empty" do
+            it "data in author group are empty" do
               expect(serialized[:author_group][:name]).to be_empty
               expect(serialized[:author_group][:id]).to be_empty
             end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -152,7 +152,7 @@ module Decidim
           context "when author is not a group" do
             it "data in author are not empty" do
               expect(serialized[:author][:name]).not_to be_empty
-              expect(serialized[:author][:id]).to eq(proposal.creator_author.id)
+              expect(serialized[:author][:id]).to eq(proposal.creator_identity.id)
             end
 
             it "data in author group are empty" do
@@ -162,8 +162,13 @@ module Decidim
           end
 
           context "when author is a group" do
-            let(:user_group) { create(:user_group) }
-            let!(:proposal) { create(:proposal, :accepted, user_groups: user_group) }
+            let(:author) { create(:user, :confirmed, organization: proposal.organization) }
+            let(:user_group) { create(:user_group, :verified, users: [author], organization: proposal.organization) }
+
+            before do
+              proposal.coauthorships.clear
+              proposal.add_coauthor(author, user_group: user_group)
+            end
 
             it "data in author are empty" do
               expect(serialized[:author][:name]).to be_empty
@@ -172,8 +177,7 @@ module Decidim
 
             it "data in author group are not empty" do
               expect(serialized[:author_group][:name]).not_to be_empty
-              expect(serialized[:author_group][:id]).not_to be_empty
-              expect(serialized[:author_group][:id]).to match(/^[0-9]+$/)
+              expect(serialized[:author_group][:id]).to eq(proposal.creator_identity.id)
             end
           end
 

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -131,7 +131,15 @@ module Decidim
           expect(serialized).not_to include(:author)
         end
 
+        it "doesn't serialize author's group data" do
+          expect(serialized).not_to include(:author_group)
+        end
+
         context "when data is exported from backoffice" do
+          subject do
+            described_class.new(proposal, false)
+          end
+          let(:serialized) { subject.serialize }
 
           it "serializes author's data" do
             expect(serialized).to include(:author)
@@ -144,31 +152,31 @@ module Decidim
           context "when author is not a group" do
             it "data in author are not empty" do
               expect(serialized[:author][:name]).not_to be_empty
-              expect(serialized[:author][:id]).not_to be_empty
+              expect(serialized[:author][:id]).to eq(proposal.creator_author.id)
             end
 
             it "data in author group are empty" do
-              expect(serialized[:author_group][:name]).to be_empty
+              expect(serialized[:author_group][:name]).to eq("")
               expect(serialized[:author_group][:id]).to be_empty
             end
           end
 
           context "when author is a group" do
-            it "data in author are not empty" do
+            let(:user_group) { create(:user_group) }
+            let!(:proposal) { create(:proposal, :accepted, user_groups: user_group) }
+
+            it "data in author are empty" do
               expect(serialized[:author][:name]).to be_empty
               expect(serialized[:author][:id]).to be_empty
             end
 
-            it "data in author group are empty" do
+            it "data in author group are not empty" do
               expect(serialized[:author_group][:name]).not_to be_empty
               expect(serialized[:author_group][:id]).not_to be_empty
+              expect(serialized[:author_group][:id]).to match(/^[0-9]+$/)
             end
           end
 
-          it "ID field is numeric" do
-            expect(serialized[:author][:id]).to match(/^[0-9]+$/)
-            expect(serialized[:author_group][:id]).to match(/^[0-9]+$/)
-          end
         end
       end
     end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -126,6 +126,50 @@ module Decidim
             expect(serialized).to include(answer: expected_answer)
           end
         end
+
+        it "doesn't serialize author's data" do
+          expect(serialized).not_to include(:author)
+        end
+
+        context "when data is exported from backoffice" do
+
+          it "serializes author's data" do
+            expect(serialized).to include(:author)
+          end
+
+          it "serializes author's group data" do
+            expect(serialized).to include(:author_group)
+          end
+
+          context "when author is not a group" do
+            it "data in author are not empty" do
+              expect(serialized[:author][:name]).not_to be_empty
+              expect(serialized[:author][:id]).not_to be_empty
+            end
+
+            it "data in author group are empty" do
+              expect(serialized[:author_group][:name]).to be_empty
+              expect(serialized[:author_group][:id]).to be_empty
+            end
+          end
+
+          context "when author is a group" do
+            it "data in author are not empty" do
+              expect(serialized[:author][:name]).to be_empty
+              expect(serialized[:author][:id]).to be_empty
+            end
+
+            it "data in author group are empty" do
+              expect(serialized[:author_group][:name]).not_to be_empty
+              expect(serialized[:author_group][:id]).not_to be_empty
+            end
+          end
+
+          it "ID field is numeric" do
+            expect(serialized[:author][:id]).to match(/^[0-9]+$/)
+            expect(serialized[:author_group][:id]).to match(/^[0-9]+$/)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Add some fields for the proposals exports from backoffice. 
Also, add a logic to add more fields in proposals exports only for administrator exports and not exported in open data. 

#### :clipboard: Subtasks
- [x] Add tests
- [x] Add missing fields in proposals export
- [x] Enable adding more fields for administrator proposals exports
