### PR TITLE
Remove moderated proposals in export

### DIFF
--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -9,7 +9,12 @@ module Decidim
         manifest.name == name.to_sym
       end
 
-      collection = export_manifest.collection.call(component)
+      collection = if export_manifest.manifest.name == :proposals
+                     export_manifest.collection.call(component).not_hidden
+                   else
+                     export_manifest.collection.call(component)
+                   end
+
       serializer = export_manifest.serializer
 
       export_data = if serializer == Decidim::Proposals::ProposalSerializer

--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -38,7 +38,11 @@ module Decidim
 
     def data_for(export_manifest)
       collection = components.where(manifest_name: export_manifest.manifest.name).find_each.flat_map do |component|
-        export_manifest.collection.call(component)
+        if export_manifest.manifest.name == :proposals
+          export_manifest.collection.call(component).not_hidden
+        else
+          export_manifest.collection.call(component)
+        end
       end
 
       Decidim::Exporters::CSV.new(collection, export_manifest.serializer).export

--- a/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
@@ -39,6 +39,14 @@ describe Decidim::OpenDataExporter do
           expect(csv_data).to include(proposal.title)
         end
 
+        context "with moderated proposal" do
+          let!(:proposal) { create(:proposal, :hidden, component: component) }
+
+          it "do not includes the proposals data" do
+            expect(csv_data).not_to include(proposal.title)
+          end
+        end
+
         context "with unpublished components" do
           let(:component) do
             create(:proposal_component, organization: organization, published_at: nil)


### PR DESCRIPTION
#### :tophat: What? Why?

At the moment, moderated proposals are exported in Open Data and when administrator exports the proposals.

The wanted behaviour is to only export visible proposals

#### :clipboard: Subtasks
- [x] Remove moderated proposals in Open Data exports
- [x] Remove moderated proposals in backoffice exports
- [x] Add tests for Open Data
