### PR TITLE
Allow users to register in their own language

### DIFF
--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -41,7 +41,8 @@ module Decidim
         tos_agreement: form.tos_agreement,
         newsletter_notifications_at: form.newsletter_at,
         email_on_notification: true,
-        accepted_tos_version: form.current_organization.tos_version
+        accepted_tos_version: form.current_organization.tos_version,
+        locale: form.current_locale
       )
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -16,14 +16,12 @@ module Decidim
 
       def new
         @form = form(RegistrationForm).from_params(
-          user: {
-            sign_up_as: "user"
-          }
+          user: { sign_up_as: "user" }
         )
       end
 
       def create
-        @form = form(RegistrationForm).from_params(params[:user])
+        @form = form(RegistrationForm).from_params(params[:user].merge(current_locale: current_locale))
 
         CreateRegistration.call(@form) do
           on(:ok) do |user|

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -12,6 +12,7 @@ module Decidim
     attribute :password_confirmation, String
     attribute :newsletter, Boolean
     attribute :tos_agreement, Boolean
+    attribute :current_locale, String
 
     validates :name, presence: true
     validates :nickname, presence: true, length: { maximum: Decidim::User.nickname_max_length }

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -15,6 +15,7 @@ module Decidim
         let(:password_confirmation) { password }
         let(:tos_agreement) { "1" }
         let(:newsletter) { "1" }
+        let(:current_locale) { "es" }
 
         let(:form_params) do
           {
@@ -31,7 +32,8 @@ module Decidim
         end
         let(:form) do
           RegistrationForm.from_params(
-            form_params
+              form_params,
+              current_locale: current_locale
           ).with_context(
             current_organization: organization
           )
@@ -70,7 +72,8 @@ module Decidim
               newsletter_notifications_at: form.newsletter_at,
               email_on_notification: true,
               organization: organization,
-              accepted_tos_version: organization.tos_version
+              accepted_tos_version: organization.tos_version,
+              locale: form.current_locale
             ).and_call_original
 
             expect { command.call }.to change(User, :count).by(1)

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -32,8 +32,8 @@ module Decidim
         end
         let(:form) do
           RegistrationForm.from_params(
-              form_params,
-              current_locale: current_locale
+            form_params,
+            current_locale: current_locale
           ).with_context(
             current_organization: organization
           )

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -31,6 +31,32 @@ describe "Authentication", type: :system do
       end
     end
 
+    context "when using another langage" do
+      before do
+        within_language_menu do
+          click_link "Castellano"
+        end
+      end
+
+      it "keeps the locale settings" do
+        find(".sign-up-link").click
+
+        within ".new_user" do
+          fill_in :user_email, with: "user@example.org"
+          fill_in :user_name, with: "Responsible Citizen"
+          fill_in :user_nickname, with: "responsible"
+          fill_in :user_password, with: "DfyvHn425mYAy2HL"
+          fill_in :user_password_confirmation, with: "DfyvHn425mYAy2HL"
+          check :user_tos_agreement
+          check :user_newsletter
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("¡Bienvenida! Te has registrado con éxito.")
+        expect(last_user.locale).to eq("es")
+      end
+    end
+
     context "when being a robot" do
       it "denies the sign up" do
         find(".sign-up-link").click


### PR DESCRIPTION
#### :tophat: What? Why?
Allow users to register in their own language

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)

### :ghost: GIF (optional)
![Description](URL)
