### PR TITLE
avoid nil user in participatory private space admin index

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
@@ -95,6 +95,7 @@ module Decidim
           def collection
             @collection ||= privatable_to
                             .participatory_space_private_users
+                            .includes(:user).where.not("decidim_users.id" => nil)
                             .page(params[:page])
                             .per(20)
           end

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -23,6 +23,7 @@
           </thead>
           <tbody>
             <% collection.each do |private_user| %>
+              <% next if private_user.user.nil? %>
               <tr>
                 <td>
                   <%= private_user.user.name %><br>

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -23,7 +23,6 @@
           </thead>
           <tbody>
             <% collection.each do |private_user| %>
-              <% next if private_user.user.nil? %>
               <tr>
                 <td>
                   <%= private_user.user.name %><br>

--- a/decidim-admin/spec/system/admin_manages_private_users_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_private_users_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Private Space Participatory", type: :system do
+  let(:organization) { create(:organization) }
+
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:main_user) { create(:user, :confirmed, organization: organization) }
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+
+  let!(:participatory_space_private_main_user) { create :participatory_space_private_user, user: main_user, privatable_to: participatory_space_private }
+  let!(:participatory_space_private_user) { create :participatory_space_private_user, user: other_user, privatable_to: participatory_space_private }
+
+  let!(:participatory_space_private) { create :assembly, :published, organization: organization, private_space: true }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin.root_path
+  end
+
+  context "when there is users" do
+    before do
+      click_link "Assemblies"
+      click_link participatory_space_private.translated_title
+      click_link "Private users"
+    end
+
+    it "displays users in private space" do
+      within "#private_users" do
+        expect(page).to have_content(main_user.name)
+        expect(page).to have_content(other_user.name)
+      end
+    end
+  end
+
+  context "when a user is removed manually" do
+    before do
+      Decidim::User.find_by(email: main_user.email).destroy
+      click_link "Assemblies"
+      click_link participatory_space_private.translated_title
+      click_link "Private users"
+    end
+
+    it "displays users in private space" do
+      within "#private_users" do
+        expect(page).not_to have_content(main_user.name)
+        expect(page).to have_content(other_user.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Because when user is manually destroyed for x reason, a server error can occur when this user is a private space Assembly Member in admin side. 

This update allows to skip a unknown user.

#### :clipboard: Subtasks
- [x] Backport collection enhancement of private users
- [x] Add tests

#### Error raised 

```ruby
NoMethodError
undefined method `name' for nil:NilClass
```
in `decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb`