### PR TITLE
Fix/graphical improvements

### DIFF
--- a/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
+++ b/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
@@ -3,6 +3,7 @@
 @import "admin";
 
 $archived-color: #867d84;
+$archived-background-color: #f6f6f6;
 
 .ql-formats{
   .ql-video{
@@ -89,7 +90,15 @@ fieldset{
   margin-bottom: 1em;
 }
 
+.archive-header{
+  img{
+    max-width: 15%;
+  }
+}
+
 .card.archived{
+  background: $archived-background-color;
+
   &:hover{
     border-color: $archived-color;
   }
@@ -102,6 +111,7 @@ fieldset{
     align-content: center;
     justify-content: center;
     align-items: center;
+    padding-top: 12px;
 
     img{
       max-width: 30%;

--- a/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
+++ b/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
@@ -94,6 +94,11 @@ fieldset{
   img{
     max-width: 15%;
   }
+  @media only screen and (max-width: 500px) {
+    img{
+      max-width: 30%;
+    }
+  }
 }
 
 .card.archived{

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -83,6 +83,8 @@
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
       <div class="row column">
+        <%= render partial: "archived_header" if current_initiative.archived? %>
+        <br>
         <h2 class="heading2" <%= "id=#{translate_helper_for(element: :title, model: current_initiative)}" %>>
           <%= translated_attribute(current_initiative.title) %>
         </h2>
@@ -94,8 +96,6 @@
               options: { class: "hide-for-small-only" }
             ) %>
       </div>
-
-      <%= render partial: "archived_header" if current_initiative.archived? %>
       <br>
       <div class="row column">
         <%= render partial: "initiative_badge", locals: { initiative: current_initiative } %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to improve graphical display on archived initiatives card and show.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="916" alt="Archived initiative card" src="https://user-images.githubusercontent.com/52420208/116993580-f9926880-acd7-11eb-90e7-b1e846c57b9c.png">
<img width="1234" alt="Archived initiative show" src="https://user-images.githubusercontent.com/52420208/116993587-fac39580-acd7-11eb-9d4a-fbd34b66e5ce.png">

