### PR TITLE
Enable answer date in initiatives to be set to current day

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
@@ -23,7 +23,7 @@ module Decidim
         }
         validates :state, inclusion: { in: :manual_states }
         validates :answer_date, presence: true, if: :answer_date_allowed?
-        validates :answer_date, date: { before: Date.current }, if: :answer_date_allowed?
+        validates :answer_date, date: { before: Date.current.advance(days: 1) }, if: :answer_date_allowed?
 
         def signature_dates_required?
           @signature_dates_required ||= check_state

--- a/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
@@ -42,6 +42,12 @@ module Decidim
 
               it { is_expected.to be_invalid }
             end
+
+            context "when answer_date is the current day" do
+              let(:answer_date) { Date.current }
+
+              it { is_expected.to be_valid }
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

At the moment in the initiative answer form, the answer date can't be today. 
The initial specification is that the answer date cannot be in the future, but it can be today.

#### :clipboard: Subtasks
- [x] Update admin answer form validations to accept current date
- [x] Add tests

