### PR TITLE
Backport answer form redirection

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
@@ -35,8 +35,8 @@ module Decidim
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
-              render :edit
+              flash[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
+              redirect_to edit_initiative_answer_path
             end
           end
         end

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -30,11 +30,11 @@ describe "User answers the initiative", type: :system do
     end
   end
 
-  def submit_and_validate
+  def submit_and_validate(message = "successfully")
     find("*[type=submit]").click
 
     within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
+      expect(page).to have_content(message)
     end
   end
 
@@ -83,26 +83,51 @@ describe "User answers the initiative", type: :system do
         initiative.published!
       end
 
-      it "signature dates can be edited in answer" do
-        page.find(".action-icon--answer").click
+      context "and signature dates are editable" do
+        it "can be edited in answer" do
+          page.find(".action-icon--answer").click
 
-        within ".edit_initiative_answer" do
-          fill_in_i18n_editor(
-            :initiative_answer,
-            "#initiative-answer-tabs",
-            en: "An answer",
-            es: "Una respuesta",
-            ca: "Una resposta"
-          )
-          expect(page).to have_css("#initiative_signature_start_date")
-          expect(page).to have_css("#initiative_signature_end_date")
-          expect(page).to have_css("#initiative_state")
-          expect(page).to have_css("#initiative_answer_date", visible: false)
+          within ".edit_initiative_answer" do
+            fill_in_i18n_editor(
+              :initiative_answer,
+              "#initiative-answer-tabs",
+              en: "An answer",
+              es: "Una respuesta",
+              ca: "Una resposta"
+            )
+            expect(page).to have_css("#initiative_signature_start_date")
+            expect(page).to have_css("#initiative_signature_end_date")
+            expect(page).to have_css("#initiative_state")
+            expect(page).to have_css("#initiative_answer_date", visible: false)
 
-          fill_in :initiative_signature_start_date, with: 1.day.ago
+            fill_in :initiative_signature_start_date, with: 1.day.ago
+          end
+
+          submit_and_validate
         end
+      end
 
-        submit_and_validate
+      context "when dates are invalid" do
+        it "returns an error message" do
+          page.find(".action-icon--answer").click
+
+          within ".edit_initiative_answer" do
+            fill_in_i18n_editor(
+              :initiative_answer,
+              "#initiative-answer-tabs",
+              en: "An answer",
+              es: "Una respuesta",
+              ca: "Una resposta"
+            )
+            expect(page).to have_css("#initiative_signature_start_date")
+            expect(page).to have_css("#initiative_signature_end_date")
+
+            fill_in :initiative_signature_start_date, with: 1.month.since(initiative.signature_end_date)
+          end
+
+          submit_and_validate("error")
+          expect(page).to have_current_path decidim_admin_initiatives.edit_initiative_answer_path(initiative)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin answers to an initiative, with an invalid form, he / she is not redirected to the answer edit route. Then if the admin tries to submit again, a 404 error append.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add tests
- [x] Change `answer#update` method redirection
