### PR TITLE
bump rubocop version

### DIFF
--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rspec-html-matchers", "~> 0.9.1"
   s.add_dependency "rspec-rails", "~> 3.7"
   s.add_dependency "rspec_junit_formatter", "~> 0.3.0"
-  s.add_dependency "rubocop", "~> 0.58.0"
+  s.add_dependency "rubocop", "~> 0.71.0"
   s.add_dependency "rubocop-rspec", "~> 1.21"
   s.add_dependency "selenium-webdriver", "~> 3.7"
   s.add_dependency "simplecov", "~> 0.17.1"


### PR DESCRIPTION
#### :tophat: What? Why?

Rubocop-rails needs at least the version `v0.71.0` of rubocop for running correctly in [osp-app](https://github.com/Quentinchampenois/osp-app-toulouse)

Furthermore, the official [Decidim v0.18.0 dev gemspec](https://github.com/decidim/decidim/blob/release/0.18-stable/decidim-dev/decidim-dev.gemspec) has already bump the rubocop version.


