### PR TITLE
add rel='notrack' attribute on mailer links

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/_initiative_link.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/_initiative_link.html.erb
@@ -1,5 +1,5 @@
 <% if @link %>
     <p>
-      <%= t(".check_initiative_details") %> <%= link_to t(".here"), @link %>
+      <%= t(".check_initiative_details") %> <%= link_to t(".here"), @link, rel: "notrack" %>
     </p>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,6 +1,6 @@
 <p>
 <%= t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", host: @organization.host) %>
+<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", host: @organization.host), rel: "notrack" %>
 </p>
 
 <% if @initiative.created_by_individual? %>
@@ -10,7 +10,7 @@
     </p>
     <p>
       <%= link_to decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host),
-                  decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host) %>
+                  decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host), rel: "notrack" %>
     </p>
 <% end %>
 <br><br>
@@ -18,5 +18,5 @@
 <p>
   <%= t("check_initiative_details", scope: "decidim.initiatives.initiatives_mailer.initiative_link") %>
   <%= link_to t("here",  scope: "decidim.initiatives.initiatives_mailer.initiative_link"),
-              decidim_admin_initiatives.initiative_url(@initiative, host: @organization.host) %>
+              decidim_admin_initiatives.initiative_url(@initiative, host: @organization.host), rel: "notrack" %>
 </p>


### PR DESCRIPTION
#### :tophat: What? Why?

By default, Mailjet will rewrite urls to be shortened. According to mailjet's documentation `rel="notrack"` attribute should avoid the url rewriting

- [x] Add  `rel="notrack"` attribute on initiatives mail links