### PR TITLE
Fix state translations in initiatives cards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "uglifier", "~> 4.1"
 gem "faker", "~> 1.9"
 
 gem "deepl-rb"
+gem "activerecord-session_store"
 
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 1.9"
 
-gem "deepl-rb"
 gem "activerecord-session_store"
+gem "deepl-rb"
 
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -220,6 +220,7 @@ ignore_unused:
   - decidim.initiatives.create_initiative.select_initiative_type.more_information
   - decidim.initiatives.create_initiative.show_similar_initiatives.more_information
   - decidim.initiatives.state.*
+  - decidim.initiatives.initiative_signatures.fill_personal_data.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,12 +321,6 @@ en:
           title_cont: Search %{collection} by title.
         state_eq:
           label: State
-          values:
-            accepted: Accepted
-            created: Created
-            discarded: Discarded
-            published: Published
-            rejected: Rejected
       help_sections:
         error: There was a problem updating the help sections
         form:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,6 +321,12 @@ en:
           title_cont: Search %{collection} by title.
         state_eq:
           label: State
+          values:
+            accepted: Accepted
+            created: Created
+            discarded: Discarded
+            published: Published
+            rejected: Rejected
       help_sections:
         error: There was a problem updating the help sections
         form:

--- a/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
+++ b/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
+++ b/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class AddSessionsTable < ActiveRecord::Migration[5.2]
   def change
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, null: false
       t.text :data
       t.timestamps
     end
 
-    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :session_id, unique: true
     add_index :sessions, :updated_at
   end
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -269,7 +269,7 @@ module Decidim
       end
 
       initializer "Expire sessions" do
-        Rails.application.config.session_store :active_record_store, :key => '_decidim_session', expire_after: Decidim.config.expire_session_after
+        Rails.application.config.session_store :active_record_store, key: "_decidim_session", expire_after: Decidim.config.expire_session_after
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
@@ -28,7 +28,7 @@ module Decidim
       def humanize_state(initiative)
         return I18n.t("expired", scope: "decidim.initiatives.states") if initiative.rejected?
 
-        I18n.t(initiative.state, scope: "decidim.initiatives.states")
+        I18n.t(initiative.state, scope: "decidim.initiatives.states", default: :created)
       end
 
       # Public: The state of an initiative in a way a human can understand.
@@ -37,7 +37,7 @@ module Decidim
       #
       # Returns a String.
       def humanize_initiative_state(initiative)
-        I18n.t(initiative.state, scope: "decidim.initiatives.state", default: :created)
+        I18n.t(initiative.state, scope: "decidim.initiatives.state")
       end
 
       # Public: The state of an initiative from an administration perspective in

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
@@ -28,7 +28,7 @@ module Decidim
       def humanize_state(initiative)
         return I18n.t("expired", scope: "decidim.initiatives.states") if initiative.rejected?
 
-        I18n.t(initiative.state, scope: "decidim.initiatives.states", default: :created)
+        I18n.t(initiative.state, scope: "decidim.initiatives.states")
       end
 
       # Public: The state of an initiative in a way a human can understand.
@@ -37,7 +37,7 @@ module Decidim
       #
       # Returns a String.
       def humanize_initiative_state(initiative)
-        I18n.t(initiative.state, scope: "decidim.initiatives.state")
+        I18n.t(initiative.state, scope: "decidim.initiatives.state", default: :created)
       end
 
       # Public: The state of an initiative from an administration perspective in

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -67,7 +67,7 @@ module Decidim
 
     scope :open, lambda {
       published
-        .where.not(state: [:discarded, :rejected, :accepted, :created, :classified])
+        .where.not(state: [:discarded, :rejected, :accepted, :created, :classified, :validating])
         .where("signature_start_date <= ?", Date.current)
         .where("signature_end_date >= ?", Date.current)
     }

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -19,7 +19,8 @@
             <%= f.select :user_scope_id,
                          user_scopes.map { |scope| [translated_attribute(scope&.name), scope&.id]},
                          prompt: t(".select_scope"),
-                         required: true %>
+                         required: true,
+            label: t(".select_scope_label") %>
           </div>
         <% end %>
 

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -339,6 +339,7 @@ en:
             year: Year
           help: Please, fill the following fields with your personal data to sign the initiative
           select_scope: Select scope
+          select_scope_label: Scope
         finish:
           back_to_initiative: Back to initiative
         sms_code:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -360,8 +360,8 @@ en:
           invalid: The phone number is invalid or pending of authorization. Please, check your authorizations.
       initiatives:
         author:
-          identifier: "Identifier: <b>N°%{identifier}</b>"
           deleted: Deleted
+          identifier: 'Identifier: <b>N°%{identifier}</b>'
         author_list:
           hidden_authors_count:
             one: and 1 more person
@@ -453,8 +453,11 @@ en:
             see_all_initiatives: See all initiatives
       state:
         accepted: Accepted
+        classified: Classified
         created: Created
+        debatted: Debatted
         discarded: Discarded
+        examinated: Examinated
         published: Published
         rejected: Rejected
         validating: Technical validation

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -56,7 +56,7 @@ fr:
         document_number: Numéro de document
         name_and_surname: Nom et surnom
         postal_code: Code postal
-        resident: I'm a local resident
+        resident: Je suis résident
       organization_data:
         address: Adresse
         id_document: Document d'identité
@@ -419,7 +419,8 @@ fr:
             year: Année
           help: S'il vous plaît, remplissez les champs suivants avec vos données personnelles
             pour signer l'initiative
-          select_scope: "Sélectionner un périmètre d'application"
+          select_scope: Sélectionner un périmètre d'application
+          select_scope_label: Périmètre d'application
         finish:
           back_to_initiative: Retour à l'initiative
         sms_code:

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -550,8 +550,11 @@ fr:
             see_all_initiatives: Voir toutes les initiatives
       state:
         accepted: Acceptée
+        classified: Classée
         created: Créée
+        debatted: Débattue
         discarded: Retirée
+        examinated: Examinée
         published: Publiée
         rejected: Rejetée
         validating: Validation technique

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -60,7 +60,7 @@ module Decidim
         expect(offline_initiative).to be_valid
       end
 
-      it "technical revission request is notified by email" do
+      it "technical revision request is notified by email" do
         expect(administrator).not_to be_nil
         expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_validating_request)
           .at_least(:once)

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -72,15 +72,26 @@ describe "Initiatives", type: :system do
       it "doesn't display the initiative type filter" do
         within ".new_filter[action='/initiatives']" do
           expect(page).not_to have_css("#filter_type")
-    end
-    
-    context "when in a manual state" do
-      let(:base_initiative) { create(:initiative, :debatted, organization: organization) }
-
-      it "displays the correct badge status" do
-        within "#initiative_#{base_initiative.id}" do
-          expect(page).to have_css(".success.card__text--status")
         end
+      end
+    end
+
+    context "when in a manual state" do
+      shared_examples_for "initiative card" do
+        it "displays the correct badge status" do
+          within "#initiative_#{base_initiative.id}" do
+            expect(page).to have_css(".#{state_class}.card__text--status")
+            expect(find("span.#{state_class}.card__text--status").text).to eq(base_initiative.state.upcase)
+          end
+        end
+      end
+      it_behaves_like "initiative card" do
+        let(:base_initiative) { create(:initiative, :debatted, organization: organization) }
+        let(:state_class) { "success" }
+      end
+      it_behaves_like "initiative card" do
+        let(:base_initiative) { create(:initiative, :examinated, organization: organization) }
+        let(:state_class) { "warning" }
       end
     end
   end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -67,13 +67,12 @@ describe "Initiatives", type: :system do
       end
 
       it_behaves_like "invalid state for index" do
-        let!(:base_initiative) { create(:initiative, :created, organization: organization)}
+        let!(:base_initiative) { create(:initiative, :created, organization: organization) }
       end
 
       it_behaves_like "invalid state for index" do
-        let!(:base_initiative) { create(:initiative, :validating, organization: organization)}
+        let!(:base_initiative) { create(:initiative, :validating, organization: organization) }
       end
-
     end
 
     it "links to the individual initiative page" do

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -55,6 +55,27 @@ describe "Initiatives", type: :system do
       end
     end
 
+    context "when the initiative is 'created' or 'technical validation'" do
+      shared_examples_for "invalid state for index" do
+        it "does not list initiative" do
+          within "#initiatives" do
+            expect(page).not_to have_content(translated(initiative.title, locale: :en))
+            expect(page).not_to have_content(initiative.author_name, count: 1)
+            expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
+          end
+        end
+      end
+
+      it_behaves_like "invalid state for index" do
+        let!(:base_initiative) { create(:initiative, :created, organization: organization)}
+      end
+
+      it_behaves_like "invalid state for index" do
+        let!(:base_initiative) { create(:initiative, :validating, organization: organization)}
+      end
+
+    end
+
     it "links to the individual initiative page" do
       click_link(translated(initiative.title, locale: :en))
       expect(page).to have_current_path(decidim_initiatives.initiative_path(initiative))

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!


### PR DESCRIPTION
#### :tophat: What? Why?

When user navigates to initiatives index, some initiatives have a different state on index and show page. 
When the state is "debatted" or "examinated", the initiative will be display as "created" 

#### :clipboard: Subtasks
- [x] Add translations
- [x] Remove initiatives with 'validating' state in index list
- [x] Add active_record_store migration in core
- [x] Add missing translations in personal form fields
- [x] Add tests

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/26109239/82216017-92d63c80-9918-11ea-8625-e7b02b267444.png)

Personal fields form
![image](https://user-images.githubusercontent.com/26109239/82235970-b955a100-9933-11ea-9417-91b294cbb301.png)
