### PR TITLE
Fix support count sort in BO

### DIFF
--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -78,7 +78,7 @@ module Decidim
 
       def authors
         [present(model).author] +
-            model.committee_members.approved.non_deleted.excluding_author.map { |member| present(member.user) }
+          model.committee_members.approved.non_deleted.excluding_author.map { |member| present(member.user) }
       end
 
       def comments_count

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -68,7 +68,7 @@ module Decidim
 
     scope :open, lambda {
       where.not(state: [:classified, :discarded, :rejected, :accepted, :created])
-        .currently_signable
+           .currently_signable
     }
     scope :closed, lambda {
       where(state: [:classified, :discarded, :rejected, :accepted])
@@ -96,9 +96,9 @@ module Decidim
     scope :order_by_supports, -> { order("((online_votes->>'total')::int + (offline_votes->>'total')::int) DESC") }
     scope :order_by_most_commented, lambda {
       select("decidim_initiatives.*")
-          .left_joins(:comments)
-          .group("decidim_initiatives.id")
-          .order(Arel.sql("count(decidim_comments_comments.id) desc"))
+        .left_joins(:comments)
+        .group("decidim_initiatives.id")
+        .order(Arel.sql("count(decidim_comments_comments.id) desc"))
     }
     scope :future_spaces, -> { none }
     scope :past_spaces, -> { closed }
@@ -107,10 +107,10 @@ module Decidim
     after_create :notify_creation
 
     searchable_fields({
-                          participatory_space: :itself,
-                          A: :title,
-                          D: :description,
-                          datetime: :published_at
+                        participatory_space: :itself,
+                        A: :title,
+                        D: :description,
+                        datetime: :published_at
                       },
                       index_on_create: ->(_initiative) { false },
                       # is Resourceable instead of ParticipatorySpaceResourceable so we can't use `visible?`
@@ -138,9 +138,7 @@ module Decidim
       Decidim::Initiatives::InitiativeSerializer
     end
 
-    def self.data_portability_images(user)
-      ;
-    end
+    def self.data_portability_images(user); end
 
     # PUBLIC banner image
     #
@@ -204,13 +202,13 @@ module Decidim
     # RETURNS STRING
     def author_avatar_url
       author.avatar&.url ||
-          ActionController::Base.helpers.asset_path("decidim/default-avatar.svg")
+        ActionController::Base.helpers.asset_path("decidim/default-avatar.svg")
     end
 
     def votes_enabled?
       votes_enabled_state? &&
-          signature_start_date <= Date.current &&
-          signature_end_date >= Date.current
+        signature_start_date <= Date.current &&
+        signature_end_date >= Date.current
     end
 
     def votes_enabled_state?
@@ -252,10 +250,10 @@ module Decidim
       return false if published?
 
       update(
-          published_at: Time.current,
-          state: "published",
-          signature_start_date: Date.current,
-          signature_end_date: signature_end_date || Date.current + Decidim::Initiatives.default_signature_time_period_length
+        published_at: Time.current,
+        state: "published",
+        signature_start_date: Date.current,
+        signature_end_date: signature_end_date || Date.current + Decidim::Initiatives.default_signature_time_period_length
       )
     end
 

--- a/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/initiative_search.rb
@@ -54,7 +54,6 @@ module Decidim
         states
       end
 
-      # rubocop:enable Metrics/CyclomaticComplexity
       def search_type_id
         return query if type_ids.include?("all")
 
@@ -91,6 +90,7 @@ module Decidim
       private
 
       # search_state and search_custom_state should be a common query in different filter
+      # rubocop:disable Metrics/CyclomaticComplexity
       def states
         accepted ||= query.accepted if state&.member?("accepted")
         rejected ||= query.rejected if state&.member?("rejected")
@@ -115,6 +115,7 @@ module Decidim
       end
 
       # Private: Returns an array with checked type ids.
+      # rubocop:enable Metrics/CyclomaticComplexity
       def type_ids
         [type_id].flatten
       end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -16,9 +16,7 @@
             <th><%= t("models.initiatives.fields.id", scope: "decidim.admin") %></th>
             <th><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
             <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
-            <th><%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %></th>
-            <%-# TODO: Check for sorting by supports_count -%>
-            <%-#sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) -%>
+            <th><%= sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :published_at, t("models.initiatives.fields.published_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th class="actions"><%= t ".actions_title" %></th>

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -106,6 +106,8 @@ FactoryBot.define do
     signature_type { "online" }
     signature_start_date { Date.current - 1.day }
     signature_end_date { Date.current + 120.days }
+    online_votes { { "total": 0 } }
+    offline_votes { { "total": 0 } }
     answer_date {}
     area {}
 

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -12,9 +12,9 @@ module Decidim
     let(:initiatives_type_minimum_committee_members) { 2 }
     let(:initiatives_type) do
       create(
-          :initiatives_type,
-          organization: organization,
-          minimum_committee_members: initiatives_type_minimum_committee_members
+        :initiatives_type,
+        organization: organization,
+        minimum_committee_members: initiatives_type_minimum_committee_members
       )
     end
     let(:scoped_type) { create(:initiatives_type_scope, type: initiatives_type) }
@@ -24,16 +24,16 @@ module Decidim
     describe ".states" do
       it "returns the correct enumerator" do
         expect(subject.class.states).to eq(
-                                            "created" => 0,
-                                            "validating" => 1,
-                                            "discarded" => 2,
-                                            "published" => 3,
-                                            "rejected" => 4,
-                                            "accepted" => 5,
-                                            "examinated" => 6,
-                                            "debatted" => 7,
-                                            "classified" => 8
-                                        )
+          "created" => 0,
+          "validating" => 1,
+          "discarded" => 2,
+          "published" => 3,
+          "rejected" => 4,
+          "accepted" => 5,
+          "examinated" => 6,
+          "debatted" => 7,
+          "classified" => 8
+        )
       end
     end
 
@@ -63,16 +63,16 @@ module Decidim
       it "technical revission request is notified by email" do
         expect(administrator).not_to be_nil
         expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_validating_request)
-                                                               .at_least(:once)
-                                                               .and_return(message_delivery)
+          .at_least(:once)
+          .and_return(message_delivery)
         initiative.validating!
       end
 
       it "Creation is notified by email" do
         expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_creation)
-                                                               .at_least(:once)
-                                                               .at_most(:once)
-                                                               .and_return(message_delivery)
+          .at_least(:once)
+          .at_most(:once)
+          .and_return(message_delivery)
         initiative = build(:initiative, :created)
         initiative.save!
       end
@@ -117,15 +117,15 @@ module Decidim
 
         it "Acceptation is notified by email" do
           expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_state_change)
-                                                                 .at_least(:once)
-                                                                 .and_return(message_delivery)
+            .at_least(:once)
+            .and_return(message_delivery)
           published_initiative.accepted!
         end
 
         it "Rejection is notified by email" do
           expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_state_change)
-                                                                 .at_least(:once)
-                                                                 .and_return(message_delivery)
+            .at_least(:once)
+            .and_return(message_delivery)
           published_initiative.rejected!
         end
       end
@@ -159,15 +159,15 @@ module Decidim
 
         it "publication is notified by email" do
           expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_state_change)
-                                                                 .at_least(:once)
-                                                                 .and_return(message_delivery)
+            .at_least(:once)
+            .and_return(message_delivery)
           validating_initiative.published!
         end
 
         it "Discard is notified by email" do
           expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_state_change)
-                                                                 .at_least(:once)
-                                                                 .and_return(message_delivery)
+            .at_least(:once)
+            .and_return(message_delivery)
           validating_initiative.discarded!
         end
       end
@@ -241,7 +241,7 @@ module Decidim
 
       before do
         allow(Decidim::Initiatives).to(
-            receive(:minimum_committee_members).and_return(committee_members_fallback_setting)
+          receive(:minimum_committee_members).and_return(committee_members_fallback_setting)
         )
       end
 
@@ -277,23 +277,32 @@ module Decidim
       end
     end
 
-    # TODO: OSP PR #969: Find a way to sort by support_counts
-    # describe "sorting" do
-    #  subject(:sorter) { described_class.ransack("s" => "supports_count desc") }
+    describe "sorting" do
+      before do
+        create(:initiative, organization: organization, signature_type: "offline")
+        create(:initiative, organization: organization, signature_type: "offline", offline_votes: { "total": 4 })
+        create(:initiative, organization: organization, signature_type: "offline", offline_votes: { "total": 3 })
+        create(:initiative, organization: organization, signature_type: "online", online_votes: { "total": 4 })
+        create(:initiative, organization: organization, signature_type: "online", online_votes: { "total": 8 })
+        create(:initiative, organization: organization, signature_type: "online", online_votes: { "total": 2 })
+      end
 
-    #  before do
-    #    create(:initiative, organization: organization, signature_type: "offline")
-    #    create(:initiative, organization: organization, signature_type: "offline", offline_votes: 4)
-    #    create(:initiative, organization: organization, signature_type: "online", initiative_votes_count: 1, initiative_supports_count: 4)
-    #    create(:initiative, organization: organization, signature_type: "online", initiative_votes_count: 2, initiative_supports_count: 1)
-    #    create(:initiative, organization: organization, signature_type: "any", initiative_votes_count: 1, initiative_supports_count: 0)
-    #    create(:initiative, organization: organization, signature_type: "any", initiative_votes_count: 3, initiative_supports_count: 2, offline_votes: 3)
-    #  end
+      context "when sorts by order desc" do
+        subject(:sorter) { described_class.ransack("s" => "supports_count desc") }
 
-    #  it "sorts initiatives by supports count" do
-    #    expect(sorter.result.map(&:supports_count)).to eq([8, 5, 4, 3, 1, 0])
-    #  end
-    # end
+        it "sorts initiatives by supports count" do
+          expect(sorter.result.map(&:supports_count)).to eq([8, 4, 4, 3, 2, 0])
+        end
+      end
+
+      context "when sorts by order asc" do
+        subject(:sorter) { described_class.ransack("s" => "supports_count asc") }
+
+        it "sorts initiatives by supports count" do
+          expect(sorter.result.map(&:supports_count)).to eq([0, 2, 3, 4, 4, 8])
+        end
+      end
+    end
 
     describe "#votes_enabled?" do
       subject { initiative.votes_enabled? }


### PR DESCRIPTION
#### :tophat: What? Why?

Allows admin to sort initiatives by support count

#### :clipboard: Subtasks
- [x] Add sort option in admin initiatives index
- [x] Update initiatives factories
- [x] Update tests

### :camera: Screenshots (optional)
![signature_count](https://user-images.githubusercontent.com/26109239/84263265-7c8a5d80-ab1f-11ea-9518-a4d87c2f09fd.png)
