### PR TITLE
allow edit only for created initiatives

### DIFF
--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -74,21 +74,27 @@ module Decidim
       end
 
       def edit_public_initiative?
-        allow! if permission_action.subject == :initiative &&
-                  permission_action.action == :edit
+        return unless permission_action.subject == :initiative &&
+                      permission_action.action == :edit
+
+        toggle_allow(editable?)
       end
 
       def update_public_initiative?
         return unless permission_action.subject == :initiative &&
                       permission_action.action == :update
 
-        toggle_allow(initiative.created?)
+        toggle_allow(editable?)
       end
 
       def creation_enabled?
         Decidim::Initiatives.creation_enabled && (
         creation_authorized? || Decidim::UserGroups::ManageableUserGroups.for(user).verified.any?
       )
+      end
+
+      def editable?
+        initiative.created?
       end
 
       def create_initiative_with_type?

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -107,40 +107,12 @@ describe Decidim::Initiatives::Permissions do
       { initiative: initiative }
     end
 
-    context "when initiative is published" do
-      let(:initiative) { create :initiative, :published, organization: organization }
+    [:published, :debatted, :examinated, :classified, :rejected, :accepted].each do |state|
+      context "when initiative is #{state}" do
+        let(:initiative) { create :initiative, state, organization: organization }
 
-      it { is_expected.to eq true }
-    end
-
-    context "when initiative is debatted" do
-      let(:initiative) { create :initiative, :debatted, organization: organization }
-
-      it { is_expected.to eq true }
-    end
-
-    context "when initiative is examinated" do
-      let(:initiative) { create :initiative, :examinated, organization: organization }
-
-      it { is_expected.to eq true }
-    end
-
-    context "when initiative is classified" do
-      let(:initiative) { create :initiative, :classified, organization: organization }
-
-      it { is_expected.to eq true }
-    end
-
-    context "when initiative is rejected" do
-      let(:initiative) { create :initiative, :rejected, organization: organization }
-
-      it { is_expected.to eq true }
-    end
-
-    context "when initiative is accepted" do
-      let(:initiative) { create :initiative, :accepted, organization: organization }
-
-      it { is_expected.to eq true }
+        it { is_expected.to eq true }
+      end
     end
 
     context "when user is admin" do
@@ -284,6 +256,9 @@ describe Decidim::Initiatives::Permissions do
 
   context "when managing an initiative" do
     let(:action_subject) { :initiative }
+    let(:context) do
+      { initiative: initiative }
+    end
 
     context "when updating" do
       let(:action_name) { :edit }
@@ -295,6 +270,14 @@ describe Decidim::Initiatives::Permissions do
         let(:initiative) { create :initiative, :created, organization: organization }
 
         it { is_expected.to eq true }
+      end
+
+      [:published, :debatted, :examinated, :classified, :rejected, :accepted].each do |state|
+        context "when initiative is #{state}" do
+          let(:initiative) { create :initiative, state.to_s.to_sym, organization: organization }
+
+          it { is_expected.to eq false }
+        end
       end
     end
 

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -274,7 +274,7 @@ describe Decidim::Initiatives::Permissions do
 
       [:published, :debatted, :examinated, :classified, :rejected, :accepted].each do |state|
         context "when initiative is #{state}" do
-          let(:initiative) { create :initiative, state.to_s.to_sym, organization: organization }
+          let(:initiative) { create :initiative, state, organization: organization }
 
           it { is_expected.to eq false }
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Ensure edit form is only reachable for created initiatives
