### PR TITLE
Remove extra param in notify_state_change

### DIFF
--- a/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       # Notify changes in state
-      def notify_state_change(initiative, user, state)
+      def notify_state_change(initiative, user)
         return if user.email.blank?
 
         @initiative = initiative
@@ -43,7 +43,7 @@ module Decidim
           @body = I18n.t(
             "decidim.initiatives.initiatives_mailer.status_change_body_for",
             title: translated_attribute(initiative.title),
-            state: I18n.t(state, scope: "decidim.initiatives.admin_states")
+            state: I18n.t(initiative.state, scope: "decidim.initiatives.admin_states")
           )
 
           @link = initiative_url(initiative, host: @organization.host)

--- a/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
@@ -83,7 +83,7 @@ module Decidim
           next unless initiative.author != committee_member.user
 
           Decidim::Initiatives::InitiativesMailer
-            .notify_state_change(initiative, committee_member.user, initiative.state)
+            .notify_state_change(initiative, committee_member.user)
             .deliver_later
         end
       end
@@ -92,14 +92,14 @@ module Decidim
         initiative.followers.each do |follower|
           initiative.organization.admins.each do |user|
             Decidim::Initiatives::InitiativesMailer
-              .notify_state_change(initiative, user, initiative.state)
+              .notify_state_change(initiative, user)
               .deliver_later
           end
 
           next unless initiative.author != follower
 
           Decidim::Initiatives::InitiativesMailer
-            .notify_state_change(initiative, follower, initiative.state)
+            .notify_state_change(initiative, follower)
             .deliver_later
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Email notifications are disabled for authors because an error occurs. This error appends because of the third param in `notify_state_change` method.

- [x] Remove `notify_state_change` third param


