### PR TITLE
refactor state logic for answer form

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
@@ -49,7 +49,7 @@ module Decidim
         end
 
         def state_validation
-          errors.add(:state, :invalid) unless context.initiative.state == state
+          errors.add(:state, :invalid) if !state_updatable? && context.initiative.state != state
           errors.add(:state, :invalid) unless uniq_states.include? state
         end
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -6,7 +6,6 @@
       <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>
     </div>
 
-
     <% if @form.state_updatable? %>
       <div class="card-section">
         <div class="row xlarge-6">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -6,7 +6,6 @@
       <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>
     </div>
 
-    <%= f.hidden_field :state, value: current_initiative.state %>
 
     <% if @form.state_updatable? %>
       <div class="card-section">
@@ -14,6 +13,8 @@
           <%= f.select :state, Decidim::Initiative::MANUAL_STATES.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] } %>
         </div>
       </div>
+    <% else %>
+      <%= f.hidden_field :state, value: current_initiative.state %>
     <% end %>
 
     <div class="card-section">

--- a/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_answer_form_spec.rb
@@ -70,6 +70,13 @@ module Decidim
             it { is_expected.to eq(true) }
           end
         end
+
+        describe "#state_validation" do
+          let(:answer_date) { Date.current }
+          let(:state) { "examinated" }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When changing an initiative custom state on the answer form, the form is not validated and I find an error message. 

All the other fields of the admin form are working. The error only happens when you change the custom state.

#### :clipboard: Subtasks
- [x] update state logic for answer form