### PR TITLE
Fix broken tos display

### DIFF
--- a/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
+++ b/decidim-core/app/cells/decidim/tos_page/sticky_form.erb
@@ -1,11 +1,4 @@
-<div data-sticky-container class="cell-sticky">
-  <div class="sticky"
-        data-sticky
-        data-stick-to="bottom"
-        data-margin-bottom="0"
-        data-top-anchor="sticky-top-stop:top"
-        data-btm-anchor="sticky-btm-stop:top"
-        data-sticky-on="small">
+
     <article class="card">
       <div class="card__content">
         <div class="card__header">
@@ -23,7 +16,6 @@
         </div>
       </div>
     </article>
-  </div>
-</div>
+
 
 <div id="sticky-btm-stop"></div>


### PR DESCRIPTION
### Describe the bug

When user signs in, she is redirected to the term and conditions page in order to accept them. However, the content of the TOS is not displayed anymore, and in some case not selectable or clickable.

### To Reproduce
Steps to reproduce the behavior:

Go to 'sign in' page
Log in with user which has not accepted TOS
See missing TOS content
### Expected behavior

User expects to see the TOS content and to be able to click link if there is some links in the TOS.


#### :clipboard: Subtasks
- [x] Edit TOS partial
