### PR TITLE
[WIP] - Display button "send to technical validation" in initiative create form

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -21,6 +21,7 @@ module Decidim
       helper_method :current_initiative
       helper_method :initiative_type
       helper_method :promotal_committee_required?
+      helper_method :minimum_committee_members
 
       steps :select_initiative_type,
             :previous_form,
@@ -171,9 +172,12 @@ module Decidim
       def promotal_committee_required?
         return false unless initiative_type.promoting_committee_enabled?
 
-        minimum_committee_members = initiative_type.minimum_committee_members ||
-                                    Decidim::Initiatives.minimum_committee_members
-        minimum_committee_members.present? && minimum_committee_members.positive?
+        minimum_members = minimum_committee_members
+        minimum_members.present? && minimum_members.positive?
+      end
+
+      def minimum_committee_members
+        initiative_type.minimum_committee_members || Decidim::Initiatives.minimum_committee_members
       end
     end
   end

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -21,7 +21,7 @@
       </div>
 
       <div class="column actions">
-        <% unless promotal_committee_required? %>
+        <% if !promotal_committee_required? || minimum_committee_members == 1 %>
           <%= link_to t(".send_my_initiative"),
                       decidim_admin_initiatives.send_to_technical_validation_initiative_path(current_initiative),
                       class: "button success light expanded",

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -12,7 +12,7 @@
   <div class="show-for-large">
     <ol class="wizard__steps">
       <% wizard_steps.each do |wizard_step| %>
-        <% next if wizard_step.to_s == "promotal_committee" && !promotal_committee_required? %>
+        <% next if (wizard_step.to_s == "promotal_committee" && !promotal_committee_required?) || (wizard_step.to_s == "promotal_committee" && minimum_committee_members == 1) %>
         <% next if wizard_step.to_s == "select_initiative_type" && single_initiative_type? %>
         <% if step == wizard_step %>
           <li class="step--active">

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -332,7 +332,7 @@ describe "Initiative", type: :system do
           end
 
           it "Offers contextual help" do
-            within ".callout.secondary" do
+            within ".callout.success" do
               expect(page).to have_content("Congratulations! Your citizen initiative has been successfully created.")
             end
           end

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -319,8 +319,6 @@ describe "Initiative", type: :system do
 
           select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")
           select("Online", from: "Signature collection type")
-          fill_in :initiative_attachment_title, with: "Document name"
-          attach_file :initiative_attachment_file, Decidim::Dev.asset("Exampledocument.pdf")
           find_button("Continue").click
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

**Comportement actuel**

- Quand le nombre min de membre pour le comité promoteur est fixé à `0`
    - L'étape "Ajout de co-auteur" n' `apparaît pas`
    - Le bouton "Envoyer à la validation technique" est lui bien présent sur l'étape du wizard
    - Dans le back-office il est possible de rajouter des co-auteurs
- Quand le nombre min de membre pour le comité promoteur est fixé à `1`
    - L'étape "Ajout de co-auteur" `apparaît` dans le wizard
    - Le bouton "Envoyer à la validation technique" n'est  `pas présent` sur l'étape du wizard

NB : l'auteur d'une pétition est directement ajouté au comité de promotion, quand le nombre min de membre est fixé à 1 il est possible d'envoyer la pétition à la validation technique.

**Les changements de cette PR**

Quand le `comité de promotion est activé` et que le nombre min de membre pour le comité promoteur est fixé à `1` alors le bouton d'envoi à la validation technique devrait être présent dans l'étape finish du wizard

#### 📋 Tasks
- [ ] add tests