### PR TITLE
add activerecord_session_store to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "uglifier", "~> 4.1"
 gem "faker", "~> 1.9"
 
 gem "deepl-rb"
-
+gem "activerecord-session_store"
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!


### PR DESCRIPTION
#### :tophat: What? Why?

When user try to create a new development app an error `ActiveRecord::SessionStore` occurs.

Error : `ActiveRecord::SessionStore is extracted out of Rails into a gem. Please add activerecord-session_store to your Gemfile to use it.`

#### :clipboard: Subtasks
- [x] Add gem 'activerecord-session_store' into Gemfile
- [x] Update Gemfile.lock
- [x] Update app_design's Gemfile.lock
