### PR TITLE
update default end signature date

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -255,7 +255,7 @@ module Decidim
           published_at: Time.current,
           state: "published",
           signature_start_date: Date.current,
-          signature_end_date: signature_end_date || Date.current + Decidim::Initiatives.default_signature_time_period_length
+          signature_end_date: signature_end_date || Date.new(2022,6,21)
       )
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The end of signature collection date must be set by default on `2022, June 21` for all created initiatives

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Update initiative model