### PR TITLE
Don't send technical validation email when not email_on_notifications 

### DIFF
--- a/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
@@ -106,6 +106,8 @@ module Decidim
 
       def notify_admins
         initiative.organization.admins.each do |user|
+          next unless user.email_on_notification?
+
           Decidim::Initiatives::InitiativesMailer
             .notify_validating_request(initiative, user)
             .deliver_later

--- a/decidim-initiatives/spec/services/decidim/initiatives/status_change_notifier_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/status_change_notifier_spec.rb
@@ -69,6 +69,23 @@ module Decidim
             .and_return(message_delivery)
           subject.notify
         end
+
+        context "when administrators disable email_on_notification" do
+          let!(:administrators) do
+            create_list(:user, 7, :admin, organization: organization)
+          end
+          let!(:administrators_without_notifications) do
+            create_list(:user, 3, :admin, organization: organization, email_on_notification: false)
+          end
+
+          it "Validating is notified except for admin without email_on_notification" do
+            expect(Decidim::Initiatives::InitiativesMailer).to receive(:notify_validating_request)
+              .with(any_args)
+              .exactly(7).times
+              .and_return(message_delivery)
+            subject.notify
+          end
+        end
       end
 
       context "when published" do


### PR DESCRIPTION
## :tophat: What? Why?

When administrator switches off `email_on_notification`, technical validation notifications are still sent by email. 

#### :clipboard: Subtasks
- [x] Send technical validation notifications only for admin with `email_on_notification` enabled
- [x] Add tests
