### PR TITLE
Fix committee request email name

### DIFF
--- a/decidim-initiatives/app/events/decidim/initiatives/spawn_committee_request_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/spawn_committee_request_event.rb
@@ -9,7 +9,7 @@ module Decidim
       def email_subject
         I18n.t(
           "decidim.initiatives.events.spawn_committee_request_event.email_subject",
-          applicant_nickname: applicant_nickname
+          applicant_name: applicant_name
         )
       end
 
@@ -19,7 +19,7 @@ module Decidim
           resource_title: resource_title,
           resource_url: resource_url,
           applicant_profile_url: applicant_profile_url,
-          applicant_nickname: applicant_nickname
+          applicant_name: applicant_name
         )
       end
 
@@ -37,14 +37,14 @@ module Decidim
           resource_title: resource_title,
           resource_url: resource_url,
           applicant_profile_url: applicant_profile_url,
-          applicant_nickname: applicant_nickname
+          applicant_name: applicant_name
         ).html_safe
       end
 
       private
 
-      def applicant_nickname
-        applicant.nickname
+      def applicant_name
+        applicant.name
       end
 
       def applicant_profile_url

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -416,10 +416,10 @@ en:
           email_subject: "%{author_nickname} rejected your application to the promoter committee"
           notification_title: <a href="%{author_profile_url}">%{author_nickname}</a> rejected you application to be part of the promoter committee for the following initiative <a href="%{resource_url}">%{resource_title}</a>.
         spawn_committee_request_event:
-          email_intro: "%{applicant_nickname} applied for the promoter committee of your initiative %{resource_title}. To accept or reject the application, go to the edit form of your initiative."
+          email_intro: "%{applicant_name} applied for the promoter committee of your initiative %{resource_title}. To accept or reject the application, go to the edit form of your initiative."
           email_outro: 'You received this notification because you are the author of this initiative : %{resource_title}'
-          email_subject: "%{applicant_nickname} wants to join your initiative"
-          notification_title: <a href="%{applicant_profile_url}">%{applicant_nickname}</a> applied for the promoter committee of your initiative <a href="%{resource_url}">%{resource_title}</a>. To accept or reject click <a href="%{resource_url}/edit">here</a>.
+          email_subject: "%{applicant_name} wants to join your initiative"
+          notification_title: <a href="%{applicant_profile_url}">%{applicant_name}</a> applied for the promoter committee of your initiative <a href="%{resource_url}">%{resource_title}</a>. To accept or reject click <a href="%{resource_url}/edit">here</a>.
       form:
         add_attachments: Documents
         attachment_legend: "(Optional) Add Attachments"

--- a/decidim-initiatives/spec/events/decidim/initiatives/spawn_committee_request_event_spec.rb
+++ b/decidim-initiatives/spec/events/decidim/initiatives/spawn_committee_request_event_spec.rb
@@ -17,8 +17,9 @@ describe Decidim::Initiatives::SpawnCommitteeRequestEvent do
   let(:initiative) { create :initiative }
   let(:event_name) { "decidim.events.initiatives.initiative_created" }
   let(:applicant) { create :user, organization: organization }
-  let(:applicant_profile_url) { Decidim::UserPresenter.new(applicant).profile_url }
-  let(:applicant_nickname) { Decidim::UserPresenter.new(applicant).nickname }
+  let(:applicant_presenter) { Decidim::UserPresenter.new(applicant) }
+  let(:applicant_profile_url) { applicant_presenter.profile_url }
+  let(:applicant_name) { applicant_presenter.name }
   let(:resource_url) { resource_locator(initiative).url }
   let(:resource_title) { translated(initiative.title) }
 
@@ -36,13 +37,13 @@ describe Decidim::Initiatives::SpawnCommitteeRequestEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("#{applicant_nickname} wants to join your initiative")
+      expect(subject.email_subject).to eq("#{applicant_name} wants to join your initiative")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("#{applicant_nickname} applied for the promoter committee of your initiative #{resource_title}. To accept or reject the application, go to the edit form of your initiative.")
+      expect(subject.email_intro).to eq("#{applicant_name} applied for the promoter committee of your initiative #{resource_title}. To accept or reject the application, go to the edit form of your initiative.")
     end
   end
 
@@ -56,7 +57,7 @@ describe Decidim::Initiatives::SpawnCommitteeRequestEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to eq("<a href=\"#{applicant_profile_url}\">#{applicant_nickname}</a> applied for the promoter committee of your initiative <a href=\"#{resource_url}\">#{resource_title}</a>. To accept or reject click <a href=\"#{resource_url}/edit\">here</a>.")
+        .to eq("<a href=\"#{applicant_profile_url}\">#{applicant_name}</a> applied for the promoter committee of your initiative <a href=\"#{resource_url}\">#{resource_title}</a>. To accept or reject click <a href=\"#{resource_url}/edit\">here</a>.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As an author, when I receive a mail about co-authors, I want to know the name of the applicant instead of her nickname. 

:hearts: Thank you!
