### PR TITLE
Fix fc signataire promoting committee

### DIFF
--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -125,12 +125,16 @@ module Decidim
         !initiative.published? &&
           initiative.promoting_committee_enabled? &&
           !initiative.has_authorship?(user) &&
-          user.email.present? &&
+          !user_signataire? &&
           (
               Decidim::Initiatives.do_not_require_authorization ||
               ActionAuthorizer.new(user, :create, initiative, initiative_type).authorize.ok? ||
               Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
             )
+      end
+
+      def user_signataire?
+        user.email.blank? && user.name == "Anonyme"
       end
 
       def vote_initiative?

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -125,11 +125,12 @@ module Decidim
         !initiative.published? &&
           initiative.promoting_committee_enabled? &&
           !initiative.has_authorship?(user) &&
+          user.email.present? &&
           (
-            Decidim::Initiatives.do_not_require_authorization ||
-            ActionAuthorizer.new(user, :create, initiative, initiative_type).authorize.ok? ||
-            Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
-          )
+              Decidim::Initiatives.do_not_require_authorization ||
+              ActionAuthorizer.new(user, :create, initiative, initiative_type).authorize.ok? ||
+              Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
+            )
       end
 
       def vote_initiative?

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -373,6 +373,15 @@ describe Decidim::Initiatives::Permissions do
 
           it { is_expected.to eq true }
         end
+
+        context "when user is a 'signataire'" do
+          before do
+            # bypass validation for matching signataire model defined in osp-app
+            user.update_attribute "email", ""
+          end
+
+          it { is_expected.to be_falsey }
+        end
       end
     end
   end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -337,7 +337,6 @@ describe Decidim::Initiatives::Permissions do
       context "when user is not a member" do
         let(:initiative) { create :initiative, :discarded, organization: organization }
 
-        # TODO: Check again this test, maybe it should be equal to falsey
         it "restricts join committee request on creation" do
           expect(subject).to be_truthy
         end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -378,6 +378,7 @@ describe Decidim::Initiatives::Permissions do
           before do
             # bypass validation for matching signataire model defined in osp-app
             user.update_attribute "email", ""
+            user.update_attribute "name", "Anonyme"
           end
 
           it { is_expected.to be_falsey }

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -376,8 +376,10 @@ describe Decidim::Initiatives::Permissions do
         context "when user is a 'signataire'" do
           before do
             # bypass validation for matching signataire model defined in osp-app
+            # rubocop:disable Rails/SkipsModelValidations
             user.update_attribute "email", ""
             user.update_attribute "name", "Anonyme"
+            # rubocop:enable Rails/SkipsModelValidations
           end
 
           it { is_expected.to be_falsey }


### PR DESCRIPTION
#### :tophat: What? Why?

As a signataire, I can ask to join a promoting committee. This should only be possible for users connected as authors.


#### :clipboard: Subtasks
- [x] Update initiative permissions
- [x] Add tests

### More info

FC Signataire model is defined in `osp-app`, I decided to fix in decidim for testing.
