### PR TITLE
status notifier backport

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -104,7 +104,7 @@ module Decidim
     scope :future_spaces, -> { none }
     scope :past_spaces, -> { closed }
 
-    after_save :notify_state_change
+    after_commit :notify_state_change
     after_create :notify_creation
 
     searchable_fields({

--- a/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
+++ b/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
@@ -21,7 +21,7 @@ module Decidim
       end
 
       context "when notifies state change" do
-        let(:mail) { InitiativesMailer.notify_state_change(initiative, initiative.author, initiative.state) }
+        let(:mail) { InitiativesMailer.notify_state_change(initiative, initiative.author) }
 
         it "renders the headers" do
           expect(mail.subject).to eq("The initiative #{initiative.title["en"]} has changed its status")


### PR DESCRIPTION
#### :tophat: What? Why?

When initiative's state changes, the notification sent shows the previous state.
This behaviour seems to occur because of race condition. In fact, in initiative model, notify_state_change method is called with after_save.
