### PR TITLE
fix missing validations after redirection

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/answers_controller.rb
@@ -35,8 +35,8 @@ module Decidim
             end
 
             on(:invalid) do
-              flash[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
-              redirect_to edit_initiative_answer_path
+              flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
+              render :edit
             end
           end
         end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "info_initiative", locals: { initiative: current_initiative } %>
 
-<%= decidim_form_for(@form, url: initiative_answer_path(current_initiative), html: { class: "form edit_initiative_answer" }) do |f| %>
+<%= decidim_form_for(@form, url: initiative_answer_path(current_initiative), method: "PUT", html: { class: "form edit_initiative_answer" }) do |f| %>
   <div class="card">
     <div class="card-divider">
       <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -129,7 +129,6 @@ describe "User answers the initiative", type: :system do
           end
 
           submit_and_validate("error")
-          expect(page).to have_current_path decidim_admin_initiatives.edit_initiative_answer_path(initiative)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Because of controller redirection, errors message from answer form validation are no longer visible


