### PR TITLE
Add firms/scopes column in initiatives exports

### DIFF
--- a/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
@@ -44,6 +44,9 @@ module Decidim
           authors: {
             id: initiative.author_users.map(&:id),
             name: initiative.author_users.map(&:name)
+          },
+          firms: {
+            scopes: uniq_vote_scopes
           }
         }
       end
@@ -87,6 +90,12 @@ module Decidim
       def serialize_components
         serializer = Decidim::Exporters::ParticipatorySpaceComponentsSerializer.new(@initiative)
         serializer.serialize
+      end
+
+      def uniq_vote_scopes
+        return 0 if initiative.votes.blank?
+
+        initiative.votes.map(&:decidim_scope_id).uniq.size
       end
     end
   end

--- a/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    describe InitiativeSerializer do
+      subject do
+        described_class.new(initiative)
+      end
+
+      let!(:initiative) { create(:initiative, organization: organization) }
+      let(:organization) { create(:organization) }
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "serializes the id" do
+          expect(serialized).to include(id: initiative.id)
+        end
+
+        it "serializes the reference" do
+          expect(serialized).to include(reference: initiative.reference)
+        end
+
+        it "serializes the title" do
+          expect(serialized).to include(title: initiative.title)
+        end
+
+        it "serializes the description" do
+          expect(serialized).to include(description: initiative.description)
+        end
+
+        it "serializes the created_at" do
+          expect(serialized).to include(created_at: initiative.created_at)
+        end
+
+        it "serializes the published_at" do
+          expect(serialized).to include(published_at: initiative.published_at)
+        end
+
+        it "serializes the hashtag" do
+          expect(serialized).to include(hashtag: initiative.hashtag)
+        end
+
+        it "serializes the type" do
+          expect(serialized[:type]).to be_a_kind_of Hash
+          expect(serialized[:type]).to include(id: initiative.type.id)
+          expect(serialized[:type]).to include(name: initiative.type.title)
+        end
+
+        it "serializes the scope" do
+          expect(serialized[:scope]).to be_a_kind_of Hash
+          expect(serialized[:scope]).to include(id: initiative.scope.id)
+          expect(serialized[:scope]).to include(name: initiative.scope.name)
+        end
+
+        it "serializes the signature_type" do
+          expect(serialized).to include(signature_type: initiative.signature_type)
+        end
+
+        it "serializes the signature_start_date" do
+          expect(serialized).to include(signature_start_date: initiative.signature_start_date)
+        end
+
+        it "serializes the signature_end_date" do
+          expect(serialized).to include(signature_end_date: initiative.signature_end_date)
+        end
+
+        it "serializes the state" do
+          expect(serialized).to include(state: initiative.state)
+        end
+
+        it "serializes the offline_votes" do
+          expect(serialized).to include(offline_votes: initiative.offline_votes)
+        end
+
+        it "serializes the answer" do
+          expect(serialized).to include(answer: initiative.answer)
+        end
+
+        it "serializes attachments, components, authors" do
+          expect(serialized).to have_key(:attachments)
+          expect(serialized).to have_key(:components)
+          expect(serialized).to have_key(:authors)
+        end
+
+        it "serializes the scopes vote count" do
+          expect(serialized[:firms]).to be_a_kind_of Hash
+          expect(serialized[:firms]).to include(scopes: 0)
+        end
+
+        context "when the is votes" do
+          let(:vote) { create_list(:initiative_user_vote, 5, initiative: initiative) }
+
+          it "serializes uniq scopes vote count" do
+            expect(serialized[:firms]).to be_a_kind_of Hash
+            expect(serialized[:firms]).to include(scopes: initiative.votes.map(&:decidim_scope_id).uniq.size)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
@@ -90,7 +90,7 @@ module Decidim
           expect(serialized[:firms]).to include(scopes: 0)
         end
 
-        context "when the is votes" do
+        context "when there is votes" do
           let(:vote) { create_list(:initiative_user_vote, 5, initiative: initiative) }
 
           it "serializes uniq scopes vote count" do


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin, when exporting the initiatives, I want to be able to see the number of different scopes the "signataires" chose. 

#### :clipboard: Subtasks
- [x] Add `firms/scopes` columns in export
- [x] Add tests

