### PR TITLE
enhance request membership tests

### DIFF
--- a/decidim-initiatives/spec/commands/decidim/initiatives/revoke_membership_request_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/revoke_membership_request_spec.rb
@@ -31,6 +31,15 @@ module Decidim
           command.call
         end
 
+        it "sends notification by email" do
+          expect do
+            perform_enqueued_jobs { command.call }
+          end.to change(emails, :count).by(1)
+
+          expect(last_email.to).to eq([membership_request.user.email])
+          expect(last_email_body).to include("#{initiative.author.name} rejected your application to be part of the promoter committee for the following initiative")
+        end
+
         it "revokes committee membership request" do
           expect do
             command.call

--- a/decidim-initiatives/spec/commands/decidim/initiatives/spawn_committee_request_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/spawn_committee_request_spec.rb
@@ -46,6 +46,15 @@ module Decidim
           command.call
         end
 
+        it "sends notification by email" do
+          expect do
+            perform_enqueued_jobs { command.call }
+          end.to change(emails, :count).by(3)
+
+          expect(last_email.to).to eq([initiative.author.email])
+          expect(last_email_body).to include("applied for the promoter committee of your initiative")
+        end
+
         it "Creates a committee membership request" do
           expect do
             command.call


### PR DESCRIPTION
#### :tophat: What? Why?

Ensure mails about membership requests are still sent to concerned users