### PR TITLE
Update text value when disabled button 'continue'

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -92,7 +92,7 @@
             <% end %>
           </div>
           <div class="actions">
-            <%= f.submit t(".continue"), class: "button expanded", data: { disable_with: true } %>
+            <%= f.submit t(".continue"), class: "button expanded", data: { disable_with: t(".continue") } %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?

When user is creating an initiative, the text value of 'continue' button in fill data step turns to 'true' when disabled.

#### :clipboard: Subtasks
- [x] When disabled, button text remains 'continue'
