### PR TITLE
Feature overload custom page

### DIFF
--- a/decidim-core/app/controllers/decidim/errors_controller.rb
+++ b/decidim-core/app/controllers/decidim/errors_controller.rb
@@ -12,5 +12,9 @@ module Decidim
     def internal_server_error
       render status: :internal_server_error
     end
+
+    def overload_server_error
+      render status: 503
+    end
   end
 end

--- a/decidim-core/app/views/decidim/errors/overload_server_error.html.erb
+++ b/decidim-core/app/views/decidim/errors/overload_server_error.html.erb
@@ -1,0 +1,22 @@
+<main class="wrapper">
+  <div class="row">
+    <div class="large-8 large-centered">
+      <div class="page-image row align-center">
+        <% if current_organization.logo.present? %>
+          <%= image_tag current_organization.logo.medium.url, alt: t(".image_alt"), class: "column small" %>
+        <% else %>
+          <%# image_tag "overload", alt: t(".image_alt"), class: "column small" %>
+          <%= image_tag "", alt: t(".image_alt"), class: "column small" %>
+        <% end %>
+      </div>
+      <div class="static__message">
+
+        <h1 class="heading1 page-title"><%= t(".title") %></h1>
+        <p><%= t(".description") %></p>
+        <div class="static__message__cta">
+          <%= link_to t(".back_home"), page_path(""), class: "button" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -468,6 +468,11 @@ en:
         back_home: Back home
         content_doesnt_exist: This address is incorrect or has been removed.
         title: The page you're looking for can't be found
+      overload_server_error:
+        back_home: Back home
+        description: The platform is undergoing maintenance due to a large number of connections. Our teams are mobilized to make the platform operational as soon as possible. Thank you for your understanding.
+        image_alt: Image temporarily unavailable page
+        title: The platform is temporarily unavailable.
     events:
       amendments:
         amendment_accepted:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -120,6 +120,9 @@ Decidim::Core::Engine.routes.draw do
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
 
+  # 503 error code according to phusionpassenger request_load_balancing documentation
+  match "/503", to: "errors#overload_server_error", via: :all
+
   get "/open-data/download", to: "open_data#download", as: :open_data_download
 
   resource :follow, only: [:create, :destroy]

--- a/decidim-core/spec/controllers/errors_controller_spec.rb
+++ b/decidim-core/spec/controllers/errors_controller_spec.rb
@@ -21,6 +21,7 @@ module Decidim
       routes.draw do
         get "not_found" => "decidim/errors#not_found"
         get "internal_server_error" => "decidim/errors#internal_server_error"
+        get "overload_server_error" => "decidim/errors#overload_server_error"
         post "internal_server_error" => "decidim/errors#internal_server_error"
         post "auth_token" => "decidim/errors#auth_token"
         post "cors" => "decidim/errors#cors"
@@ -31,6 +32,13 @@ module Decidim
       it "reports the correct status code" do
         get :not_found
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "overload" do
+      it "reports the correct status code" do
+        get :overload_server_error
+        expect(response).to have_http_status(503)
       end
     end
 

--- a/decidim_app-design/app/views/public/index.html.erb
+++ b/decidim_app-design/app/views/public/index.html.erb
@@ -1,6 +1,6 @@
 <%
-@title = "Decidim Barcelona"
-@activesection = "home"
+  @title = "Decidim Barcelona"
+  @activesection = "home"
 %>
 
 <%= partial "template_top" %>
@@ -18,7 +18,6 @@
           <li><%= link_to "Home con tooltips de ayuda", page_path("home-with-helpers") %></li>
           <li><%= link_to "Estadísticas", page_path("stats") %></li>
         </ul>
-
         <h2 class="section-heading">Search</h2>
         <ul>
           <li><%= link_to "Página de resultados", page_path("search") %></li>
@@ -67,12 +66,6 @@
             </ul>
           </li>
         </ul>
-        <h2 class="section-heading">Comments</h2>
-        <ul>
-          <li>
-            <%= link_to "Detalle de comentario", page_path("proposals/comment-view") + "#single-comment" %>
-          </li>
-        </ul>
         <h2 class="section-heading">Amendments</h2>
         <ul>
           <li><%= link_to "Propuesta con botón de enmienda", page_path("amendments/proposal-view-with-amendment-button") %></li>
@@ -82,19 +75,6 @@
           <li><%= link_to "Validar coautoría", page_path("amendments/amendment-view-validate-coauthorship") %></li>
           <li><%= link_to "Propuesta con enmienda aceptada", page_path("amendments/proposal-view-with-amendment-approved") %></li>
           <li><%= link_to "Propuesta con enmienda rechazada", page_path("amendments/proposal-view-with-amendment-rejected") %></li>
-        </ul>
-        <h2 class="section-heading">Presupuestos participativos</h2>
-        <ul>
-          <li><%= link_to "Presupuestos - Inicio", page_path("projects-budget-welcome") %></li>
-          <li><%= link_to "Presupuestos - Votación en distrito", page_path("projects-budget") %></li>
-          <li><%= link_to "Presupuestos - Vista de proyecto", page_path("project-budget-view") %></li>
-          <li><%= link_to "Presupuestos - Votos excedidos", page_path("projects-budget-excess") %></li>
-          <li><%= link_to "Presupuestos - Confirmar voto", page_path("projects-budget-confirm") %></li>
-          <li><%= link_to "Presupuestos - Voto confirmado (elegir otro distrito)", page_path("projects-budget-next") %></li>
-          <li><%= link_to "Presupuestos - Voto confirmado (sin más distritos)", page_path("projects-budget-two-districts") %></li>
-          <li><%= link_to "Presupuestos - Landing con un distrito votado", page_path("projects-budget-one-voted") %></li>
-          <li><%= link_to "Presupuestos - Landing con dos distritos votados", page_path("projects-budget-already-voted") %></li>
-          <li><%= link_to "Presupuestos - Consulta de votación", page_path("projects-budget-finish") %></li>
         </ul>
         <h2 class="section-heading">Initiatives</h2>
         <ul>
@@ -232,17 +212,17 @@
           La plantilla de email está creada con
           <a href="http://foundation.zurb.com/emails/docs/" target="_blank">
             Foundation para email</a>, y el HTML y CSS original están en la carpeta
-            <code>/source/emails/</code>.
-          </p>
-          <p>
-            El HTML y CSS de los emails se puede combinar con la
-            <a href="http://foundation.zurb.com/emails/inliner-v2.html" target="_blank">
-              herramienta inliner</a> de Foundation.
-            </p>
-            <ul>
-              <li><%= link_to "Ejemplo de email con estilos inline", page_path("email-inline") %></li>
-            </ul>
-          </div>
+          <code>/source/emails/</code>.
+        </p>
+        <p>
+          El HTML y CSS de los emails se puede combinar con la
+          <a href="http://foundation.zurb.com/emails/inliner-v2.html" target="_blank">
+            herramienta inliner</a> de Foundation.
+        </p>
+        <ul>
+          <li><%= link_to "Ejemplo de email con estilos inline", page_path("email-inline") %></li>
+        </ul>
+      </div>
       <hr>
       <h2 class="text-center heading2 mb-m">Legacy views</h2>
       <div class="section" style="columns:2">
@@ -260,6 +240,14 @@
             </ul>
           </li>
           <li><%= link_to "Resultado", page_path("action-view") %></li>
+        </ul>
+        <h2 class="section-heading">Presupuestos participativos</h2>
+        <ul>
+          <li><%= link_to "Presupuestos - Lista de proyectos", page_path("projects-budget") %></li>
+          <li><%= link_to "Presupuestos - Ver proyecto", page_path("project-budget-view") %></li>
+          <li><%= link_to "Presupuestos - Confirmar voto", page_path("projects-budget-confirm") %></li>
+          <li><%= link_to "Presupuestos - Votos excedidos", page_path("projects-budget-excess") %></li>
+          <li><%= link_to "Presupuestos - Votación finalizada", page_path("projects-budget-finish") %></li>
         </ul>
         <h2 class="section-heading">User</h2>
         <ul>
@@ -283,13 +271,14 @@
           <li><%= link_to "Pregunta: dónde votar", page_path("consultations-voting-places") %></li>
           <li><%= link_to "Pregunta: votación en modal", page_path("consultations-vote") %></li>
           <li><%= link_to "Pregunta: votación en modal - confirmar", page_path("consultations-vote-confirm") %></li>
-         </ul>
+        </ul>
         <h2 class="section-heading">Legal y sistema</h2>
         <ul>
           <li><%= link_to "Contenido estático/legal", page_path("static") %></li>
           <li><%= link_to "Contenido estático con navegación", page_path("static-with-nav") %></li>
           <li><%= link_to "Error 404", page_path("404") %></li>
           <li><%= link_to "Error 500", page_path("500") %></li>
+          <li><%= link_to "Overload page", page_path("overload") %></li>
           <li><%= link_to "Cookie warning", page_path("cookie-bar") %></li>
         </ul>
       </div>

--- a/decidim_app-design/app/views/public/overload.html.erb
+++ b/decidim_app-design/app/views/public/overload.html.erb
@@ -1,0 +1,26 @@
+<%
+  @title = "Decidim Barcelona"
+%>
+
+<%= partial "template_top" %>
+
+<main class="wrapper">
+  <div class="row">
+    <div class="large-8 large-centered">
+      <div class="page-image row align-center">
+        <%= image_tag "decidim-logo.svg", class:"column small", alt: "Page image"  %>
+      </div>
+      <div class="static__message">
+
+        <h1 class="heading1 page-title">La plataforma de peticiones no está disponible temporalmente.</h1>
+        <p>La plataforma de peticions està en manteniment a causa d'un gran nombre de connexions.
+          Els nostres equips es mobilitzen perquè la plataforma funcioni el més aviat possible. Gràcies per la seva comprensió.</p>
+        <div class="static__message__cta">
+          <%= link_to "Tornar a l'inici", page_path(""), class: "button" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial "template_bottom" %>


### PR DESCRIPTION
#### :tophat: What? Why?

As a signataire, when trying to sign an initiative while a lot of people do the same, if the server is overloaded, I expect to see a custom page, and not a 500 error. 

As a regular user or visitor, is the whole website is overloaded, I expect to see a custom page as well.

#### :clipboard: Subtasks
- [x] New custom page 
- [x] Add new route
- [x] Add controller tests
- [x] App design page

### :camera: Screenshots (optional)
<img width="1439" alt="Screenshot 2020-08-03 at 12 38 03" src="https://user-images.githubusercontent.com/26109239/89181608-6683a100-d594-11ea-8903-cc09dee6b5fc.png">