### PR TITLE
Fix notification threshold reached

### DIFF
--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -11,7 +11,7 @@ module Decidim
 
       return unless notifiable?
 
-      EmailNotificationGeneratorJob.perform_later(
+      EmailNotificationGeneratorJob.perform_now(
         event_name,
         data[:event_class],
         data[:resource],
@@ -20,7 +20,7 @@ module Decidim
         data[:extra]
       )
 
-      NotificationGeneratorJob.perform_later(
+      NotificationGeneratorJob.perform_now(
         event_name,
         data[:event_class],
         data[:resource],
@@ -47,9 +47,9 @@ module Decidim
     end
 
     def published?
-      return resource.published? if resource.is_a?(Decidim::Publicable) && !resource.respond_to?(:state)
+      return resource.published? if resource.is_a?(Decidim::Publicable) && !resource.respond_to?(:votes_enabled_state?)
 
-      resource.published_at.present?
+      resource.votes_enabled_state?
     end
 
     def component

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -49,12 +49,12 @@ module Decidim
     def published?
       return resource.published? if resource.is_a?(Decidim::Publicable) && !resource.respond_to?(:votes_enabled_state?)
 
-      resource.votes_enabled_state?
+      resource.votes_enabled_state? && resource.published_at.present?
     end
 
     def component
       return resource.component if resource.is_a?(Decidim::HasComponent)
-      return resource if resource.is_a?(Decidim::Component)
+      resource if resource.is_a?(Decidim::Component)
     end
 
     def participatory_space

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -39,11 +39,17 @@ module Decidim
     # `Decidim::Publicable` and it isn't published or participatory_space
     # is a `Decidim::Participable` and the user can't participate.
     def notifiable?
-      return false if resource.is_a?(Decidim::Publicable) && !resource.published?
+      return false if resource.is_a?(Decidim::Publicable) && !published?
       return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?
       return false if component && !component.published?
 
       true
+    end
+
+    def published?
+      return resource.published? if resource.is_a?(Decidim::Publicable) && !resource.respond_to?(:state)
+
+      resource.published_at.present?
     end
 
     def component

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -54,6 +54,7 @@ module Decidim
 
     def component
       return resource.component if resource.is_a?(Decidim::HasComponent)
+
       resource if resource.is_a?(Decidim::Component)
     end
 

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -11,7 +11,7 @@ module Decidim
 
       return unless notifiable?
 
-      EmailNotificationGeneratorJob.perform_now(
+      EmailNotificationGeneratorJob.perform_later(
         event_name,
         data[:event_class],
         data[:resource],
@@ -20,7 +20,7 @@ module Decidim
         data[:extra]
       )
 
-      NotificationGeneratorJob.perform_now(
+      NotificationGeneratorJob.perform_later(
         event_name,
         data[:event_class],
         data[:resource],

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -38,7 +38,6 @@ module Decidim
 
       followers.each do |recipient|
         next unless ["all", "followed-only"].include?(recipient.notification_types)
-        next unless participatory_space.present? && participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
 
         send_email_to(recipient, user_role: :follower)
       end
@@ -81,7 +80,8 @@ module Decidim
 
     def component
       return resource.component if resource.is_a?(Decidim::HasComponent)
-      return resource if resource.is_a?(Decidim::Component)
+
+      resource if resource.is_a?(Decidim::Component)
     end
 
     def participatory_space

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
@@ -27,7 +27,7 @@ module MailerHelpers
   end
 
   def email_body(email)
-    (email.try(:html_part).try(:body) || email.body).encoded
+    (email.try(:html_part).try(:body) || email.try(:body))&.encoded
   end
 
   def last_email_link

--- a/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
@@ -101,13 +101,13 @@ module Decidim
         Decidim::EventsManager.publish(
           event: "decidim.events.initiatives.support_threshold_reached",
           event_class: Decidim::Initiatives::Admin::SupportThresholdReachedEvent,
-          resource: @initiative,
+          resource: initiative,
           followers: organization_admins
         )
       end
 
       def organization_admins
-        Decidim::User.where(organization: @initiative.organization, admin: true)
+        Decidim::User.where(organization: initiative.organization, admin: true)
       end
     end
   end

--- a/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
@@ -30,7 +30,7 @@ module Decidim
 
         send_notification
         notify_percentage_change(percentage_before, percentage_after)
-        notify_support_threshold_reached(percentage_after)
+        notify_support_threshold_reached(percentage_before, percentage_after)
 
         broadcast(:ok, votes)
       end
@@ -95,8 +95,9 @@ module Decidim
         )
       end
 
-      def notify_support_threshold_reached(percentage)
-        return unless percentage >= 100
+      def notify_support_threshold_reached(before, after)
+        # Don't need to notify if threshold has already been reached
+        return if before == after || after != 100
 
         Decidim::EventsManager.publish(
           event: "decidim.events.initiatives.support_threshold_reached",

--- a/decidim-initiatives/spec/commands/decidim/initiatives/vote_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/vote_initiative_spec.rb
@@ -69,6 +69,17 @@ module Decidim
           command.call
         end
 
+        it "sends notification with email" do
+          follower = create(:user, organization: initiative.organization)
+          create(:follow, followable: initiative.author, user: follower)
+
+          expect do
+            perform_enqueued_jobs { command.call }
+          end.to change(emails, :count).by(2)
+
+          expect(last_email_body).to include("has endorsed the following initiative")
+        end
+
         context "when a new milestone is completed" do
           let(:initiative) do
             create(:initiative,
@@ -80,15 +91,15 @@ module Decidim
                    ))
           end
 
+          let!(:follower) { create(:user, organization: initiative.organization) }
+          let!(:follow) { create(:follow, followable: initiative, user: follower) }
+
           before do
             create(:initiative_user_vote, initiative: initiative)
             create(:initiative_user_vote, initiative: initiative)
           end
 
           it "notifies the followers" do
-            follower = create(:user, organization: initiative.organization)
-            create(:follow, followable: initiative, user: follower)
-
             expect(Decidim::EventsManager).to receive(:publish)
               .with(kind_of(Hash))
 
@@ -105,13 +116,40 @@ module Decidim
 
             command.call
           end
+
+          it "sends notification with email" do
+            expect do
+              perform_enqueued_jobs { command.call }
+            end.to change(emails, :count).by(3)
+
+            expect(last_email_body).to include("has achieved the 75% of signatures")
+          end
         end
 
         context "when support threshold is reached" do
-          shared_examples_for "notifies the admins" do
+          shared_examples_for "when support threshold is reached with state" do |state|
+            let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+            let(:initiative) do
+              create(:initiative,
+                     state.to_sym,
+                     organization: organization,
+
+                     scoped_type: create(
+                       :initiatives_type_scope,
+                       supports_required: 4,
+                       type: create(:initiatives_type, organization: organization)
+                     ))
+            end
+
+            before do
+              create(:initiative_user_vote, initiative: initiative)
+              create(:initiative_user_vote, initiative: initiative)
+              create(:initiative_user_vote, initiative: initiative)
+            end
+
             it "notifies the admins" do
               expect(Decidim::EventsManager).to receive(:publish)
-                .with(kind_of(Hash))
+                .with(kind_of(Hash)).twice
 
               expect(Decidim::EventsManager)
                 .to receive(:publish)
@@ -124,65 +162,43 @@ module Decidim
 
               command.call
             end
-          end
 
-          let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-          let(:initiative) do
-            create(:initiative,
-                   organization: organization,
-                   scoped_type: create(
-                     :initiatives_type_scope,
-                     supports_required: 4,
-                     type: create(:initiatives_type, organization: organization)
-                   ))
-          end
+            it "sends notification with email" do
+              expect do
+                perform_enqueued_jobs { command.call }
+              end.to change(emails, :count).by(3)
 
-          before do
-            create(:initiative_user_vote, initiative: initiative)
-            create(:initiative_user_vote, initiative: initiative)
-            create(:initiative_user_vote, initiative: initiative)
-            create(:initiative_user_vote, initiative: initiative)
-          end
-
-          it_behaves_like "notifies the admins"
-
-          context "when notifications is examinated" do
-            let(:initiative) do
-              create(:initiative,
-                     :examinated,
-                     organization: organization,
-                     scoped_type: create(
-                       :initiatives_type_scope,
-                       supports_required: 1,
-                       type: create(:initiatives_type, organization: organization)
-                     ))
+              expect(last_email_body).to include("has reached the support threshold")
             end
 
-            before do
-              create(:initiative_user_vote, initiative: initiative)
-            end
+            context "when more votes are added" do
+              before do
+                create(:initiative_user_vote, initiative: initiative)
+              end
 
-            it_behaves_like "notifies the admins"
+              it "doesn't notifies the admins" do
+                expect(Decidim::EventsManager).to receive(:publish)
+                  .with(kind_of(Hash)).once
+
+                expect(Decidim::EventsManager)
+                  .not_to receive(:publish)
+                  .with(
+                    event: "decidim.events.initiatives.support_threshold_reached",
+                    event_class: Decidim::Initiatives::Admin::SupportThresholdReachedEvent,
+                    resource: initiative,
+                    followers: [admin]
+                  )
+
+                expect do
+                  perform_enqueued_jobs { command.call }
+                end.to change(emails, :count).by(1)
+              end
+            end
           end
 
-          context "when notifications is debatted" do
-            let(:initiative) do
-              create(:initiative,
-                     :debatted,
-                     organization: organization,
-                     scoped_type: create(
-                       :initiatives_type_scope,
-                       supports_required: 1,
-                       type: create(:initiatives_type, organization: organization)
-                     ))
-            end
-
-            before do
-              create(:initiative_user_vote, initiative: initiative)
-            end
-
-            it_behaves_like "notifies the admins"
-          end
+          it_behaves_like "when support threshold is reached with state", "published"
+          it_behaves_like "when support threshold is reached with state", "examinated"
+          it_behaves_like "when support threshold is reached with state", "debatted"
         end
 
         context "when initiative type requires extra user fields" do
@@ -204,17 +220,6 @@ module Decidim
             expect { invalid_command.call }.to broadcast :invalid
           end
 
-          it "broadcasts ok when form contains personal data" do
-            expect { command_with_personal_data.call }.to broadcast :ok
-          end
-
-          it "stores encrypted user personal data in vote" do
-            command_with_personal_data.call
-            vote = InitiativesVote.last
-            expect(vote.encrypted_metadata).to be_present
-            expect(vote.decrypted_metadata).to eq personal_data_params
-          end
-
           context "when another signature exists with the same hash_id" do
             before do
               create(:initiative_user_vote, initiative: initiative, hash_id: form_with_personal_data.hash_id)
@@ -228,7 +233,12 @@ module Decidim
           context "when initiative type has document number authorization handler" do
             let(:handler_name) { "dummy_authorization_handler" }
             let(:unique_id) { "test_digest" }
-            let(:metadata) { { test: "dummy" } }
+            let(:metadata) do
+              {
+                test: "dummy",
+                scope_id: initiative.scoped_type.scope.id
+              }
+            end
             let!(:authorization_handler) { Decidim::AuthorizationHandler.handler_for(handler_name) }
 
             before do
@@ -253,6 +263,13 @@ module Decidim
               context "when authorization unique_id and metadata are coincident with handler" do
                 it "broadcasts ok" do
                   expect { command_with_personal_data.call }.to broadcast :ok
+                end
+
+                it "stores encrypted user personal data in vote" do
+                  command_with_personal_data.call
+                  vote = InitiativesVote.last
+                  expect(vote.encrypted_metadata).to be_present
+                  expect(vote.decrypted_metadata).to eq personal_data_params
                 end
               end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When initiative vote count reached 100%, admin should receive notification.

#### :clipboard: Subtasks
- [x] Fix undefined variable in `vote_initiative` command
- [x] Allows `event_publisher_job` to consider initiative as notifiable
- [x] Add tests for specific initiative state
- [x] Backport fix initiative followers notifications
- [x] Backport avoid to send notification if limit has already been reached