### PR TITLE
Fix admin answer form

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -6,6 +6,8 @@
       <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>
     </div>
 
+    <%= f.hidden_field :state, value: current_initiative.state %>
+
     <% if @form.state_updatable? %>
       <div class="card-section">
         <div class="row xlarge-6">

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -17,6 +17,7 @@ describe "User answers the initiative", type: :system do
           es: "Una respuesta",
           ca: "Una resposta"
         )
+        expect(page).to have_css("#initiative_state", visible: false)
         expect(page).to have_css("#initiative_signature_start_date")
         expect(page).to have_css("#initiative_signature_end_date")
         expect(page).to have_css("#initiative_state")


### PR DESCRIPTION
#### :tophat: What? Why?

When trying to answer a discarded initiative, the first time I click on "Answer", I find an error message "Une erreur est survenue", and the 2nd time I find a routing error. 

Now, admin can answer initiative with automatic or manual states

