### PR TITLE
Update default answer date

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -21,7 +21,7 @@
 
       <% if @form.state_updatable? %>
         <div class="row column">
-          <%= f.date_field :answer_date %>
+          <%= f.date_field :answer_date, value: l(Date.current, format: :decidim_short ) %>
         </div>
       <% end %>
 

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -22,6 +22,8 @@ describe "User answers the initiative", type: :system do
         expect(page).to have_css("#initiative_state")
         expect(page).to have_css("#initiative_answer_date")
 
+        expect(find("#initiative_answer_date").value).to eq(I18n.l(Date.current, format: :decidim_short))
+
         fill_in :initiative_answer_date, with: 1.day.ago.strftime("%dd/%mm/%Y")
         fill_in :initiative_signature_start_date, with: 2.days.ago
       end


### PR DESCRIPTION
#### :tophat: What? Why?

When an initiative is given a custom state in the initiative answer form, the answer date must automatically be set on current date


#### :clipboard: Subtasks
- [x] Set default answer date to current date
- [x] Add tests

