### PR TITLE
add new 'published_at' field in comment export

### DIFF
--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -30,7 +30,8 @@ module Decidim
         return common unless resource.upstream_moderation_activated?
 
         common.merge(
-          upstream_status: upstream_status
+          upstream_status: upstream_status,
+          published_at: upstream_moderation.try(:updated_at)
         )
       end
 
@@ -48,6 +49,14 @@ module Decidim
 
       def root_commentable_url
         @root_commentable_url ||= Decidim::ResourceLocatorPresenter.new(resource.root_commentable).url
+      end
+
+      def upstream_moderation
+        find_upstream_moderation_by_id(resource.id)
+      end
+
+      def find_upstream_moderation_by_id(id)
+        Decidim::UpstreamModeration.find_by decidim_upstream_reportable_id: id
       end
     end
   end

--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -31,7 +31,7 @@ module Decidim
 
         common.merge(
           upstream_status: upstream_status,
-          published_at: upstream_moderation.try(:updated_at)
+          published_at: upstream_moderation_updated_at
         )
       end
 
@@ -49,6 +49,14 @@ module Decidim
 
       def root_commentable_url
         @root_commentable_url ||= Decidim::ResourceLocatorPresenter.new(resource.root_commentable).url
+      end
+
+      # Updated_at field has to be nil when the comment is pending or hidden
+      def upstream_moderation_updated_at
+        return nil if resource.upstream_pending?
+        return nil if resource.upstream_hidden?
+
+        upstream_moderation.try(:updated_at)
       end
 
       def upstream_moderation


### PR DESCRIPTION
#### :tophat: What? Why?

Add a new field in comment export when upstream moderation is enabled.

#### :clipboard: Subtasks
- [x] Add a new field 'published_at' in comment export that corresponds to administrator validation
