### PR TITLE
Backport destroy admin account

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -32,6 +32,7 @@ module Decidim
       @user.nickname = ""
       @user.email = ""
       @user.delete_reason = @form.delete_reason
+      @user.admin = false if @user.admin?
       @user.deleted_at = Time.current
       @user.skip_reconfirmation!
       @user.remove_avatar!

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -80,6 +80,15 @@ module Decidim
           command.call
         end.to change(Follow, :count).by(-2)
       end
+
+      context "when user is admin" do
+        let(:user) { create(:user, :confirmed, :admin) }
+
+        it "removes admin role" do
+          command.call
+          expect(user.reload.admin).to be_falsey
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When admin removes his / her account, the admin role is kept. It occurs an empty row in the BO users index.

This PR removes the admin role when destroying account, if the current user is admin.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/6310

#### :clipboard: Subtasks
- [x] Update destroy account command
- [x] Add tests
