### PR TITLE
Add answer date sort in BO

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -21,6 +21,7 @@
             <%-#sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) -%>
             <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :published_at, t("models.initiatives.fields.published_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :answer_date, t("models.initiatives.fields.answered_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th class="actions"><%= t ".actions_title" %></th>
           </tr>
         </thead>
@@ -40,6 +41,7 @@
             <td><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
             <td><%= l initiative.created_at, format: :short %></td>
             <td><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
+            <td><%= initiative.answer_date? ? l(initiative.answer_date.to_time, format: :short) : "" %></td>
             <td class="table-list__actions">
               <% if allowed_to? :preview, :initiative, initiative: initiative %>
                 <%= icon_link_to "eye",

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
       models:
         initiatives:
           fields:
+            answered_at: Answered at
             created_at: Created at
             id: ID
             published_at: Published at

--- a/decidim-initiatives/config/locales/fr.yml
+++ b/decidim-initiatives/config/locales/fr.yml
@@ -123,6 +123,7 @@ fr:
       models:
         initiatives:
           fields:
+            answered_at: Répondu à
             created_at: Créé à
             id: ID
             published_at: Publié à l'adresse
@@ -621,8 +622,11 @@ fr:
       show:
         badge_name:
           accepted: Assez de signatures
+          classified: Classée
           created: Créé
+          debatted: Débattue
           discarded: Rejeté
+          examinated: Examinée
           published: Publié
           rejected: Pas assez de signatures
           validating: Validation technique


### PR DESCRIPTION
#### :tophat: What? Why?

Add new filter option in initiatives admin panel to sort by `answer_date`

#### :clipboard: Subtasks
- [x] Add new sort option
- [x] Add missing FR translations for custom state cards translation

### :camera: Screenshots (optional)
<img width="1100" alt="Screenshot 2020-06-10 at 11 40 37" src="https://user-images.githubusercontent.com/26109239/84252941-9328b880-ab0f-11ea-9931-3f53e6121ea1.png">
