### PR TITLE
filter child assemblies by title

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -86,7 +86,7 @@ edit_link(
         <section id="assemblies-grid" class="section row collapse">
           <h4 class="section-heading"><%= t("children", scope: "decidim.assemblies.show") %></h4>
           <div class="row small-up-1 medium-up-2 large-up-2 card-grid">
-            <%= render partial: "decidim/assemblies/assembly", collection: current_participatory_space.sort_children_by %>
+            <%= render partial: "decidim/assemblies/assembly", collection: current_participatory_space.sort_children_by(:title) %>
           </div>
         </section>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Change filter child assemblies option from slug to title

![image](https://user-images.githubusercontent.com/26109239/80590064-92363e80-8a1b-11ea-85a3-bc47ffe855c7.png)
