### PR TITLE
Feature/add fields to personal data

### DIFF
--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -30,4 +30,10 @@
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= scope %>
   </div>
+  <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+    <%= user_scope %>
+  </div>
+  <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
+    <%= resident %>
+  </div>
 </div>

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -33,6 +33,14 @@ module Decidim
         metadata[:postal_code]
       end
 
+      def user_scope
+        metadata[:user_scope]
+      end
+
+      def resident
+        metadata[:resident]
+      end
+
       def time_and_date
         model.created_at
       end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -16,7 +16,7 @@ module Decidim
 
       helper InitiativeHelper
 
-      helper_method :initiative_type, :extra_data_legal_information
+      helper_method :initiative_type, :extra_data_legal_information, :user_scopes
 
       # GET /initiatives/:initiative_id/initiative_signatures/:step
       def show
@@ -42,11 +42,11 @@ module Decidim
         enforce_permission_to :vote, :initiative, initiative: current_initiative, group_id: group_id
 
         @form = form(Decidim::Initiatives::VoteForm)
-                .from_params(
-                  initiative: current_initiative,
-                  signer: current_user,
-                  group_id: group_id
-                )
+                    .from_params(
+                        initiative: current_initiative,
+                        signer: current_user,
+                        group_id: group_id
+                    )
 
         VoteInitiative.call(@form) do
           on(:ok) do
@@ -56,7 +56,7 @@ module Decidim
 
           on(:invalid) do
             render json: {
-              error: I18n.t("create.error", scope: "decidim.initiatives.initiative_votes")
+                error: I18n.t("create.error", scope: "decidim.initiatives.initiative_votes")
             }, status: :unprocessable_entity
           end
         end
@@ -66,11 +66,11 @@ module Decidim
 
       def fill_personal_data_step(_unused)
         @form = form(Decidim::Initiatives::VoteForm)
-                .from_params(
-                  initiative: current_initiative,
-                  signer: current_user,
-                  group_id: params[:group_id]
-                )
+                    .from_params(
+                        initiative: current_initiative,
+                        signer: current_user,
+                        group_id: params[:group_id]
+                    )
 
         session[:initiative_vote_form] = { group_id: @form.group_id }
         skip_step unless initiative_type.collect_user_extra_fields
@@ -163,7 +163,7 @@ module Decidim
         return unless raw_birth_date
 
         @vote_form = form(Decidim::Initiatives::VoteForm).from_params(
-          session[:initiative_vote_form].merge("date_of_birth" => Date.parse(raw_birth_date))
+            session[:initiative_vote_form].merge("date_of_birth" => Date.parse(raw_birth_date))
         )
       end
 
@@ -208,6 +208,10 @@ module Decidim
         initial_wizard_steps.unshift(:fill_personal_data) if fill_personal_data_step?
 
         self.steps = initial_wizard_steps
+      end
+
+      def user_scopes
+        @user_scopes ||= current_organization.scopes
       end
     end
   end

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -14,6 +14,8 @@ module Decidim
       attribute :name_and_surname, String
       attribute :document_number, String
       attribute :date_of_birth, Date
+      attribute :user_scope_id, Integer
+      attribute :resident, Boolean
 
       attribute :postal_code, String
       attribute :encrypted_metadata, String
@@ -30,6 +32,8 @@ module Decidim
         validate :document_number_authorized?
         validate :already_voted?
         validate :personal_data_consistent_with_metadata
+        validate :user_scope_belongs_to_organization?
+        validates :resident, acceptance: true
       end
 
       delegate :scope, to: :initiative
@@ -48,11 +52,11 @@ module Decidim
         return unless initiative && (document_number || signer)
 
         @hash_id ||= Digest::MD5.hexdigest(
-          [
-            initiative.id,
-            document_number || signer.id,
-            Rails.application.secrets.secret_key_base
-          ].compact.join("-")
+            [
+                initiative.id,
+                document_number || signer.id,
+                Rails.application.secrets.secret_key_base
+            ].compact.join("-")
         )
       end
 
@@ -66,7 +70,7 @@ module Decidim
         list = initiative.votable_initiative_type_scopes.select do |initiative_type_scope|
           if initiative_type_scope.scope.present?
             initiative_type_scope.scope == user_authorized_scope ||
-              initiative_type_scope.scope.ancestor_of?(user_authorized_scope)
+                initiative_type_scope.scope.ancestor_of?(user_authorized_scope)
           else
             initiative.type.only_global_scope_enabled && user_authorized_scope.nil?
           end
@@ -117,11 +121,13 @@ module Decidim
 
       def metadata
         {
-          name_and_surname: name_and_surname,
-          document_number: document_number,
-          date_of_birth: date_of_birth,
-          postal_code: postal_code,
-          scope: scope
+            name_and_surname: name_and_surname,
+            document_number: document_number,
+            date_of_birth: date_of_birth,
+            postal_code: postal_code,
+            scope: scope,
+            user_scope_id: user_scope_id,
+            resident: resident
         }
       end
 
@@ -165,9 +171,9 @@ module Decidim
         return unless signer && handler_name
 
         @authorization ||= Verifications::Authorizations.new(
-          organization: signer.organization,
-          user: signer,
-          name: handler_name
+            organization: signer.organization,
+            user: signer,
+            name: handler_name
         ).first
       end
 
@@ -211,6 +217,16 @@ module Decidim
 
       def encryptor
         @encryptor ||= DataEncryptor.new(secret: "personal user metadata")
+      end
+
+      def user_scope_belongs_to_organization?
+        return unless user_scope_id.present?
+
+        current_organization.scopes.include? user_scope
+      end
+
+      def user_scope
+        @user_scope ||= Decidim::Scope.find(user_scope_id) if user_scope_id.present?
       end
     end
   end

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -28,6 +28,21 @@
           <%= f.text_field :postal_code, required: true %>
         </div>
 
+        <% if user_scopes.length == 1 %>
+          <%= f.hidden_field :scope_id, value: user_scopes.first&.id %>
+        <% else %>
+          <div class="field">
+            <%= f.select :user_scope_id,
+                         user_scopes.map { |scope| [translated_attribute(scope&.name), scope&.id]},
+                         prompt: t(".select_scope"),
+                         required: true %>
+          </div>
+        <% end %>
+
+        <div class="field">
+          <%= f.check_box :resident, required: true %>
+        </div>
+
         <div class="pb-s">
           <small class="text-small">
           <%= strip_tags(translated_attribute(extra_data_legal_information)) %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -30,11 +30,13 @@ en:
       initiatives_type:
         banner_image: Banner image
         child_scope_threshold_enabled: Enable child scope signatures
-        comments_enabled: Enable comments
         collect_user_extra_fields: Collect participant personal data on signature
+        comments_enabled: Enable comments
         description: Description
-        document_number_authorization_handler: Authorization to verify document number on signatures
-        extra_fields_legal_information: Legal information about the collection of personal data
+        document_number_authorization_handler: Authorization to verify document number
+          on signatures
+        extra_fields_legal_information: Legal information about the collection of
+          personal data
         minimum_committee_members: Minimum of committee members
         online_signature_enabled: Online signature enabled
         only_global_scope_enabled: Only allow global scope initiatives creation
@@ -47,6 +49,7 @@ en:
         document_number: Document number
         name_and_surname: Name and surname
         postal_code: Postal code
+        resident: I'm a local resident
       organization_data:
         address: Address
         id_document: ID document
@@ -114,39 +117,77 @@ en:
     events:
       initiatives:
         initiative_extended:
-          email_intro: The signatures end date for the initiative %{resource_title} have been extended!
-          email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+          email_intro: The signatures end date for the initiative %{resource_title}
+            have been extended!
+          email_outro: You have received this notification because you are following
+            %{resource_title}. You can stop receiving notifications following the
+            previous link.
           email_subject: Initiative signatures end date extended!
-          notification_title: The signatures end date for the <a href="%{resource_path}">%{resource_title}</a> initiative have been extended.
+          notification_title: The signatures end date for the <a href="%{resource_path}">%{resource_title}</a>
+            initiative have been extended.
         milestone_completed:
           affected_user:
-            email_intro: Your initiative %{resource_title} has achieved the %{percentage}% of signatures!
-            email_outro: You have received this notification because you are the author of the initiative %{resource_title}.
+            email_intro: Your initiative %{resource_title} has achieved the %{percentage}%
+              of signatures!
+            email_outro: You have received this notification because you are the author
+              of the initiative %{resource_title}.
             email_subject: New milestone completed!
-            notification_title: Your <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+            notification_title: Your <a href="%{resource_path}">%{resource_title}</a>
+              initiative has achieved the %{percentage}% of signatures.
           follower:
-            email_intro: The initiative %{resource_title} has achieved the %{percentage}% of signatures!
-            email_outro: You have received this notification because you are following %{resource_title}. You can stop receiving notifications following the previous link.
+            email_intro: The initiative %{resource_title} has achieved the %{percentage}%
+              of signatures!
+            email_outro: You have received this notification because you are following
+              %{resource_title}. You can stop receiving notifications following the
+              previous link.
             email_subject: New milestone completed!
-            notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative has achieved the %{percentage}% of signatures.
+            notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+              initiative has achieved the %{percentage}% of signatures.
     gamification:
       badges:
         initiatives:
           conditions:
           - Go to the participation space of Intiatives
           - Follow the steps to create a new initiative
-          description: This badge is granted when you launch new initiatives, partnering with others to carry them out.
+          description: This badge is granted when you launch new initiatives, partnering
+            with others to carry them out.
           description_another: This participant has gotten %{score} initiatives published.
           description_own: You've got %{score} initiatives published.
           name: Published initiatives
-          next_level_in: Get %{score} more initiatives published to reach the next level!
-          unearned_another: This participant hasn't gotten any initiatives published yet.
+          next_level_in: Get %{score} more initiatives published to reach the next
+            level!
+          unearned_another: This participant hasn't gotten any initiatives published
+            yet.
           unearned_own: You got no initiatives published yet.
     help:
       participatory_spaces:
         initiatives:
-          contextual: "<p>An <strong>initiative</strong> is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
-          page: "<p>An <strong>initiative</strong> is a proposal that can be promoted by anyone on their own initiative (independently of other channels or participation spaces) through the collection of (digital) signatures for the organization to carry out a specific action (modify a regulation, initiate a project, change the name of a department or a street, etc.).</p> <p>The promoters of an initiative can define its objectives, gather support, debate, disseminate it and define meeting points where signatures can be collected from the attendees or debates open to other participants.</p> <p>Examples: An initiative can collect signatures to convene a consultation among all the people of an organization, or to create or convene an assembly, or to initiate a process of budget increase for a territory or area of the organization. During the process of collecting signatures, more people can add to this demand and carry it forward in the organization.</p>\n"
+          contextual: "<p>An <strong>initiative</strong> is a proposal that can be
+            promoted by anyone on their own initiative (independently of other channels
+            or participation spaces) through the collection of (digital) signatures
+            for the organization to carry out a specific action (modify a regulation,
+            initiate a project, change the name of a department or a street, etc.).</p>
+            <p>The promoters of an initiative can define its objectives, gather support,
+            debate, disseminate it and define meeting points where signatures can
+            be collected from the attendees or debates open to other participants.</p>
+            <p>Examples: An initiative can collect signatures to convene a consultation
+            among all the people of an organization, or to create or convene an assembly,
+            or to initiate a process of budget increase for a territory or area of
+            the organization. During the process of collecting signatures, more people
+            can add to this demand and carry it forward in the organization.</p>\n"
+          page: "<p>An <strong>initiative</strong> is a proposal that can be promoted
+            by anyone on their own initiative (independently of other channels or
+            participation spaces) through the collection of (digital) signatures for
+            the organization to carry out a specific action (modify a regulation,
+            initiate a project, change the name of a department or a street, etc.).</p>
+            <p>The promoters of an initiative can define its objectives, gather support,
+            debate, disseminate it and define meeting points where signatures can
+            be collected from the attendees or debates open to other participants.</p>
+            <p>Examples: An initiative can collect signatures to convene a consultation
+            among all the people of an organization, or to create or convene an assembly,
+            or to initiate a process of budget increase for a territory or area of
+            the organization. During the process of collecting signatures, more people
+            can add to this demand and carry it forward in the organization.</p>\n"
           title: What are initiatives?
     initiatives:
       actions:
@@ -166,7 +207,8 @@ en:
           index:
             approve: Approve
             confirm_revoke: Are you sure?
-            invite_to_committee_help: Share this link to invite other participants to the promoter committee
+            invite_to_committee_help: Share this link to invite other participants
+              to the promoter committee
             no_members_yet: There are no members in the promoter committee
             revoke: Revoke
             title: Committee members
@@ -239,7 +281,8 @@ en:
       admin_log:
         initiative:
           publish: "%{user_name} published the %{resource_name} initiative"
-          send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
+          send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative
+            to technical validation"
           unpublish: "%{user_name} discarded the %{resource_name} initiative"
           update: "%{user_name} updated the %{resource_name} initiative"
       admin_states:
@@ -252,7 +295,8 @@ en:
       committee_requests:
         new:
           continue: Continue
-          help_text: You are about to request becoming a member of the promoter committee of this initiative
+          help_text: You are about to request becoming a member of the promoter committee
+            of this initiative
         spawn:
           success: Your request has been sent to the initiative author.
       content_blocks:
@@ -262,57 +306,91 @@ en:
         fill_data:
           back: Back
           continue: Continue
-          fill_data_help: "<ul> <li>Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative? City, district?</li> </ul>"
+          fill_data_help: "<ul> <li>Review the content of your initiative. Is your
+            title easy to understand? Is the objective of your initiative clear?</li>
+            <li>You have to choose the type of signature. In-person, online or a combination
+            of both</li> <li>Which is the geographic scope of the initiative? City,
+            district?</li> </ul>"
           initiative_type: Initiative type
           more_information: "(More information)"
           select_scope: Select a scope
         finish:
           back: Back
           back_to_initiatives: Back to initiatives
-          callout_text: Congratulations! Your citizen initiative has been successfully created.
+          callout_text: Congratulations! Your citizen initiative has been successfully
+            created.
           go_to_my_initiatives: Go to my initiatives
           more_information: "(More information)"
         finish_help:
-          access_reminder: Remember that you will always be able to access your initiatives through the participant menu.
-          help_for_organizations: If you are an association you will have to upload the minutes of the management board of all the organisations that form the Promoting Commission
-          help_in_person_signatures: If you have chosen to collect the signatures in-person or combined with online, you will have to upload the required information.
-          help_text: Remember that in order to properly process the initiative you must access the administration panel where you will find the user menu, upload the information required and send it for processing.
-          initiatives_page_link: You can look up all this information on the %{link} dedicated to inform about initiatives.
+          access_reminder: Remember that you will always be able to access your initiatives
+            through the participant menu.
+          help_for_organizations: If you are an association you will have to upload
+            the minutes of the management board of all the organisations that form
+            the Promoting Commission
+          help_in_person_signatures: If you have chosen to collect the signatures
+            in-person or combined with online, you will have to upload the required
+            information.
+          help_text: Remember that in order to properly process the initiative you
+            must access the administration panel where you will find the user menu,
+            upload the information required and send it for processing.
+          initiatives_page_link: You can look up all this information on the %{link}
+            dedicated to inform about initiatives.
           page: page
         previous_form:
           back: Back
           continue: Continue
-          help: What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.
+          help: What does the initiative consist of? Write down the title and description.
+            We recommend a short and concise title and a description focused on the
+            proposed solution.
           more_information: "(More information)"
         promotal_committee:
           back: Back
-          individual_help_text: This kind of citizen initiative requires a Promoting Commission consisting of at least %{committee_size} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.
+          individual_help_text: This kind of citizen initiative requires a Promoting
+            Commission consisting of at least %{committee_size} people (attestors).
+            You must share the following link with the other people that are part
+            of this initiative. When your contacts receive this link they will have
+            to follow the indicated steps.
           more_information: "(More information)"
         select_initiative_type:
           back: Back
           choose_html: I want to create a <strong>%{title}</strong>
           more_information: "(More information)"
           select: I want to promote this initiative
-          select_initiative_type_help: Citizen initiatives are a means by which the citizenship can intervene so that the City Council can undertake actions in defence of the general interest that are within fields of municipal jurisdiction. Which initiative do you want to launch?
+          select_initiative_type_help: Citizen initiatives are a means by which the
+            citizenship can intervene so that the City Council can undertake actions
+            in defence of the general interest that are within fields of municipal
+            jurisdiction. Which initiative do you want to launch?
         share_committee_link:
           continue: Continue
-          invite_to_committee_help: Link to invite people that will be part of the promoter committee
+          invite_to_committee_help: Link to invite people that will be part of the
+            promoter committee
         show_similar_initiatives:
           back: Back
-          compare_help: If any of the following initiatives is similar to yours we encourage you to sign it. Your proposal will have more possibilities to get done.
+          compare_help: If any of the following initiatives is similar to yours we
+            encourage you to sign it. Your proposal will have more possibilities to
+            get done.
           continue: My initiative is different
           more_information: "(More information)"
       events:
         create_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, who you are following, has created a new initiative, check it out and contribute:"
-          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: "%{author_name} %{author_nickname}, who you are following,
+            has created a new initiative, check it out and contribute:"
+          email_outro: You have received this notification because you are following
+            %{author_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: New initiative by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            initiative was created by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         endorse_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, who you are following, has endorsed the following initiative, maybe you want to contribute to the conversation:"
-          email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
+          email_intro: "%{author_name} %{author_nickname}, who you are following,
+            has endorsed the following initiative, maybe you want to contribute to
+            the conversation:"
+          email_outro: You have received this notification because you are following
+            %{author_nickname}. You can stop receiving notifications following the
+            previous link.
           email_subject: Initiative endorsed by %{author_nickname}
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> initiative was endorsed by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: The <a href="%{resource_path}">%{resource_title}</a>
+            initiative was endorsed by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
       index:
         title: Initiatives
       initiative_signatures:
@@ -322,7 +400,9 @@ en:
             day: Day
             month: Month
             year: Year
-          help: Please, fill the following fields with your personal data to sign the initiative
+          help: Please, fill the following fields with your personal data to sign
+            the initiative
+          select_scope: Select scope
         finish:
           back_to_initiative: Back to initiative
         sms_code:
@@ -330,18 +410,22 @@ en:
           help: Check the SMS received at your phone
         sms_phone_number:
           continue: Send me an SMS
-          help: Fill the form with your verified phone number to request your verification code
+          help: Fill the form with your verified phone number to request your verification
+            code
       initiative_votes:
         create:
           error: There was a problem signing the initiative.
           invalid: The data provided to sign the initiative is not valid
-          success_html: Congratulations! The <strong> %{title}</strong> initiative has been successfully signed
+          success_html: Congratulations! The <strong> %{title}</strong> initiative
+            has been successfully signed
         personal_data:
           invalid: Personal data is not consistent with data provided for authorization.
         sms_code:
-          invalid: Your verification code doesn't match ours. Please double-check the SMS we sent you.
+          invalid: Your verification code doesn't match ours. Please double-check
+            the SMS we sent you.
         sms_phone:
-          invalid: The phone number is invalid or pending of authorization. Please, check your authorizations.
+          invalid: The phone number is invalid or pending of authorization. Please,
+            check your authorizations.
       initiatives:
         author:
           deleted: Deleted
@@ -389,9 +473,11 @@ en:
             published: This proposal is published because
             rejected: This proposal has been rejected because
             validating: This proposal is being evaluated
-          initiative_rejected_reason: This initiative has been rejected due to its lack of signatures.
+          initiative_rejected_reason: This initiative has been rejected due to its
+            lack of signatures.
         show:
-          any_vote_method: This citizen initiative collects both online and in-person signatures.
+          any_vote_method: This citizen initiative collects both online and in-person
+            signatures.
           follow_description: Receive a notification when there are news in this initiative
           offline_method: This citizen initiative only collects in-person signatures.
         signature_identities:
@@ -416,14 +502,21 @@ en:
         initiative_link:
           check_initiative_details: You can see the initiative details
           here: here
-        more_information: Here you have more information about the initiative creation process.
-        progress_report_body_for: The initiative %{title} has reached the %{percentage}% of required signatures.
+        more_information: Here you have more information about the initiative creation
+          process.
+        progress_report_body_for: The initiative %{title} has reached the %{percentage}%
+          of required signatures.
         progress_report_for: 'Summary about the initiative: %{title}'
-        promotal_committee_help: Remember that you must invite at least %{member_count} people to promoter committee. Forward the following link to invite people to the promoter committee
-        status_change_body_for: 'The initiative %{title} has changed its status to: %{state}'
+        promotal_committee_help: Remember that you must invite at least %{member_count}
+          people to promoter committee. Forward the following link to invite people
+          to the promoter committee
+        status_change_body_for: 'The initiative %{title} has changed its status to:
+          %{state}'
         status_change_for: The initiative %{title} has changed its status
-        technical_validation_body_for: The initiative %{title} has requested its technical validation.
-        technical_validation_for: The initiative %{title} has requested its technical validation.
+        technical_validation_body_for: The initiative %{title} has requested its technical
+          validation.
+        technical_validation_for: The initiative %{title} has requested its technical
+          validation.
       last_activity:
         new_initiative: New initiative
       pages:
@@ -447,8 +540,8 @@ en:
     resources:
       initiatives_type:
         actions:
-          title: Actions
           create: Create initiative
+          title: Actions
           vote: Sign initiative
   layouts:
     decidim:

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -30,23 +30,32 @@ fr:
       initiatives_type:
         banner_image: Image d'en-tête
         child_scope_threshold_enabled: Activer les signatures des sous-périmètres
-        collect_user_extra_fields: Collecter les données personnelles de l'utilisateur lors de la signature
+        collect_user_extra_fields: Collecter les données personnelles de l'utilisateur
+          lors de la signature
         comments_enabled: Activer les commentaires
         description: Description
-        document_number_authorization_handler: Niveau d'autorisation nécessaire pour signer les initiatives de ce type
-        extra_fields_legal_information: Informations juridiques sur la collecte de données personnelles
+        document_number_authorization_handler: Niveau d'autorisation nécessaire pour
+          signer les initiatives de ce type
+        extra_fields_legal_information: Informations juridiques sur la collecte de
+          données personnelles
         minimum_committee_members: Minimum de membres du comité
         online_signature_enabled: Signature en ligne activée
-        only_global_scope_enabled: Ne permettre que la création d'initiatives de portée globale
-        promoting_committee_enabled: Activer les comités de promotion sur ce type d'initiative (témoin.s dont l'invitation par l'auteur est obligatoire pour la validation de l'initiative si cette fonctionnalité est activée)
+        only_global_scope_enabled: Ne permettre que la création d'initiatives de portée
+          globale
+        promoting_committee_enabled: Activer les comités de promotion sur ce type
+          d'initiative (témoin.s dont l'invitation par l'auteur est obligatoire pour
+          la validation de l'initiative si cette fonctionnalité est activée)
         title: Titre
-        undo_online_signatures_enabled: Autoriser les utilisateurs à annuler leurs signatures en ligne
-        validate_sms_code_on_votes: Ajouter une étape de validation du code SMS au processus de signature
+        undo_online_signatures_enabled: Autoriser les utilisateurs à annuler leurs
+          signatures en ligne
+        validate_sms_code_on_votes: Ajouter une étape de validation du code SMS au
+          processus de signature
       initiatives_vote:
         date_of_birth: Date de naissance
         document_number: Numéro de document
         name_and_surname: Nom et surnom
         postal_code: Code postal
+        resident: I'm a local resident
       organization_data:
         address: Adresse
         id_document: Document d'identité
@@ -114,39 +123,80 @@ fr:
     events:
       initiatives:
         initiative_extended:
-          email_intro: La date de fin du recueil des signatures pour l'initiative %{resource_title} a été prolongée !
-          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
-          email_subject: La date de fin du recueil des signatures pour l'initiative est prolongée !
-          notification_title: La date de fin de recueil des signatures pour l'initiative <a href="%{resource_path}">%{resource_title}</a> a été prolongée.
+          email_intro: La date de fin du recueil des signatures pour l'initiative
+            %{resource_title} a été prolongée !
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}.
+            Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_subject: La date de fin du recueil des signatures pour l'initiative
+            est prolongée !
+          notification_title: La date de fin de recueil des signatures pour l'initiative
+            <a href="%{resource_path}">%{resource_title}</a> a été prolongée.
         milestone_completed:
           affected_user:
-            email_intro: Votre initiative %{resource_title} a atteint %{percentage}% de signatures!
-            email_outro: Vous avez reçu cette notification car vous êtes l'auteur de l'initiative %{resource_title}.
+            email_intro: Votre initiative %{resource_title} a atteint %{percentage}%
+              de signatures!
+            email_outro: Vous avez reçu cette notification car vous êtes l'auteur
+              de l'initiative %{resource_title}.
             email_subject: Nouvelle étape franchie !
-            notification_title: Votre initiative <a href="%{resource_path}">%{resource_title}</a> a atteint les %{percentage}% de signatures.
+            notification_title: Votre initiative <a href="%{resource_path}">%{resource_title}</a>
+              a atteint les %{percentage}% de signatures.
           follower:
-            email_intro: L'initiative %{resource_title} a atteint %{percentage}% des signatures requises !
-            email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}. Vous pouvez cesser de recevoir des notifications en suivant le lien précédent.
+            email_intro: L'initiative %{resource_title} a atteint %{percentage}% des
+              signatures requises !
+            email_outro: Vous avez reçu cette notification parce que vous suivez %{resource_title}.
+              Vous pouvez cesser de recevoir des notifications en suivant le lien
+              précédent.
             email_subject: Nouvelle étape franchie !
-            notification_title: L'initiative <a href="%{resource_path}">%{resource_title}</a> a atteint les %{percentage}% de signatures.
+            notification_title: L'initiative <a href="%{resource_path}">%{resource_title}</a>
+              a atteint les %{percentage}% de signatures.
     gamification:
       badges:
         initiatives:
           conditions:
           - Accéder à l'espace Initiatives
           - Suivez les étapes pour créer une nouvelle initiative
-          description: Ce badge vous est attribué lorsque vous lancez de nouvelles initiatives, en partenariat avec d’autres pour les mener à bien.
+          description: Ce badge vous est attribué lorsque vous lancez de nouvelles
+            initiatives, en partenariat avec d’autres pour les mener à bien.
           description_another: Ce participant a publié %{score} initiatives.
           description_own: Vous avez publié %{score} initiatives.
           name: Initiatives publiées
-          next_level_in: Obtenez %{score} autres initiatives publiées pour atteindre le niveau supérieur!
+          next_level_in: Obtenez %{score} autres initiatives publiées pour atteindre
+            le niveau supérieur!
           unearned_another: Cet utilisateur n'a pas encore publié d'initiative.
           unearned_own: Vous n'avez pas encore publié d'initiative.
     help:
       participatory_spaces:
         initiatives:
-          contextual: "<p>Une <strong>initiative</strong> est une proposition qui peut être favorisée par toute personne de leur propre initiative (indépendamment des autres canaux ou espaces de participation) grâce à la collecte de signatures (numériques) pour l'organisation de mener une action spécifique (modifier un règlement, initier un projet, changer le nom d’un département ou d’une rue, etc.).</p> <p>Les promoteurs d'une initiative peuvent définir ses objectifs, rassembler un soutien, débattre, la diffuser et définir des points de rencontre où des signatures peuvent être collectées auprès des participants ou des débats ouverts à d'autres participants.</p> <p>Exemples: Une initiative peut collecter des signatures pour organiser une consultation de toutes les personnes d'une organisation, pour créer ou réunir une assemblée, ou pour lancer un processus d'augmentation budgétaire pour un territoire ou une zone de l'organisation. Au cours du processus de collecte des signatures, davantage de personnes peuvent ajouter à cette demande et la transmettre à l’organisation.</p>\n"
-          page: "<p>Une initiative est une proposition qui peut être promue par n'importe qui de sa propre initiative (indépendamment des autres canaux ou espaces de participation) grâce à la collecte de signatures (numériques) permettant à l'organisation de réaliser une action spécifique (modifier un règlement, initier un projet , changez le nom d’un département ou d’une rue, etc.).</p> <p>Les promoteurs d'une initiative peuvent définir ses objectifs, rassembler un soutien, débattre, la diffuser et définir des points de rencontre où des signatures peuvent être collectées auprès des participants ou des débats ouverts à d'autres participants.</p> <p>Exemples: Une initiative peut collecter des signatures pour organiser une consultation de toutes les personnes d'une organisation, pour créer ou réunir une assemblée, ou pour lancer un processus d'augmentation budgétaire pour un territoire ou une zone de l'organisation. Au cours du processus de collecte de signatures, davantage de personnes peuvent ajouter à cette demande et la transmettre à l’organisation.</p>\n"
+          contextual: "<p>Une <strong>initiative</strong> est une proposition qui
+            peut être favorisée par toute personne de leur propre initiative (indépendamment
+            des autres canaux ou espaces de participation) grâce à la collecte de
+            signatures (numériques) pour l'organisation de mener une action spécifique
+            (modifier un règlement, initier un projet, changer le nom d’un département
+            ou d’une rue, etc.).</p> <p>Les promoteurs d'une initiative peuvent définir
+            ses objectifs, rassembler un soutien, débattre, la diffuser et définir
+            des points de rencontre où des signatures peuvent être collectées auprès
+            des participants ou des débats ouverts à d'autres participants.</p> <p>Exemples:
+            Une initiative peut collecter des signatures pour organiser une consultation
+            de toutes les personnes d'une organisation, pour créer ou réunir une assemblée,
+            ou pour lancer un processus d'augmentation budgétaire pour un territoire
+            ou une zone de l'organisation. Au cours du processus de collecte des signatures,
+            davantage de personnes peuvent ajouter à cette demande et la transmettre
+            à l’organisation.</p>\n"
+          page: "<p>Une initiative est une proposition qui peut être promue par n'importe
+            qui de sa propre initiative (indépendamment des autres canaux ou espaces
+            de participation) grâce à la collecte de signatures (numériques) permettant
+            à l'organisation de réaliser une action spécifique (modifier un règlement,
+            initier un projet , changez le nom d’un département ou d’une rue, etc.).</p>
+            <p>Les promoteurs d'une initiative peuvent définir ses objectifs, rassembler
+            un soutien, débattre, la diffuser et définir des points de rencontre où
+            des signatures peuvent être collectées auprès des participants ou des
+            débats ouverts à d'autres participants.</p> <p>Exemples: Une initiative
+            peut collecter des signatures pour organiser une consultation de toutes
+            les personnes d'une organisation, pour créer ou réunir une assemblée,
+            ou pour lancer un processus d'augmentation budgétaire pour un territoire
+            ou une zone de l'organisation. Au cours du processus de collecte de signatures,
+            davantage de personnes peuvent ajouter à cette demande et la transmettre
+            à l’organisation.</p>\n"
           title: Comment fonctionnent les initiatives ?
     initiatives:
       actions:
@@ -166,7 +216,8 @@ fr:
           index:
             approve: Approuver
             confirm_revoke: Êtes-vous certain ?
-            invite_to_committee_help: Partagez ce lien pour inviter d'autres utilisateurs au Comité de promotion
+            invite_to_committee_help: Partagez ce lien pour inviter d'autres utilisateurs
+              au Comité de promotion
             no_members_yet: Il n'y a pas encore de membres dans le Comité de promotion
             revoke: Révoquer
             title: Membres du comité de promotion
@@ -239,7 +290,8 @@ fr:
       admin_log:
         initiative:
           publish: "%{user_name} a publié l'initiative %{resource_name}"
-          send_to_technical_validation: "%{user_name} a envoyé l'initiative %{resource_name} à la validation technique"
+          send_to_technical_validation: "%{user_name} a envoyé l'initiative %{resource_name}
+            à la validation technique"
           unpublish: "%{user_name} a dépublié l'initiative %{resource_name}"
           update: "%{user_name} a mis à jour l'initiative %{resource_name}"
       admin_states:
@@ -252,7 +304,8 @@ fr:
       committee_requests:
         new:
           continue: Continuer
-          help_text: Vous êtes sur le point de demander à devenir membre du Comité de promotion de cette initiative
+          help_text: Vous êtes sur le point de demander à devenir membre du Comité
+            de promotion de cette initiative
         spawn:
           success: Votre demande a été envoyée à l'auteur de l'initiative.
       content_blocks:
@@ -262,7 +315,12 @@ fr:
         fill_data:
           back: Retour
           continue: Continuer
-          fill_data_help: "<ul> <li>Vérifier le contenu de votre initiative. Votre titre est-il facile à comprendre ? L'objectif de votre pétition est-il clair ?</li> <li>Vous devez choisir le type de recueil des signatures : en présentiel, en ligne ou une combinaison des deux</li> <li>Quelle est le secteur géographique de l'initiative ? Ville, arrondissement, quartier ?</li> </ul>"
+          fill_data_help: "<ul> <li>Vérifier le contenu de votre initiative. Votre
+            titre est-il facile à comprendre ? L'objectif de votre pétition est-il
+            clair ?</li> <li>Vous devez choisir le type de recueil des signatures
+            : en présentiel, en ligne ou une combinaison des deux</li> <li>Quelle
+            est le secteur géographique de l'initiative ? Ville, arrondissement, quartier
+            ?</li> </ul>"
           initiative_type: Type d'initiative
           more_information: "(Plus d'informations)"
           select_scope: Sélectionnez une portée
@@ -273,46 +331,73 @@ fr:
           go_to_my_initiatives: Consulter mes initiatives
           more_information: "(Plus d'informations)"
         finish_help:
-          access_reminder: Rappelez-vous que vous serez toujours en mesure d'accéder à vos initiatives via le menu utilisateur.
-          help_for_organizations: Si vous êtes une association, vous devrez télécharger les procès-verbaux du conseil d'administration de toutes les organisations qui constituent le Comité de promotion
-          help_in_person_signatures: Si vous avez choisi de recueillir les signatures en présentiel ou de façon combinée, vous devrez télécharger les informations requises.
-          help_text: N'oubliez pas que pour valider correctement l'initiative, vous devez accéder au panneau d'administration dans lequel vous trouverez le menu utilisateur, télécharger les informations requises et l'envoyer pour validation technique.
-          initiatives_page_link: Vous pouvez consulter toutes ces informations sur la %{link} dédié à l'information sur les initiatives.
+          access_reminder: Rappelez-vous que vous serez toujours en mesure d'accéder
+            à vos initiatives via le menu utilisateur.
+          help_for_organizations: Si vous êtes une association, vous devrez télécharger
+            les procès-verbaux du conseil d'administration de toutes les organisations
+            qui constituent le Comité de promotion
+          help_in_person_signatures: Si vous avez choisi de recueillir les signatures
+            en présentiel ou de façon combinée, vous devrez télécharger les informations
+            requises.
+          help_text: N'oubliez pas que pour valider correctement l'initiative, vous
+            devez accéder au panneau d'administration dans lequel vous trouverez le
+            menu utilisateur, télécharger les informations requises et l'envoyer pour
+            validation technique.
+          initiatives_page_link: Vous pouvez consulter toutes ces informations sur
+            la %{link} dédié à l'information sur les initiatives.
           page: page
         previous_form:
           back: Retour
           continue: Continuer
-          help: En quoi consiste l'initiative ? Saisissez son titre et sa description. Nous recommandons un titre court et synthétique et une description axée sur la solution proposée.
+          help: En quoi consiste l'initiative ? Saisissez son titre et sa description.
+            Nous recommandons un titre court et synthétique et une description axée
+            sur la solution proposée.
           more_information: "(Plus d'informations)"
         promotal_committee:
           back: Retour
-          individual_help_text: Ce type d’initiative citoyenne nécessite une Commission de promotion composée d’au moins %{committee_size} personnes. Vous devez partager le lien suivant avec les autres personnes participant à cette initiative. Lorsque vos contacts recevront ce lien, ils devront suivre les étapes indiquées.
+          individual_help_text: Ce type d’initiative citoyenne nécessite une Commission
+            de promotion composée d’au moins %{committee_size} personnes. Vous devez
+            partager le lien suivant avec les autres personnes participant à cette
+            initiative. Lorsque vos contacts recevront ce lien, ils devront suivre
+            les étapes indiquées.
           more_information: "(Plus d'informations)"
         select_initiative_type:
           back: Retour
           choose_html: Je veux créer un <strong>%{title}</strong>
           more_information: "(Plus d'informations)"
           select: Créer une initiative
-          select_initiative_type_help: Les initiatives sont un moyen par lequel la communauté des citoyens peut se manifester afin que le conseil municipal entreprenne des actions d'intérêt général qui relèvent des champs de compétence municipaux. Quelle initiative voulez-vous lancer ?
+          select_initiative_type_help: Les initiatives sont un moyen par lequel la
+            communauté des citoyens peut se manifester afin que le conseil municipal
+            entreprenne des actions d'intérêt général qui relèvent des champs de compétence
+            municipaux. Quelle initiative voulez-vous lancer ?
         share_committee_link:
           continue: Continuer
-          invite_to_committee_help: Lien pour inviter des personnes à faire partie du Comité de promotion
+          invite_to_committee_help: Lien pour inviter des personnes à faire partie
+            du Comité de promotion
         show_similar_initiatives:
           back: Retour
-          compare_help: Si l'une des initiatives suivantes est similaire à la vôtre, nous vous encourageons à l'appuyer. Votre proposition aura ainsi plus de possibilités de se réaliser.
+          compare_help: Si l'une des initiatives suivantes est similaire à la vôtre,
+            nous vous encourageons à l'appuyer. Votre proposition aura ainsi plus
+            de possibilités de se réaliser.
           continue: Mon initiative est différente
           more_information: "(Plus d'informations)"
       events:
         create_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, que vous suivez, a créé une nouvelle initiative, lisez -la et contribuez :"
-          email_outro: Vous avez reçu cette notification, car vous suivez %{author_nickname}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_intro: "%{author_name} %{author_nickname}, que vous suivez, a créé
+            une nouvelle initiative, lisez -la et contribuez :"
+          email_outro: Vous avez reçu cette notification, car vous suivez %{author_nickname}.
+            Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
           email_subject: Nouvelle initiative de %{author_nickname}
-          notification_title: L'initiative <a href="%{resource_path}">%{resource_title}</a> a été créée par <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: L'initiative <a href="%{resource_path}">%{resource_title}</a>
+            a été créée par <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
         endorse_initiative_event:
-          email_intro: "%{author_name} %{author_nickname}, que vous suivez, a soutenu l'initiative suivante; vous pouvez y contribuer si vous le souhaitez :"
-          email_outro: Vous avez reçu cette notification parce que vous suivez %{author_nickname}. Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
+          email_intro: "%{author_name} %{author_nickname}, que vous suivez, a soutenu
+            l'initiative suivante; vous pouvez y contribuer si vous le souhaitez :"
+          email_outro: Vous avez reçu cette notification parce que vous suivez %{author_nickname}.
+            Vous pouvez arrêter de recevoir des notifications à partir du lien précédent.
           email_subject: Initiative soutenue par %{author_nickname}
-          notification_title: L'initiative<a href="%{resource_path}">%{resource_title}</a> a été soutenue par <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title: L'initiative<a href="%{resource_path}">%{resource_title}</a>
+            a été soutenue par <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
       index:
         title: Initiatives
       initiative_signatures:
@@ -322,7 +407,9 @@ fr:
             day: journée
             month: Mois
             year: Année
-          help: S'il vous plaît, remplissez les champs suivants avec vos données personnelles pour signer l'initiative
+          help: S'il vous plaît, remplissez les champs suivants avec vos données personnelles
+            pour signer l'initiative
+          select_scope: Select scope
         finish:
           back_to_initiative: Retour à l'initiative
         sms_code:
@@ -330,18 +417,23 @@ fr:
           help: Vérifiez les SMS reçus sur votre téléphone
         sms_phone_number:
           continue: Envoyez moi un SMS
-          help: Remplissez le formulaire avec votre numéro de téléphone vérifié pour demander votre code de vérification
+          help: Remplissez le formulaire avec votre numéro de téléphone vérifié pour
+            demander votre code de vérification
       initiative_votes:
         create:
           error: Il y a eu des erreurs lors de la signature de l'initiative.
           invalid: Les données fournies pour signer l'initiative ne sont pas valides
-          success_html: Toutes nos félicitations! L'initiative <strong> %{title}</strong> a été signée correctement
+          success_html: Toutes nos félicitations! L'initiative <strong> %{title}</strong>
+            a été signée correctement
         personal_data:
-          invalid: Les données personnelles ne correspondent pas aux données fournies pour autorisation.
+          invalid: Les données personnelles ne correspondent pas aux données fournies
+            pour autorisation.
         sms_code:
-          invalid: Votre code de vérification ne correspond pas au nôtre. Veuillez vérifier le SMS que nous vous avons envoyé.
+          invalid: Votre code de vérification ne correspond pas au nôtre. Veuillez
+            vérifier le SMS que nous vous avons envoyé.
         sms_phone:
-          invalid: Le numéro de téléphone est invalide ou en attente d'autorisation. S'il vous plaît, vérifiez vos autorisations.
+          invalid: Le numéro de téléphone est invalide ou en attente d'autorisation.
+            S'il vous plaît, vérifiez vos autorisations.
       initiatives:
         author:
           deleted: Supprimé
@@ -389,10 +481,13 @@ fr:
             published: Cette proposition est publiée parce que
             rejected: Cette proposition a été rejetée parce que
             validating: Cette proposition est en cours d'évaluation
-          initiative_rejected_reason: Cette initiative a été rejetée car elle n'a pas atteint le nombre de signatures requis dans le délai de collecte.
+          initiative_rejected_reason: Cette initiative a été rejetée car elle n'a
+            pas atteint le nombre de signatures requis dans le délai de collecte.
         show:
-          any_vote_method: Cette initiative recueille des signatures en ligne ainsi qu'en présentiel.
-          follow_description: Recevoir une notification lorsqu'il y a des actualités sur cette initiative
+          any_vote_method: Cette initiative recueille des signatures en ligne ainsi
+            qu'en présentiel.
+          follow_description: Recevoir une notification lorsqu'il y a des actualités
+            sur cette initiative
           offline_method: Cette initiative ne recueille que des soutiens en présentiel.
         signature_identities:
           select_identity: Sélectionner l'identifiant de l'utilisateur
@@ -418,14 +513,20 @@ fr:
         initiative_link:
           check_initiative_details: Vous pouvez accéder aux détails de l'initiative
           here: ici
-        more_information: Vous trouverez ici plus d'informations sur le processus de création d'une initiative.
-        progress_report_body_for: L'initiative %{title} a atteint %{percentage}% des soutiens requis.
+        more_information: Vous trouverez ici plus d'informations sur le processus
+          de création d'une initiative.
+        progress_report_body_for: L'initiative %{title} a atteint %{percentage}% des
+          soutiens requis.
         progress_report_for: 'Résumé de l''initiative : %{title}'
-        promotal_committee_help: Rappelez-vous que vous devez inviter au moins %{member_count} personnes au Comité de promotion. Envoyez le lien suivant pour les inviter
-        status_change_body_for: 'Le statut de l''initiative %{title} a été changé pour : %{state}'
+        promotal_committee_help: Rappelez-vous que vous devez inviter au moins %{member_count}
+          personnes au Comité de promotion. Envoyez le lien suivant pour les inviter
+        status_change_body_for: 'Le statut de l''initiative %{title} a été changé
+          pour : %{state}'
         status_change_for: L'initiative %{title} a changé de statut
-        technical_validation_body_for: Une validation technique a été demandée pour l'initiative %{title}.
-        technical_validation_for: Une validation technique a été demandée pour l'initiative %{title}.
+        technical_validation_body_for: Une validation technique a été demandée pour
+          l'initiative %{title}.
+        technical_validation_for: Une validation technique a été demandée pour l'initiative
+          %{title}.
       last_activity:
         new_initiative: Nouvelle initiative
       pages:


### PR DESCRIPTION
#### :tophat: What? Why?
En tant que signataire connecté de manière anonyme avec France Connect, lorsque je clique sur le bouton "Signer" d'une pétition, je suis redirigé vers un formulaire où je doit choisir mon département et déclarer sur l'honneur que je suis citoyen français et que mes renseignements sont vrais. Le signataire remplit ces information pour chaque pétition qu'il signe.

#### :pushpin: Related Issues
- Related to https://gitlab.com/open-source-politics/ppan/decidim/-/issues/19?

#### To do 

- [x]  Activer le formulaire de récolte des données personnelles
- [x] Texte d'explication pour expliquer pourquoi cette information est demandée (utilisation de l'existant)
- [x] Ajouter une liste déroulante "Sélectionnez votre département" contenant les scopes de l'organisation
- [x] Insérer une case à cocher avec pour texte : « Je certifie être citoyen français ou résidant régulièrement en France, ainsi que l’exactitude du département saisi. »
- [x] Ces informations doivent se retrouver dans l'export des signatures
- [ ] Supprimer les champs inutiles : nom et surnom, numéro de document, date de naissance et code postal

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)

### :ghost: GIF (optional)
![Description](URL)
