### PR TITLE
Special characters message for new registration

### DIFF
--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -14,7 +14,9 @@ module Decidim
     attribute :tos_agreement, Boolean
 
     validates :name, presence: true
+    validates :name, format: { with: /\A(?!.*[<>?%&\^*#@\(\)\[\]\=\+\:\;\"\{\}\\\|])/, message: I18n.t("decidim.forms.errors.special_characters") }
     validates :nickname, presence: true, length: { maximum: Decidim::User.nickname_max_length }
+    validates :nickname, format: { with: /\A(?!.*[<>?%&\^*#@\(\)\[\]\=\+\:\;\"\{\}\\\|])/, message: I18n.t("decidim.forms.errors.special_characters") }
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
     validates :password, confirmation: true
     validates :password, password: { name: :name, email: :email, username: :nickname }

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1260,6 +1260,7 @@ en:
     password_too_common: is too common
     password_too_long: is too long
     password_too_short: is too short
+    username_included_in_password: is too similar to your username
   social_share_button:
     delicious: Delicious
     douban: Douban

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -554,6 +554,7 @@ en:
       default_image: Default image
       errors:
         error: There's an error in this field.
+        special_characters: Please avoid special characters
       remove_this_file: Remove this file
     gamification:
       all_badges_link: See all available badges.

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -1249,6 +1249,7 @@ fr:
     password_too_common: est trop commun
     password_too_long: est trop long
     password_too_short: est trop court
+    username_included_in_password: est trop similaire à votre surnom
   social_share_button:
     delicious: Delicious
     douban: Douban

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -543,6 +543,7 @@ fr:
       default_image: Image par défaut
       errors:
         error: Ce champ contient une erreur.
+        special_characters: Veillez à ne pas renseigner de caractères spéciaux
       remove_this_file: Supprimer ce fichier
     gamification:
       all_badges_link: Voir tous les badges disponibles.

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -53,6 +53,12 @@ module Decidim
       it { is_expected.to be_invalid }
     end
 
+    context "when the name contains special characters" do
+      let(:name) { "§!çname23éà)" }
+
+      it { is_expected.to be_invalid }
+    end
+
     context "when the nickname is not present" do
       let(:nickname) { nil }
 
@@ -79,6 +85,12 @@ module Decidim
 
     context "when the nickname is too long" do
       let(:nickname) { "verylongnicknamethatcreatesanerror" }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the nickname contains special characters" do
+      let(:nickname) { "§!çnickname23éà)" }
 
       it { is_expected.to be_invalid }
     end

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -33,6 +33,29 @@ describe "Registration", type: :system do
     end
   end
 
+  context "when name or nickname contains special chars" do
+    before do
+      fill_in :user_name, with: "#& Nikola Tesla"
+      fill_in :user_nickname, with: "#& the-greatest-genius-in-history"
+      fill_in :user_email, with: "nikola.tesla@example.org"
+      fill_in :user_password, with: "sekritpass123"
+      fill_in :user_password_confirmation, with: "sekritpass123"
+    end
+
+    it "fill name and nickname fields" do
+      click_button "Sign up"
+      click_button "Keep uncheck"
+
+      within "label[for='user_name']" do
+        expect(page).to have_content "Please avoid special characters"
+      end
+
+      within "label[for='user_nickname']" do
+        expect(page).to have_content "Please avoid special characters"
+      end
+    end
+  end
+
   context "when newsletter checkbox is unchecked" do
     it "opens modal on submit" do
       within "form.new_user" do


### PR DESCRIPTION
#### :tophat: What? Why?

When a user try to registrer on the platform, if he / she insert special chars in nickname or name, the validation will fail but no message is displayed. 

So a error message is now displayed when nickname or name field contains one or more special characters.

#### :clipboard: Subtasks
- [x] Update registration form and system specs
- [x] Add a new 'special_characters' attribute in locales
- [x] Add a format validation on name and nickname field
- [x] Add a french translation for nickname length