### PR TITLE
Backport add filter initiative type admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Due to [\#5553](https://github.com/decidim/decidim/pull/5553), SSL is turned on 
 
 ### Added
 
+- **decidim-initiatives**: Add filter by type to admin. [\#6093](https://github.com/decidim/decidim/pull/6093)
 - **decidim-initiative**: Add CTA on initiative submission. [\#5838](https://github.com/decidim/decidim/pull/5838)
 - **decidim-core**: Allow users to register with a preferred language. [\#5789](https://github.com/decidim/decidim/pull/5789
 - **decidim-dev**: Retry failed test to avoid flaky. [\#5894](https://github.com/decidim/decidim/pull/5894)

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 1.9"
 
-gem "deepl-rb"
 gem "activerecord-session_store"
+gem "deepl-rb"
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "uglifier", "~> 4.1"
 gem "faker", "~> 1.9"
 
 gem "deepl-rb"
-
+gem "activerecord-session_store"
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -220,6 +220,7 @@ ignore_unused:
   - decidim.initiatives.create_initiative.select_initiative_type.more_information
   - decidim.initiatives.create_initiative.show_similar_initiatives.more_information
   - decidim.initiatives.state.*
+  - decidim.initiatives.initiative_signatures.fill_personal_data.date_select.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,12 +321,6 @@ en:
           title_cont: Search %{collection} by title.
         state_eq:
           label: State
-          values:
-            accepted: Accepted
-            created: Created
-            discarded: Discarded
-            published: Published
-            rejected: Rejected
       help_sections:
         error: There was a problem updating the help sections
         form:

--- a/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
+++ b/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSessionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -269,7 +269,7 @@ module Decidim
       end
 
       initializer "Expire sessions" do
-        Rails.application.config.session_store :active_record_store, :key => '_decidim_session', expire_after: Decidim.config.expire_session_after
+        Rails.application.config.session_store :active_record_store, key: "_decidim_session", expire_after: Decidim.config.expire_session_after
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/admin/filterable.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/admin/filterable.rb
@@ -14,7 +14,7 @@ module Decidim
           private
 
           def base_query
-            collection
+            collection.joins(:scoped_type).joins("JOIN decidim_users ON decidim_users.id = decidim_initiatives.decidim_author_id")
           end
 
           def search_field_predicate
@@ -22,14 +22,23 @@ module Decidim
           end
 
           def filters
-            [:state_eq]
+            [:state_eq, :type_id_eq]
           end
 
           def filters_with_values
             {
-              state_eq: Initiative.states.keys
+              state_eq: Initiative.states.keys,
+              type_id_eq: InitiativesType.where(organization: current_organization).pluck(:id)
             }
           end
+        end
+
+        def dynamically_translated_filters
+          [:type_id_eq]
+        end
+
+        def translated_type_id_eq(id)
+          translated_attribute(Decidim::InitiativesType.find_by(id: id).title[I18n.locale.to_s])
         end
       end
     end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -455,6 +455,4 @@ module Decidim
       Arel.sql("decidim_initiatives_type_scopes.decidim_initiatives_types_id")
     end
   end
-
-
 end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -451,5 +451,10 @@ module Decidim
 
     # Allow ransacker to search on an Enum Field
     ransacker :state, formatter: proc { |int| states[int] }
+    ransacker :type_id do
+      Arel.sql("decidim_initiatives_type_scopes.decidim_initiatives_types_id")
+    end
   end
+
+
 end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -362,8 +362,8 @@ en:
           invalid: The phone number is invalid or pending of authorization. Please, check your authorizations.
       initiatives:
         author:
-          identifier: "Identifier: <b>N°%{identifier}</b>"
           deleted: Deleted
+          identifier: 'Identifier: <b>N°%{identifier}</b>'
         author_list:
           hidden_authors_count:
             one: and 1 more person

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
             published: Published
             rejected: Rejected
             validating: Technical validation
+        type_id_eq:
+          label: Type
       menu:
         initiatives: Initiatives
         initiatives_types: Initiative types

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -17,11 +17,30 @@ describe "Admin manages initiatives", type: :system do
     Decidim::Initiative.where.not(state: state).sample
   end
 
+  def initiative_with_type(type)
+    Decidim::Initiative.join(:scoped_type).find_by(decidim_initiatives_types_id: type)
+  end
+
+  def initiative_without_type(type)
+    Decidim::Initiative.join(:scoped_type).where.not(decidim_initiatives_types_id: type).sample
+  end
+  def initiative_with_type(type)
+    Decidim::Initiative.join(:scoped_type).find_by(decidim_initiatives_types_id: type)
+  end
+
+  def initiative_without_type(type)
+    Decidim::Initiative.join(:scoped_type).where.not(decidim_initiatives_types_id: type).sample
+  end
+
   include_context "with filterable context"
 
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, organization: organization) }
   let(:model_name) { Decidim::Initiative.model_name }
+  let(:type1) { create :initiatives_type, organization: organization }
+  let(:type2) { create :initiatives_type, organization: organization }
+  let(:scoped_type1) { create :initiatives_type_scope, type: type1 }
+  let(:scoped_type2) { create :initiatives_type_scope, type: type2 }
 
   STATES.each do |state|
     let!("#{state}_initiative") { create_initiative_with_trait(state) }
@@ -41,6 +60,23 @@ describe "Admin manages initiatives", type: :system do
         it_behaves_like "a filtered collection", options: "State", filter: i18n_state do
           let(:in_filter) { translated(initiative_with_state(state).title) }
           let(:not_in_filter) { translated(initiative_without_state(state).title) }
+        end
+      end
+    end
+
+    Decidim::InitiativesTypeScope.all.each do |scoped_type|
+      type = scoped_type.type
+      i18n_type = type.title[I18n.locale.to_s]
+
+      context "filtering collection by type: #{i18n_type}" do
+        before do
+          create(:initiative, organization: organization, scoped_type: scoped_type1)
+          create(:initiative, organization: organization, scoped_type: scoped_type2)
+        end
+
+        it_behaves_like "a filtered collection", options: "Type", filter: i18n_type do
+          let(:in_filter) { translated(initiative_with_type(type).title) }
+          let(:not_in_filter) { translated(initiative_without_type(type).title) }
         end
       end
     end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -24,6 +24,7 @@ describe "Admin manages initiatives", type: :system do
   def initiative_without_type(type)
     Decidim::Initiative.join(:scoped_type).where.not(decidim_initiatives_types_id: type).sample
   end
+
   def initiative_with_type(type)
     Decidim::Initiative.join(:scoped_type).find_by(decidim_initiatives_types_id: type)
   end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -72,8 +72,10 @@ describe "Initiatives", type: :system do
       it "doesn't display the initiative type filter" do
         within ".new_filter[action='/initiatives']" do
           expect(page).not_to have_css("#filter_type")
+        end
+      end
     end
-    
+
     context "when in a manual state" do
       let(:base_initiative) { create(:initiative, :debatted, organization: organization) }
 

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!


### PR DESCRIPTION
#### :tophat: What? Why?

Enable admins to filter initiatives by type

#### 📌 Related Issues
- Metadecidim proposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/15236

#### :clipboard: Subtasks
- [x] Backport
