### PR TITLE
Fix answer date form

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1268,6 +1268,7 @@ en:
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
       invalid_time_zone: is not a valid time zone
       long_words: contains words that are too long (over 35 characters)
+      must_be_before: must be before %{date}
       must_start_with_caps: must start with a capital letter
       nesting_too_deep: can't be inside of a subcategory
       not_found: could not be found. Did you sign up previously?

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -1268,6 +1268,7 @@ fr:
       file_size_is_less_than_or_equal_to: la taille du fichier doit être inférieure ou égale à %{count}
       invalid_time_zone: n'est pas un fuseau horaire valide
       long_words: contient des mots trop longs (plus de 35 caractères)
+      must_be_before: doit être avant le %{date}
       must_start_with_caps: doit commencer par une majuscule
       nesting_too_deep: ne peut pas être à l'intérieur d'une sous-catégorie
       not_found: introuvable. Vous êtes-vous déjà inscrit ?

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_answer_form.rb
@@ -24,7 +24,7 @@ module Decidim
         validates :state, presence: true
         validate :state_validation
         validates :answer_date, presence: true, if: :answer_date_allowed?
-        validates :answer_date, date: { before: Date.current.advance(days: 1) }, if: :answer_date_allowed?
+        validate :answer_date_restriction, if: :answer_date_allowed?
 
         def signature_dates_required?
           @signature_dates_required ||= check_state
@@ -51,6 +51,10 @@ module Decidim
         def state_validation
           errors.add(:state, :invalid) if !state_updatable? && context.initiative.state != state
           errors.add(:state, :invalid) unless uniq_states.include? state
+        end
+
+        def answer_date_restriction
+          errors.add(:answer_date, I18n.t("must_be_before", scope: "errors.messages", date: I18n.localize(Date.current, format: :decidim_short))) unless answer_date <= Date.current
         end
 
         private


### PR DESCRIPTION
#### :tophat: What? Why?

When giving an initiative a custom state, I can't put an answer date on a date before the current date.

#### :clipboard: Subtasks
- [x] Update answer_date validation

### :camera: Extra information

Hope this PR will fix the current bug. I decided to create a specific validation to avoid that the limit date is frozen according [to this answer](https://stackoverflow.com/questions/8512691/how-to-validate-the-date-such-that-it-is-after-today-in-rails/8512796#comment66739831_37945477)
