### PR TITLE
Add states in initiatives filter

### DIFF
--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -6,6 +6,7 @@ on:
       - master
       - release/*
       - "*-stable"
+      - feature/*
   pull_request:
     branches:
       - "*"

--- a/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
@@ -19,7 +19,11 @@ module Decidim
                 TreePoint.new("rejected", t("decidim.initiatives.application_helper.filter_state_values.rejected"))
               ]
             ),
-            TreePoint.new("answered", t("decidim.initiatives.application_helper.filter_state_values.answered"))
+            TreePoint.new("answered", t("decidim.initiatives.application_helper.filter_state_values.answered")),
+            TreePoint.new("published", t("decidim.initiatives.application_helper.filter_state_values.published")),
+            TreePoint.new("classified", t("decidim.initiatives.application_helper.filter_state_values.classified")),
+            TreePoint.new("examinated", t("decidim.initiatives.application_helper.filter_state_values.examinated")),
+            TreePoint.new("debatted", t("decidim.initiatives.application_helper.filter_state_values.debatted"))
           ]
         )
       end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -481,24 +481,24 @@ module Decidim
 
     # method for sort_link by number of supports
     ransacker :supports_count do
-     query = <<~SQL
-       (
-         SELECT
-           CASE
-             WHEN signature_type = 0 THEN 0
-             ELSE COALESCE((offline_votes::json->>'total')::int, 0)
-           END
-           +
-           CASE
-             WHEN signature_type = 1 THEN 0
-             ELSE COALESCE((online_votes::json->>'total')::int, 0)
-           END
-          FROM decidim_initiatives as initiatives
-         WHERE initiatives.id = decidim_initiatives.id
-         GROUP BY initiatives.id
-       )
-     SQL
-     Arel.sql(query)
+      query = <<~SQL
+        (
+          SELECT
+            CASE
+              WHEN signature_type = 0 THEN 0
+              ELSE COALESCE((offline_votes::json->>'total')::int, 0)
+            END
+            +
+            CASE
+              WHEN signature_type = 1 THEN 0
+              ELSE COALESCE((online_votes::json->>'total')::int, 0)
+            END
+           FROM decidim_initiatives as initiatives
+          WHERE initiatives.id = decidim_initiatives.id
+          GROUP BY initiatives.id
+        )
+      SQL
+      Arel.sql(query)
     end
   end
 end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -73,7 +73,7 @@ module Decidim
       where(state: [:discarded, :rejected, :accepted])
         .or(currently_unsignable)
     }
-    scope :published, -> { where.not(published_at: nil) }
+    scope :published, -> { where.not(published_at: nil).where.not(state: [:created, :validating]) }
     scope :with_state, ->(state) { where(state: state) if state.present? }
 
     scope :currently_signable, lambda {

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -73,7 +73,6 @@ module Decidim
       where(state: [:discarded, :rejected, :accepted])
         .or(currently_unsignable)
     }
-    scope :published, -> { where.not(published_at: nil).where.not(state: [:created, :validating]) }
     scope :with_state, ->(state) { where(state: state) if state.present? }
 
     scope :currently_signable, lambda {

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -18,7 +18,8 @@ module Decidim
           .includes(scoped_type: [:scope])
           .joins("JOIN decidim_users ON decidim_users.id = decidim_initiatives.decidim_author_id")
           .where(organization: options[:organization])
-          .published
+          .where.not(state: [:created, :validating])
+          .where.not(published_at: nil)
       end
 
       # Handle the search_text filter
@@ -45,14 +46,15 @@ module Decidim
 
       # Handle the state filter
       def search_state
-        accepted = state.member?("accepted") ? query.accepted : nil
-        rejected = state.member?("rejected") ? query.rejected : nil
-        answered = state.member?("answered") ? query.answered : nil
-        open = state.member?("open") ? query.open : nil
-        closed = state.member?("closed") ? query.closed : nil
-        classified = state.member?("classified") ? query.classified : nil
-        examinated = state.member?("examinated") ? query.examinated : nil
-        debatted = state.member?("debatted") ? query.debatted : nil
+        accepted ||= query.accepted if state.member?("accepted")
+        rejected ||= query.rejected if state.member?("rejected")
+        open ||= query.open if state.member?("open")
+        closed ||= query.closed if state.member?("closed")
+        answered ||= query.answered if state.member?("answered")
+        published ||= query.published if state.member?("published")
+        classified ||= query.classified if state.member?("classified")
+        examinated ||= query.examinated if state.member?("examinated")
+        debatted ||= query.debatted if state.member?("debatted")
 
         query
           .where(id: accepted)
@@ -60,6 +62,7 @@ module Decidim
           .or(query.where(id: answered))
           .or(query.where(id: open))
           .or(query.where(id: closed))
+          .or(query.where(id: published))
           .or(query.where(id: classified))
           .or(query.where(id: examinated))
           .or(query.where(id: debatted))

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -50,6 +50,9 @@ module Decidim
         answered = state.member?("answered") ? query.answered : nil
         open = state.member?("open") ? query.open : nil
         closed = state.member?("closed") ? query.closed : nil
+        classified = state.member?("classified") ? query.classified : nil
+        examinated = state.member?("examinated") ? query.examinated : nil
+        debatted = state.member?("debatted") ? query.debatted : nil
 
         query
           .where(id: accepted)
@@ -57,6 +60,9 @@ module Decidim
           .or(query.where(id: answered))
           .or(query.where(id: open))
           .or(query.where(id: closed))
+          .or(query.where(id: classified))
+          .or(query.where(id: examinated))
+          .or(query.where(id: debatted))
       end
 
       def search_type_id

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -45,6 +45,7 @@ module Decidim
       end
 
       # Handle the state filter
+      # rubocop:disable Metrics/CyclomaticComplexity
       def search_state
         accepted ||= query.accepted if state.member?("accepted")
         rejected ||= query.rejected if state.member?("rejected")
@@ -68,6 +69,7 @@ module Decidim
           .or(query.where(id: debatted))
       end
 
+      # rubocop:enable Metrics/CyclomaticComplexity
       def search_type_id
         return query if type_ids.include?("all")
 

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -325,8 +325,12 @@ en:
           accepted: Enough signatures
           all: All
           answered: Answered
+          classified: Classified
           closed: Closed
+          debatted: Debatted
+          examinated: Examinated
           open: Open
+          published: Published
           rejected: Not enough signatures
         filter_type_values:
           all: All
@@ -576,8 +580,11 @@ en:
       show:
         badge_name:
           accepted: Enough signatures
+          classified: Classified
           created: Created
+          debatted: Debatted
           discarded: Discarded
+          examinated: Examinated
           published: Published
           rejected: Not enough signatures
           validating: Technical validation

--- a/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
@@ -121,6 +121,54 @@ module Decidim
               expect(subject).to match_array(answered_initiatives)
             end
           end
+
+          context "and filtering published initiatives" do
+            let(:state) { ["published"] }
+
+            it "returns only published initiatives" do
+              default_published_initiatives = create_list(:initiative, 3, organization: organization)
+              published_initiatives = create_list(:initiative, 3, :published, organization: organization)
+
+              expect(subject.size).to eq(6)
+              expect(subject).to match_array(default_published_initiatives + published_initiatives)
+            end
+          end
+
+          context "and filtering classified initiatives" do
+            let(:state) { ["classified"] }
+
+            it "returns only classified initiatives" do
+              create_list(:initiative, 3, organization: organization)
+              classified_initiatives = create_list(:initiative, 3, :classified, organization: organization)
+
+              expect(subject.size).to eq(3)
+              expect(subject).to match_array(classified_initiatives)
+            end
+          end
+
+          context "and filtering examinated initiatives" do
+            let(:state) { ["examinated"] }
+
+            it "returns only examinated initiatives" do
+              create_list(:initiative, 3, organization: organization)
+              examinated_initiatives = create_list(:initiative, 3, :examinated, organization: organization)
+
+              expect(subject.size).to eq(3)
+              expect(subject).to match_array(examinated_initiatives)
+            end
+          end
+
+          context "and filtering debatted initiatives" do
+            let(:state) { ["debatted"] }
+
+            it "returns only debatted initiatives" do
+              create_list(:initiative, 3, organization: organization)
+              debatted_initiatives = create_list(:initiative, 3, :debatted, organization: organization)
+
+              expect(subject.size).to eq(3)
+              expect(subject).to match_array(debatted_initiatives)
+            end
+          end
         end
 
         context "when the filter includes scope_id" do

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -71,6 +71,12 @@ describe "Filter Initiatives", :slow, type: :system do
       create_list(:initiative, 4, organization: organization)
       create_list(:initiative, 3, :accepted, organization: organization)
       create_list(:initiative, 2, :rejected, organization: organization)
+      create_list(:initiative, 2, :published, organization: organization)
+      create_list(:initiative, 1, :examinated, organization: organization)
+      create_list(:initiative, 2, :classified, organization: organization)
+      create_list(:initiative, 2, :debatted, organization: organization)
+      create_list(:initiative, 3, :validating, organization: organization)
+      create_list(:initiative, 3, :created, organization: organization)
       create(:initiative, :acceptable, organization: organization)
       create(:initiative, organization: organization, answered_at: Time.current)
 
@@ -90,8 +96,18 @@ describe "Filter Initiatives", :slow, type: :system do
           check "All"
         end
 
-        expect(page).to have_css(".card--initiative", count: 11)
-        expect(page).to have_content("11 INITIATIVES")
+        expect(page).to have_css(".card--initiative", count: 18)
+        expect(page).to have_content("18 INITIATIVES")
+      end
+
+      it "does not list created and validating initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "All"
+        end
+
+        expect(page).not_to have_content("CREATED")
+        expect(page).not_to have_content("TECHNICAL VALIDATION")
       end
     end
 
@@ -102,8 +118,8 @@ describe "Filter Initiatives", :slow, type: :system do
           check "Open"
         end
 
-        expect(page).to have_css(".card--initiative", count: 5)
-        expect(page).to have_content("5 INITIATIVES")
+        expect(page).to have_css(".card--initiative", count: 12)
+        expect(page).to have_content("12 INITIATIVES")
       end
     end
 
@@ -158,6 +174,54 @@ describe "Filter Initiatives", :slow, type: :system do
 
         expect(page).to have_css(".card--initiative", count: 1)
         expect(page).to have_content("1 INITIATIVE")
+      end
+    end
+
+    context "when selecting the published state" do
+      it "lists the published initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Published"
+        end
+
+        expect(page).to have_css(".card--initiative", count: 8)
+        expect(page).to have_content("8 INITIATIVES")
+      end
+    end
+
+    context "when selecting the examinated state" do
+      it "lists the examinated initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Examinated"
+        end
+
+        expect(page).to have_css(".card--initiative", count: 1)
+        expect(page).to have_content("1 INITIATIVE")
+      end
+    end
+
+    context "when selecting the classified state" do
+      it "lists the classified initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Classified"
+        end
+
+        expect(page).to have_css(".card--initiative", count: 2)
+        expect(page).to have_content("2 INITIATIVES")
+      end
+    end
+
+    context "when selecting the debatted state" do
+      it "lists the debatted initiatives" do
+        within ".filters .state_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Debatted"
+        end
+
+        expect(page).to have_css(".card--initiative", count: 2)
+        expect(page).to have_content("2 INITIATIVES")
       end
     end
   end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -66,6 +66,18 @@ describe "Initiatives", type: :system do
       end
     end
 
+    context "when validating state initiative" do
+      let(:validating_initiative) { create(:initiative, :validating, organization: organization) }
+
+      it "does not display the validating initiative" do
+        within "#initiatives" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(initiative.author_name, count: 1)
+          expect(page).not_to have_content(translated(validating_initiative.title, locale: :en))
+        end
+      end
+    end
+
     context "when there is a unique initiative type" do
       let!(:unpublished_initiative) { nil }
 


### PR DESCRIPTION
#### :tophat: What? Why?
 
Add filter options "published", "classified", "examinated", "debatted" in initiatives.
Ensure "validating" and "created" state initiatives are not shown in FO because not published.

#### :clipboard: Subtasks
- [x] Add filter options
- [x] "validating" and "created" not shown in FO
- [x] Add tests