### PR TITLE
Fix participatory_process export

### DIFF
--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -10,7 +10,7 @@ module Decidim
       include Decidim::TranslationsHelper
 
       # Public: Initializes the serializer with a participatory_process.
-      def initialize(participatory_process)
+      def initialize(participatory_process, private_scope = false)
         @participatory_process = participatory_process
       end
 

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -12,6 +12,7 @@ module Decidim
       # Public: Initializes the serializer with a participatory_process.
       def initialize(participatory_process, private_scope = false)
         @participatory_process = participatory_process
+        @private_scope = private_scope
       end
 
       # Public: Exports a hash with the serialized data for this participatory_process.

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim::ParticipatoryProcesses
   describe ParticipatoryProcessSerializer do
     let(:resource) { create(:participatory_process) }
-    let(:subject) { described_class.new(resource) }
+    let(:subject) { described_class.new(resource, true) }
 
     describe "#serialize" do
       # rubocop:disable RSpec/MultipleExpectations


### PR DESCRIPTION
#### :tophat: What? Why?
Participatory processes are no longer exported and raising an error related to the `private_cope` parameter.

This is probably related to the commit 7e32803 and was never detected before.

#### :pushpin: Related Issues
- Fixes #1046
