### PR TITLE
Backport related assemblies in pp

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -214,6 +214,7 @@ ignore_unused:
   - decidim.meetings.admin.exports.column_name.*
   - decidim.debates.admin.exports.column_name.*
   - decidim.comments.exports.column_name.*
+  - decidim.participatory_processes.show.related_assemblies
   # OSP CUSTO END HERE
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -352,6 +352,9 @@ en:
         description: Number of assemblies created
         object: assemblies
         title: Assemblies
+    participatory_processes:
+      show:
+        related_assemblies: Related assemblies
   errors:
     messages:
       cannot_be_blank: can not be blank

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -20,9 +20,9 @@ module Decidim
 
       def participatory_process_assemblies
         @participatory_process_assemblies ||=
-            current_participatory_space
-                .linked_participatory_space_resources(:assembly, "included_participatory_processes")
-                .published
+          current_participatory_space
+          .linked_participatory_space_resources(:assembly, "included_participatory_processes")
+          .published
       end
 
       def show

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -9,13 +9,20 @@ module Decidim
       participatory_space_layout only: [:show, :statistics]
       include FilterResource
 
-      helper_method :collection, :promoted_participatory_processes, :participatory_processes, :stats, :metrics, :default_date_filter
+      helper_method :collection, :promoted_participatory_processes, :participatory_processes, :stats, :metrics, :default_date_filter, :participatory_process_assemblies
 
       def index
         raise ActionController::RoutingError, "Not Found" if published_processes.none?
 
         enforce_permission_to :list, :process
         enforce_permission_to :list, :process_group
+      end
+
+      def participatory_process_assemblies
+        @participatory_process_assemblies ||=
+            current_participatory_space
+                .linked_participatory_space_resources(:assembly, "included_participatory_processes")
+                .published
       end
 
       def show

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -45,6 +45,20 @@ module Decidim
           locale
         end
       end
+
+      def assemblies_for_participatory_process(participatory_process_assemblies)
+        html = ""
+        html += %( <div class="section"> ).html_safe
+        html += %( <h4 class="section-heading">#{t("participatory_process.show.related_assemblies", scope: "decidim")}</h4> ).html_safe
+        html += %( <div class="row small-up-1 medium-up-2 card-grid"> ).html_safe
+        participatory_process_assemblies.each do |participatory_process_assembly|
+          html += render partial: "decidim/assemblies/assembly", locals: { assembly: participatory_process_assembly }
+        end
+        html += %( </div> ).html_safe
+        html += %( </div> ).html_safe
+
+        html.html_safe
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -37,6 +37,7 @@ edit_link(
       </div>
       <%= attachments_for current_participatory_space %>
       <%= render_hook(:participatory_space_highlighted_elements) %>
+      <%= assemblies_for_participatory_process(participatory_process_assemblies) if participatory_process_assemblies.present? %>
     </div>
     <div class="section columns medium-5 mediumlarge-4 large-3">
       <div class="card extra">

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -295,6 +295,9 @@ en:
         metrics:
           headline: Participation in figures
           link: Show all statistics
+    participatory_process:
+      show:
+        related_assemblies: Related assemblies
     participatory_process_groups:
       show:
         group_participatory_processes:

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -432,5 +432,22 @@ describe "Participatory Processes", type: :system do
         end
       end
     end
+
+    context "when assemblies are linked to participatory process" do
+      let!(:published_assembly) { create(:assembly, :published, organization: organization) }
+      let!(:unpublished_assembly) { create(:assembly, :unpublished, organization: organization) }
+
+      before do
+        published_assembly.link_participatory_spaces_resources(participatory_process, "included_participatory_processes")
+        unpublished_assembly.link_participatory_spaces_resources(participatory_process, "included_participatory_processes")
+        visit decidim_participatory_processes.participatory_process_path(participatory_process)
+      end
+
+      it "displays related assemblies" do
+        expect(page).to have_content("RELATED ASSEMBLIES")
+        expect(page).to have_content(translated(published_assembly.title))
+        expect(page).to have_no_content(translated(unpublished_assembly.title))
+      end
+    end
   end
 end


### PR DESCRIPTION
:tophat: What? Why?

Add related assemblies to a participatory process

:clipboard: Subtasks
- [x] Add tests

:camera: Screenshots (optional)
![related_assemblies](https://user-images.githubusercontent.com/26109239/79437998-3dcea000-7fd3-11ea-9cdc-1215beecaca8.png)
