### PR TITLE
disable admin TOS for iniatives authors

### DIFF
--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -6,7 +6,7 @@
 <div class="content">
   <p><%= t ".welcome" %></p>
 
-  <% unless current_user.admin_terms_accepted? %>
+  <% if current_user.admin? && !current_user.admin_terms_accepted? %>
     <%= cell("decidim/announcement", admin_terms_announcement_args ) %>
   <% end %>
 

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -15,10 +15,23 @@ describe "User prints the initiative", type: :system do
 
   context "when initiative update" do
     context "and user is author" do
+
       before do
         switch_to_host(organization.host)
         login_as author, scope: :user
         visit decidim_admin_initiatives.initiatives_path
+      end
+
+      context "when accessing dashboard" do
+        before do
+          switch_to_host(organization.host)
+          login_as author, scope: :user
+          visit decidim_admin.root_path
+        end
+
+        it "does not see admin TOS" do
+          expect(page).not_to have_content("Please take a moment to review Admin Terms of Use. Otherwise you won't be able to admin the platform. ")
+        end
       end
 
       context "when initiative is in created state" do


### PR DESCRIPTION
#### :tophat: What? Why?

When user is not admin, she / he should not see the admin Terms of User in dashboard because it only concerns administrators 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Refactor admin tos condition
- [x] Add tests
- [ ] Another subtask

