### PR TITLE
Fix promoting committee wizard

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -21,6 +21,7 @@ module Decidim
       helper_method :current_initiative
       helper_method :initiative_type
       helper_method :promotal_committee_required?
+      helper_method :unique_committee_member?
 
       steps :select_initiative_type,
             :previous_form,
@@ -175,6 +176,13 @@ module Decidim
                                     Decidim::Initiatives.minimum_committee_members
 
         minimum_committee_members.present? && minimum_committee_members.positive?
+      end
+
+      def unique_committee_member?
+        minimum_committee_members = initiative_type.minimum_committee_members ||
+                                    Decidim::Initiatives.minimum_committee_members
+
+        minimum_committee_members == 1
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -180,7 +180,7 @@ module Decidim
 
       def unique_committee_member?
         committee_members = initiative_type.minimum_committee_members ||
-                                    Decidim::Initiatives.minimum_committee_members
+                            Decidim::Initiatives.minimum_committee_members
 
         committee_members == 1
       end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -21,7 +21,6 @@ module Decidim
       helper_method :current_initiative
       helper_method :initiative_type
       helper_method :promotal_committee_required?
-      helper_method :minimum_committee_members
 
       steps :select_initiative_type,
             :previous_form,
@@ -175,7 +174,7 @@ module Decidim
         minimum_committee_members = initiative_type.minimum_committee_members ||
                                     Decidim::Initiatives.minimum_committee_members
 
-        minimum_committee_members.present? && minimum_committee_members > 1
+        minimum_committee_members.present? && minimum_committee_members.positive?
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -179,10 +179,10 @@ module Decidim
       end
 
       def unique_committee_member?
-        minimum_committee_members = initiative_type.minimum_committee_members ||
+        committee_members = initiative_type.minimum_committee_members ||
                                     Decidim::Initiatives.minimum_committee_members
 
-        minimum_committee_members == 1
+        committee_members == 1
       end
     end
   end

--- a/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
@@ -30,6 +30,10 @@ module Decidim
         end
       end
 
+      def send_to_technical_validation?
+        !promotal_committee_required? || unique_committee_member?
+      end
+
       private
 
       def online_signature_type_options

--- a/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
@@ -19,6 +19,17 @@ module Decidim
         end
       end
 
+      def skip_wizard?(step)
+        case step
+        when :select_initiative_type
+          single_initiative_type?
+        when :promotal_committee
+          !promotal_committee_required?
+        else
+          false
+        end
+      end
+
       private
 
       def online_signature_type_options

--- a/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
@@ -19,17 +19,6 @@ module Decidim
         end
       end
 
-      def skip_wizard?(step)
-        case step
-        when :select_initiative_type
-          single_initiative_type?
-        when :promotal_committee
-          !promotal_committee_required?
-        else
-          false
-        end
-      end
-
       def send_to_technical_validation?
         !promotal_committee_required? || unique_committee_member?
       end

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -21,7 +21,7 @@
         <%= render partial: "finish_help" %>
 
         <div class="actions">
-          <% unless promotal_committee_required? %>
+          <% if send_to_technical_validation? %>
             <%= link_to t(".send_my_initiative"),
                         decidim_initiatives.send_to_technical_validation_initiative_path(current_initiative),
                         class: "button success light expanded",

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -12,8 +12,8 @@
   <div class="show-for-large">
     <ol class="wizard__steps">
       <% wizard_steps.each do |wizard_step| %>
-        <% next if wizard_step.to_s == "promotal_committee" && !promotal_committee_required? %>
-        <% next if wizard_step.to_s == "select_initiative_type" && single_initiative_type? %>
+        <% next if skip_wizard?(wizard_step) %>
+
         <% if step == wizard_step %>
           <li class="step--active">
             <%= t(".#{wizard_step}") %>

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -12,7 +12,8 @@
   <div class="show-for-large">
     <ol class="wizard__steps">
       <% wizard_steps.each do |wizard_step| %>
-        <% next if skip_wizard?(wizard_step) %>
+        <% next if wizard_step == :promotal_committee && !promotal_committee_required? %>
+        <% next if wizard_step == :select_initiative_type && single_initiative_type? %>
 
         <% if step == wizard_step %>
           <li class="step--active">

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -330,7 +330,7 @@ describe "Initiative", type: :system do
           find_button("Continue").click
         end
 
-        context "when minimum committee size is above zero" do
+        context "when minimum committee size is above one" do
           before do
             find_link("Continue").click
           end
@@ -350,11 +350,38 @@ describe "Initiative", type: :system do
               expect(page).to have_link("Edit my initiative")
             end
           end
+
+          it "doesn't displays a send to technical validation link" do
+            expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"
+            within ".actions" do
+              expect(page).not_to have_link("Send my initiative")
+              expect(page).not_to have_selector "a[data-confirm='#{expected_message}']"
+            end
+          end
         end
 
         context "when minimum committee size is zero" do
           let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
           let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "displays a send to technical validation link" do
+            expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+              expect(page).to have_selector "a[data-confirm='#{expected_message}']"
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+
+        context "when minimum committee size is equals to 1" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_minimum_committee_members) { 1 }
+
+          before do
+            find_link("Continue").click
+          end
 
           it "displays a send to technical validation link" do
             expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -57,10 +57,6 @@ describe "Initiative", type: :system do
       let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
 
       before do
-        switch_to_host(organization.host)
-        create(:authorization, user: authorized_user)
-        login_as authorized_user, scope: :user
-
         visit decidim_initiatives.create_initiative_path(id: :select_initiative_type)
       end
 
@@ -294,6 +290,16 @@ describe "Initiative", type: :system do
             within(".step--active") do
               expect(page).not_to have_content("Promoter committee")
               expect(page).to have_content("Finish")
+            end
+          end
+        end
+
+        context "when minimum committee size is equal to 1" do
+          let(:initiative_type_minimum_committee_members) { 1 }
+
+          it "displays promoting committee wizard" do
+            within ".wizard__steps" do
+              expect(page).to have_content("Promoter committee")
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

As a user, I don't see the promoting committee step in initiative creation wizard, although min promoting committee = 1. 

As an admin, when enabling promoting committee and setting it to 1, I expect to:

- See the promoting committee step in the initiative creation wizard
- See the "Send to technical validation" button at last step of the wizard.
