### PR TITLE
Compare with custom state in initiatives comparator

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -86,6 +86,7 @@ module Decidim
     }
 
     scope :answered, -> { where.not(answered_at: nil) }
+    scope :published, -> { where.not(published_at: nil) }
 
     scope :public_spaces, -> { published }
     scope :signature_type_updatable, -> { created }


### PR DESCRIPTION
#### :tophat: What? Why?

At the moment, the published initiatives are the only ones compared with the created initiative.
Now, it compares with all initiatives with a not null published_at value.

#### :clipboard: Subtasks
- [x] Reintroduce previously removed published scope in initiative model

![image](https://user-images.githubusercontent.com/26109239/84905295-c5f32380-b0b0-11ea-86c8-3cd95bc0b2c1.png)
