### PR TITLE
Add number delimiter to progress and total signatures number

### DIFF
--- a/decidim-core/app/cells/decidim/progress_bar/show.erb
+++ b/decidim-core/app/cells/decidim/progress_bar/show.erb
@@ -3,9 +3,9 @@
 
     <% if horizontal? %>
       <span class="progress__bar__text"><%= subtitle_text %></span>
-      <span class="progress__bar__number"><%= number_with_delimiter(progress, :delimiter => '.') %></span><%= "/#{number_with_delimiter(total, :delimiter => '.')}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: '.') %></span><%= "/#{number_with_delimiter(total, delimiter: '.')}" if total != 0 %>
     <% else %>
-      <span class="progress__bar__number"><%= number_with_delimiter(progress, :delimiter => '.') %></span><%= "/#{number_with_delimiter(total, :delimiter => '.')}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: '.') %></span><%= "/#{number_with_delimiter(total, delimiter: '.')}" if total != 0 %>
       <span class="progress__bar__text"><%= units_name_text %></span>
     <% end %>
   </div>

--- a/decidim-core/app/cells/decidim/progress_bar/show.erb
+++ b/decidim-core/app/cells/decidim/progress_bar/show.erb
@@ -3,9 +3,9 @@
 
     <% if horizontal? %>
       <span class="progress__bar__text"><%= subtitle_text %></span>
-      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: '.') %></span><%= "/#{number_with_delimiter(total, delimiter: '.')}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: t(".number_delimiter")) %></span><%= "/#{number_with_delimiter(total, delimiter: t(".number_delimiter"))}" if total != 0 %>
     <% else %>
-      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: '.') %></span><%= "/#{number_with_delimiter(total, delimiter: '.')}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: t(".number_delimiter")) %></span><%= "/#{number_with_delimiter(total, delimiter: t(".number_delimiter"))}" if total != 0 %>
       <span class="progress__bar__text"><%= units_name_text %></span>
     <% end %>
   </div>

--- a/decidim-core/app/cells/decidim/progress_bar/show.erb
+++ b/decidim-core/app/cells/decidim/progress_bar/show.erb
@@ -3,9 +3,9 @@
 
     <% if horizontal? %>
       <span class="progress__bar__text"><%= subtitle_text %></span>
-      <span class="progress__bar__number"><%= progress %></span><%= "/#{total}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, :delimiter => '.') %></span><%= "/#{number_with_delimiter(total, :delimiter => '.')}" if total != 0 %>
     <% else %>
-      <span class="progress__bar__number"><%= progress %></span><%= "/#{total}" if total != 0 %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, :delimiter => '.') %></span><%= "/#{number_with_delimiter(total, :delimiter => '.')}" if total != 0 %>
       <span class="progress__bar__text"><%= units_name_text %></span>
     <% end %>
   </div>

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -3,6 +3,7 @@
 module Decidim
   class ViewModel < Cell::ViewModel
     include ActionView::Helpers::TranslationHelper
+    include ActionView::Helpers::NumberHelper
     include ::Cell::Translation
     include Decidim::ResourceHelper
     include Decidim::ScopesHelper

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -460,6 +460,8 @@ en:
       unavailable_scope: Unavailable scope
     menu:
       initiatives: Initiatives
+    progress_bar:
+      number_delimiter: "."
     resources:
       initiatives_type:
         actions:

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -472,6 +472,8 @@ fr:
       unavailable_scope: Portée indisponible
     menu:
       initiatives: Initiatives
+    progress_bar:
+      number_delimiter: "."
     proposals:
       proposals:
         edit:

--- a/decidim-initiatives/config/locales/nl.yml
+++ b/decidim-initiatives/config/locales/nl.yml
@@ -472,6 +472,8 @@ nl:
       unavailable_scope: Niet beschikbaar bereik
     menu:
       initiatives: initiatieven
+    progress_bar:
+      number_delimiter: "."
     proposals:
       proposals:
         edit:


### PR DESCRIPTION
#### :tophat: What? Why?

Client needs to have a decimal delimiter for signatures number

