### PR TITLE
update export_signature_pdf permissions to accept manual states

### DIFF
--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -146,7 +146,12 @@ module Decidim
           when :discard
             toggle_allow(initiative.validating?)
           when :export_pdf_signatures
-            toggle_allow(initiative.published? || initiative.accepted? || initiative.rejected?)
+            toggle_allow(initiative.published? ||
+                           initiative.accepted? ||
+                           initiative.rejected? ||
+                           initiative.examinated? ||
+                           initiative.debatted? ||
+                           initiative.classified?)
           when :export_votes
             toggle_allow(initiative.offline_signature_type? || initiative.any_signature_type?)
           when :accept

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
@@ -395,6 +395,11 @@ describe Decidim::Initiatives::Admin::Permissions do
       it_behaves_like "checks initiative state", :discard, :validating, :published
       it_behaves_like "checks initiative state", :export_votes, :offline, :online
       it_behaves_like "checks initiative state", :export_pdf_signatures, :published, :validating
+      it_behaves_like "checks initiative state", :export_pdf_signatures, :accepted, :validating
+      it_behaves_like "checks initiative state", :export_pdf_signatures, :rejected, :validating
+      it_behaves_like "checks initiative state", :export_pdf_signatures, :classified, :validating
+      it_behaves_like "checks initiative state", :export_pdf_signatures, :examinated, :validating
+      it_behaves_like "checks initiative state", :export_pdf_signatures, :debatted, :validating
 
       context "when accepting the initiative" do
         let(:action_name) { :accept }


### PR DESCRIPTION
#### :tophat: What? Why?

At the moment the PDF signature export button is only available on Published, Accepted or Rejected initiatives in BO.
It should also be available on the following custom states :
- Examinated
- Debatted
- Classified

#### :clipboard: Subtasks
- [x] Update export_signature_pdf permissions
- [x] Add tests