### PR TITLE
Set signature_end_date to current date for classified initiatives

### DIFF
--- a/decidim-initiatives/app/assets/javascripts/decidim/initiatives/admin/initiatives_answer.js.es6
+++ b/decidim-initiatives/app/assets/javascripts/decidim/initiatives/admin/initiatives_answer.js.es6
@@ -2,6 +2,8 @@
   // ANSWER DATE TOGGLE
   const $answerDateField = $("label[for='initiative_answer_date']").parent();
   const $initiativeSelect = $("#initiative_state");
+  const $signatureEndDate = $("#initiative_signature_end_date");
+  const currentSignatureEndDate = $signatureEndDate.val();
 
   let getState = (element) => {
     // eslint-disable-next-line no-negated-condition
@@ -9,6 +11,12 @@
       $answerDateField.show();
     } else {
       $answerDateField.hide();
+    }
+
+    if (element === "classified") {
+      $signatureEndDate.val(new Date().toLocaleDateString("fr-FR"));
+    } else {
+      $signatureEndDate.val(new Date(currentSignatureEndDate).toLocaleDateString("fr-FR"));
     }
   };
 

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -173,5 +173,46 @@ describe "User answers the initiative", type: :system do
         end
       end
     end
+
+    context "when admin changes initiative state" do
+      before do
+        initiative.debatted!
+      end
+
+      context "from debatted to classified" do
+        before do
+          page.find(".action-icon--answer").click
+        end
+
+        it "set the signature_end_date to current date" do
+          original_signature_end_date = find("#initiative_signature_end_date").value
+
+          select "Classified", from: :initiative_state
+
+          expect(find("#initiative_signature_end_date").value).not_to eq(original_signature_end_date)
+          expect(find("#initiative_signature_end_date").value).to eq(I18n.l(Date.current, format: :decidim_short))
+        end
+      end
+
+      context "from debatted to classified to debatted" do
+        before do
+          page.find(".action-icon--answer").click
+        end
+
+        it "set the signature_end_date to current date" do
+          original_signature_end_date = find("#initiative_signature_end_date").value
+
+          select "Classified", from: :initiative_state
+
+          expect(find("#initiative_signature_end_date").value).not_to eq(original_signature_end_date)
+          expect(find("#initiative_signature_end_date").value).to eq(I18n.l(Date.current, format: :decidim_short))
+
+          select "Debatted", from: :initiative_state
+
+          expect(find("#initiative_signature_end_date").value).to eq(original_signature_end_date)
+          expect(find("#initiative_signature_end_date").value).not_to eq(I18n.l(Date.current, format: :decidim_short))
+        end
+      end
+    end
   end
 end

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -179,7 +179,7 @@ describe "User answers the initiative", type: :system do
         initiative.debatted!
       end
 
-      context "from debatted to classified" do
+      context "when debatted to classified" do
         before do
           page.find(".action-icon--answer").click
         end
@@ -194,7 +194,7 @@ describe "User answers the initiative", type: :system do
         end
       end
 
-      context "from debatted to classified to debatted" do
+      context "when debatted to classified then debatted" do
         before do
           page.find(".action-icon--answer").click
         end


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin answers to an initiative, or update an answer, and choose the "classified" state, the `signature_end_date` is automatically set to current date.


#### :clipboard: Subtasks
- [x] Add javascript
- [x] Add tests
- [x] Rubocop linting