### PR TITLE
Feature petition add sorting option

### DIFF
--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -6,7 +6,6 @@ on:
       - master
       - release/*
       - "*-stable"
-      - feature/*
   pull_request:
     branches:
       - "*"

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
@@ -14,8 +14,7 @@ module Decidim
         # Available orders based on enabled settings
         def available_orders
           @available_orders ||= begin
-            available_orders = %w(random recent most_voted recently_published)
-            available_orders
+            %w(random recent most_voted recently_published answer_date)
           end
         end
 
@@ -33,6 +32,8 @@ module Decidim
             initiatives.order_by_most_recent
           when "recently_published"
             initiatives.order_by_most_recently_published
+          when "answer_date"
+            initiatives.order_by_answer_date
           else
             initiatives.order_randomly(random_seed)
           end

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
@@ -13,9 +13,7 @@ module Decidim
 
         # Available orders based on enabled settings
         def available_orders
-          @available_orders ||= begin
-            %w(random recent most_voted recently_published answer_date)
-          end
+          @available_orders ||= %w(random recent most_voted recently_published answer_date)
         end
 
         def default_order

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -90,6 +90,7 @@ module Decidim
     scope :public_spaces, -> { published }
     scope :signature_type_updatable, -> { created }
 
+    scope :order_by_answer_date, -> { order("answered_at DESC nulls last") }
     scope :order_by_most_recent, -> { order(created_at: :desc) }
     scope :order_by_most_recently_published, -> { order(published_at: :desc) }
     scope :order_by_supports, -> { order("((online_votes->>'total')::int + (offline_votes->>'total')::int) DESC") }
@@ -146,7 +147,7 @@ module Decidim
     #
     # RETURNS string
     delegate :banner_image, to: :type
-    delegate :document_number_authorization_handler, :promoting_committee_enabled?, :custom_signature_end_date_enabled?,:area_enabled?, to: :type
+    delegate :document_number_authorization_handler, :promoting_committee_enabled?, :custom_signature_end_date_enabled?, :area_enabled?, to: :type
     delegate :name, to: :area, prefix: true, allow_nil: true
     delegate :type, :scope, :scope_name, to: :scoped_type, allow_nil: true
 

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -441,6 +441,7 @@ en:
               one: Comment
               other: Comment
         orders:
+          answer_date: Answer date
           label: 'Sort initiatives by:'
           most_commented: Most commented
           most_voted: Most signed

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -543,6 +543,7 @@ fr:
               one: Commentaire
               other: commentaires
         orders:
+          answer_date: Date de réponse
           label: 'Trier les initiatives par :'
           most_commented: Les plus commentées
           most_voted: Les plus soutenues

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -55,9 +55,18 @@ module Decidim
           let(:commented_initiative) { create(:initiative, organization: organization) }
           let!(:comment) { create(:comment, commentable: commented_initiative) }
 
-          it "most commented appears fisrt" do
+          it "most commented appears first" do
             get :index, params: { order: "most_commented" }
             expect(subject.helpers.initiatives.first).to eq(commented_initiative)
+          end
+        end
+
+        context "when order by answer date" do
+          let!(:answered_initiative) { create(:initiative, :with_answer, organization: organization) }
+
+          it "most recently answered appears first" do
+            get :index, params: { order: "answer_date" }
+            expect(subject.helpers.initiatives.first).to eq(answered_initiative)
           end
         end
       end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -98,4 +98,22 @@ describe "Initiatives", type: :system do
       end
     end
   end
+
+  context "when sorting initiatives" do
+    before do
+      visit decidim_initiatives.initiatives_path
+    end
+
+    it "displays the sorting list" do
+      expect(page).to have_content("Sort initiatives by")
+
+      within "#initiatives .collection-sort-controls" do
+        expect(page).to have_css("a", text: "Random")
+        expect(page).to have_css("a", text: "Most recent", visible: false)
+        expect(page).to have_css("a", text: "Most signed", visible: false)
+        expect(page).to have_css("a", text: "Most recently published", visible: false)
+        expect(page).to have_css("a", text: "Answer date", visible: false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Add a sorting option for "Answer date"  in FO 

#### :clipboard: Subtasks
- [x] Add 'answer date' filter options in initiatives index
- [x] Add tests

### :camera: Screenshots (optional)

<img width="456" alt="add_answer_date_sorting_option" src="https://user-images.githubusercontent.com/26109239/84050460-1500d080-a9ae-11ea-900e-1979fdfe0c38.png">
