### PR TITLE
Fix initiative firms scopes

### DIFF
--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -31,7 +31,7 @@
     <%= scope %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
-    <%= user_scope.name %>
+    <%= user_scope&.name %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= resident %>

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -31,7 +31,7 @@
     <%= scope %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
-    <%= user_scope&.name %>
+    <%= user_scope_name %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= resident %>

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote/show.erb
@@ -31,7 +31,7 @@
     <%= scope %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
-    <%= user_scope %>
+    <%= user_scope.name %>
   </div>
   <div class="initiatives-votes-table-cell w11" style="width: 9.4%; padding-left: 5pt; word-wrap: break-word; display: inline-block; float: left; min-height: 36pt;">
     <%= resident %>

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -33,8 +33,10 @@ module Decidim
         metadata[:postal_code]
       end
 
-      def user_scope
-        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id])) if metadata[:user_scope_id].present?
+      def user_scope_name
+        return if metadata[:user_scope_id].blank?
+
+        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id]).name)
       end
 
       def resident

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def user_scope
-        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id]).name)
+        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id]).name) if metadata[:user_scope_id].present?
       end
 
       def resident

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def user_scope
-        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id]).name) if metadata[:user_scope_id].present?
+        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id])) if metadata[:user_scope_id].present?
       end
 
       def resident

--- a/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives_votes/vote_cell.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def user_scope
-        metadata[:user_scope]
+        translated_attribute(Decidim::Scope.find(metadata[:user_scope_id]).name)
       end
 
       def resident

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -39,7 +39,7 @@ module Decidim
       def encrypted_metadata
         return unless required_personal_data?
 
-        @encrypted_metadata ||= encryptor.encrypt(user_scope_id: user_scope_id, resident: resident)
+        @encrypted_metadata ||= encryptor.encrypt(user_scope_id: user_scope_id)
       end
 
       # Public: The hash to uniquely identify an initiative vote. It uses the
@@ -204,6 +204,7 @@ module Decidim
       def authorization_status
         return unless authorization
 
+        # TODO: Fix Authorization cipher
         Decidim::Verifications::Adapter.from_element(handler_name).authorize(authorization, {}, nil, nil, nil)
       end
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -204,7 +204,6 @@ module Decidim
       def authorization_status
         return unless authorization
 
-        # TODO: Fix Authorization cipher
         Decidim::Verifications::Adapter.from_element(handler_name).authorize(authorization, {}, nil, nil, nil)
       end
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -39,7 +39,7 @@ module Decidim
       def encrypted_metadata
         return unless required_personal_data?
 
-        @encrypted_metadata ||= encryptor.encrypt({})
+        @encrypted_metadata ||= encryptor.encrypt(user_scope_id: user_scope_id, resident: resident)
       end
 
       # Public: The hash to uniquely identify an initiative vote. It uses the

--- a/decidim-initiatives/app/models/decidim/initiatives_vote.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_vote.rb
@@ -21,8 +21,7 @@ module Decidim
                class_name: "Decidim::Scope",
                optional: true
 
-    validates :initiative, uniqueness: { scope: [:author, :scope] }
-    validates :initiative, uniqueness: { scope: [:hash_id, :scope] }
+    validates :initiative, uniqueness: { scope: [:author, :scope, :hash_id] }
 
     after_commit :update_counter_cache, on: [:create, :destroy]
 

--- a/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
@@ -95,7 +95,15 @@ module Decidim
       def uniq_vote_scopes
         return 0 if initiative.votes.blank?
 
-        initiative.votes.map(&:decidim_scope_id).uniq.size
+        initiative_votes_scopes = []
+        initiative.votes.map(&:decrypted_metadata).each do |metadata|
+          next unless metadata.present?
+          next unless metadata.is_a? Hash
+
+          initiative_votes_scopes << metadata[:user_scope_id]
+        end
+
+        initiative_votes_scopes.uniq.size
       end
     end
   end

--- a/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/decidim/initiatives/initiative_serializer_spec.rb
@@ -91,11 +91,24 @@ module Decidim
         end
 
         context "when there is votes" do
-          let(:vote) { create_list(:initiative_user_vote, 5, initiative: initiative) }
+          let(:scopes) { create_list(:scope, 5, organization: organization) }
+          let(:initiative) { create(:initiative, :with_user_extra_fields_collection, organization: organization) }
+
+          before do
+            create_list(:initiative_user_vote, 2, initiative: initiative,
+                                                  encrypted_metadata: Decidim::Initiatives::DataEncryptor.new(secret: "personal user metadata").encrypt(user_scope_id: scopes[2].id))
+
+            create_list(:initiative_user_vote, 2, initiative: initiative,
+                                                  encrypted_metadata: Decidim::Initiatives::DataEncryptor.new(secret: "personal user metadata").encrypt(user_scope_id: scopes[3].id))
+
+            create(:initiative_user_vote,
+                   initiative: initiative,
+                   encrypted_metadata: Decidim::Initiatives::DataEncryptor.new(secret: "personal user metadata").encrypt(user_scope_id: scopes.first.id))
+          end
 
           it "serializes uniq scopes vote count" do
             expect(serialized[:firms]).to be_a_kind_of Hash
-            expect(serialized[:firms]).to include(scopes: initiative.votes.map(&:decidim_scope_id).uniq.size)
+            expect(serialized[:firms]).to include(scopes: 3)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the "firms/scopes"  column that display the number of different scopes of the "signataires"

For exemple, 5 users signed the initiative, with the following scopes :

    - 46 - Lot
    - 75 - Paris
    - 46 - Lot
    - 81 - Haute-Garonne
    - 75 - Paris

    → The number displayed should be "3" (46, 75, 81)

#### :clipboard: Subtasks
- [x] Refactor firm/scopes column logic
- [x] Change scope displayed in Initiative export PDF
- [x] Add tests
