### PR TITLE
Fix notifications index error

### DIFF
--- a/decidim-core/app/cells/decidim/notifications/show.erb
+++ b/decidim-core/app/cells/decidim/notifications/show.erb
@@ -17,6 +17,7 @@
   </div>
 
   <% notifications.select(&:resource).each do |notification| %>
+    <% next unless defined?(notification.event_class.constantize.model_name.human) %>
     <div class="card card--widget">
       <ul class="card-data">
         <li class="card-data__item">

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -113,11 +113,11 @@ describe "Notifications", type: :system do
 
     context "with undisplayable notifications" do
       let!(:notification) { create :notification, user: user, resource: resource, event_class: "Decidim::DummyClass" }
-  
+
       before do
         page.visit decidim.notifications_path
       end
-      
+
       it "doesn't show any notification" do
         expect(page).not_to have_content("Mark all as read")
         expect(page).to have_content("No notifications yet")

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -110,5 +110,18 @@ describe "Notifications", type: :system do
         end
       end
     end
+
+    context "with undisplayable notifications" do
+      let!(:notification) { create :notification, user: user, resource: resource, event_class: "Decidim::DummyClass" }
+  
+      before do
+        page.visit decidim.notifications_path
+      end
+      
+      it "doesn't show any notification" do
+        expect(page).not_to have_content("Mark all as read")
+        expect(page).to have_content("No notifications yet")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The [demo of OSP](demo.decidim.opensourcepolitics.eu) got a servor error when accessing to the notifications page. This error is due to the presence in the database of notifications that were readable in version 0.16, but not anymore in 0.21.

We'll first deal with this issue by skiping the notification display if it isn't recognized anymore. Further improvements in the database may also be done afterwards.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
~~- [ ] Add/modify seeds~~
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/33259633/90610665-0df40b00-e206-11ea-8870-8886f0dd641a.png)


### :ghost: GIF (optional)
![Description](URL)
