### PR TITLE
Backport sort initiatives by publishing date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "uglifier", "~> 4.1"
 gem "faker", "~> 1.9"
 
 gem "deepl-rb"
+gem "activerecord-session_store"
 
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,12 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -774,6 +780,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap (~> 1.4)
   byebug (~> 11.0)
   decidim!

--- a/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
+++ b/decidim-core/db/migrate/20200518145440_add_sessions_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSessionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
@@ -14,7 +14,7 @@ module Decidim
         # Available orders based on enabled settings
         def available_orders
           @available_orders ||= begin
-            available_orders = %w(random recent most_voted)
+            available_orders = %w(random recent most_voted recently_published)
             available_orders
           end
         end
@@ -31,6 +31,8 @@ module Decidim
             initiatives.order_by_most_commented
           when "recent"
             initiatives.order_by_most_recent
+          when "recently_published"
+            initiatives.order_by_most_recently_published
           else
             initiatives.order_randomly(random_seed)
           end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -84,6 +84,7 @@ module Decidim
     scope :signature_type_updatable, -> { created }
 
     scope :order_by_most_recent, -> { order(created_at: :desc) }
+    scope :order_by_most_recently_published, -> { order(published_at: :desc) }
     scope :order_by_supports, -> { order("((online_votes->>'total')::int + (offline_votes->>'total')::int) DESC") }
     scope :order_by_most_commented, lambda {
       select("decidim_initiatives.*")
@@ -451,5 +452,28 @@ module Decidim
 
     # Allow ransacker to search on an Enum Field
     ransacker :state, formatter: proc { |int| states[int] }
+
+
+    # method for sort_link by number of supports
+    ransacker :supports_count do
+      query = <<~SQL
+        (
+          SELECT
+            CASE
+              WHEN signature_type = 0 THEN 0
+              ELSE COALESCE(offline_votes, 0)
+            END
+            +
+            CASE
+              WHEN signature_type = 1 THEN 0
+              ELSE initiative_votes_count + initiative_supports_count
+            END
+           FROM decidim_initiatives as initiatives
+          WHERE initiatives.id = decidim_initiatives.id
+          GROUP BY initiatives.id
+        )
+      SQL
+      Arel.sql(query)
+    end
   end
 end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -13,8 +13,9 @@
             <th><%= t("models.initiatives.fields.id", scope: "decidim.admin") %></th>
             <th><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
             <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
-            <th><%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %></th>
+            <th><%= sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :published_at, t("models.initiatives.fields.published_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th class="actions"><%= t ".actions_title" %></th>
           </tr>
         </thead>
@@ -33,6 +34,7 @@
             <td><%= humanize_admin_state initiative.state %></td>
             <td><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
             <td><%= l initiative.created_at, format: :short %></td>
+            <td><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
             <td class="table-list__actions">
               <% if allowed_to? :preview, :initiative, initiative: initiative %>
                 <%= icon_link_to "eye",

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_initiatives.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_initiatives.html.erb
@@ -1,4 +1,4 @@
-<div class="collection-sort-controls row small-up-1 medium-up-3 card-grid">
+<div class="collection-sort-controls row small-up-1 medium-up-2 card-grid">
   <div class="column">
     <%= order_selector available_orders, i18n_scope: "decidim.initiatives.initiatives.orders" %>
   </div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
           fields:
             created_at: Created at
             id: ID
+            published_at: Published at
             state: Status
             supports_count: Signatures
             title: Initiatives
@@ -398,6 +399,7 @@ en:
           most_voted: Most signed
           random: Random
           recent: Most recent
+          recently_published: Most recently published
         result:
           answer_title:
             accepted: This proposal has been accepted because

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -42,6 +42,15 @@ module Decidim
           end
         end
 
+        context "when order by most recently published" do
+          let!(:old_initiative) { create(:initiative, organization: organization, published_at: initiative.published_at - 12.months) }
+
+          it "most recent appears first" do
+            get :index, params: { order: "recently_published" }
+            expect(subject.helpers.initiatives.first).to eq(initiative)
+          end
+        end
+
         context "when order by most commented" do
           let(:commented_initiative) { create(:initiative, organization: organization) }
           let!(:comment) { create(:comment, commentable: commented_initiative) }

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -304,5 +304,22 @@ module Decidim
         it { is_expected.to be_falsy }
       end
     end
+
+    describe "sorting" do
+      subject(:sorter) { described_class.ransack("s" => "supports_count desc") }
+
+      before do
+        create(:initiative, organization: organization, signature_type: "offline")
+        create(:initiative, organization: organization, signature_type: "offline", offline_votes: 4)
+        create(:initiative, organization: organization, signature_type: "online", initiative_votes_count: 1, initiative_supports_count: 4)
+        create(:initiative, organization: organization, signature_type: "online", initiative_votes_count: 2, initiative_supports_count: 1)
+        create(:initiative, organization: organization, signature_type: "any", initiative_votes_count: 1, initiative_supports_count: 0)
+        create(:initiative, organization: organization, signature_type: "any", initiative_votes_count: 3, initiative_supports_count: 2, offline_votes: 3)
+      end
+
+      it "sorts initiatives by supports count" do
+        expect(sorter.result.map(&:supports_count)).to eq([8, 5, 4, 3, 1, 0])
+      end
+    end
   end
 end


### PR DESCRIPTION
##### :tophat: What? Why?
Enable users and admins to sort initiatives by publishing date

#### :clipboard: Subtasks
- [x] Backport

#### Related metadecidim proposal
 https://meta.decidim.org/processes/roadmap/f/122/proposals/15131