### PR TITLE
Fix initiative state filter

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -34,17 +34,6 @@ module Decidim
       # GET /initiatives
       def index
         enforce_permission_to :list, :initiative
-        return unless search.results.blank? && params.dig("filter", "state") != %w(closed)
-
-        @closed_initiatives = search_klass.new(search_params.merge(state: %w(closed)))
-
-        if @closed_initiatives.results.present?
-          params[:filter] ||= {}
-          params[:filter][:date] = %w(closed)
-          @forced_closed_initiatives = true
-
-          @search = @closed_initiatives
-        end
       end
 
       # GET /initiatives/:id

--- a/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/initiative_search_spec.rb
@@ -192,6 +192,23 @@ module Decidim
               end
             end
 
+            context "when filtering by open and classified" do
+              let(:state) { %w(open) }
+              let(:custom_state) { ["classified"] }
+
+              before do
+                create_list(:initiative, 3, organization: organization)
+              end
+
+              it "does not returns initiatives" do
+                classified_initiatives = create_list(:initiative, 3, :classified, organization: organization)
+
+                expect(subject.size).to eq(0)
+                expect(subject).to match_array([])
+                expect(subject).not_to include(classified_initiatives)
+              end
+            end
+
             context "when filtering by answered, closed and examinated" do
               let(:state) { %w(answered closed) }
               let(:custom_state) { ["examinated"] }

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -230,6 +230,18 @@ describe "Filter Initiatives", :slow, type: :system do
         expect(page).to have_css(".card--initiative", count: 2)
         expect(page).to have_content("2 INITIATIVES")
       end
+
+      context "and selecting the opened state" do
+        it "does not lists initiatives" do
+          within ".filters .custom_state_check_boxes_tree_filter" do
+            uncheck "All"
+            check "Classified"
+          end
+
+          expect(page).to have_css(".card--initiative", count: 0)
+          expect(page).to have_content("0 INITIATIVE")
+        end
+      end
     end
 
     context "when selecting the debatted state" do


### PR DESCRIPTION
#### :tophat: What? Why?


Quand on sélectionne à la fois les filtres « Ouverte » et « classée » , on se retrouve quand même avec une liste de pétitions « classées », alors qu’elles sont censé être fermées et donc ne pas apparaître si « ouverte » est coché

