### PR TITLE
add request url to cache entry

### DIFF
--- a/decidim-budgets/app/helpers/decidim/budgets/application_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/application_helper.rb
@@ -9,6 +9,7 @@ module Decidim
       include Decidim::Comments::CommentsHelper
       include ProjectsHelper
       include Decidim::CheckBoxesTreeHelper
+      include Decidim::CachingHelper
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/caching_helper.rb
+++ b/decidim-core/app/helpers/decidim/caching_helper.rb
@@ -3,11 +3,18 @@
 module Decidim
   # Helpers related to caching
   module CachingHelper
-    def cache_with_url(options = {})
+    # cache_with_url fetch in Rails cache the wanted cache key or create it.
+    # @param [String] name - Name of the cache key : Default "decidim_cached_with_url"
+    # @param [Hash] options - Takes a collection (String, Array, Decidim::CheckBoxesTreeHelper::TreeNode, or other) and a url (String)
+    # @return [String] - Cache key
+    def cache_with_url(name, options = {})
       md5_digest = Digest::MD5.hexdigest("#{options[:collection]}#{options[:url]}")
 
-      Rails.cache.fetch("#{options.fetch(:name, "decidim_cached_with_url")}/#{md5_digest}") do
-        "#{options.fetch(:name, "decidim_cached_with_url")}/#{md5_digest}"
+      name ||= "decidim_cached_with_url"
+      cache_key = "#{name}/#{md5_digest}"
+
+      Rails.cache.fetch(cache_key) do
+        cache_key
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/caching_helper.rb
+++ b/decidim-core/app/helpers/decidim/caching_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helpers related to caching
+  module CachingHelper
+    def cache_with_url(options = {})
+      md5_digest = Digest::MD5.hexdigest("#{options[:collection]}#{options[:url]}")
+
+      Rails.cache.fetch("#{options.fetch(:name, "decidim_cached_with_url")}/#{md5_digest}") do
+        "#{options.fetch(:name, "decidim_cached_with_url")}/#{md5_digest}"
+      end
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<% cache "check_boxes_tree/#{Digest::MD5.hexdigest(collection.to_s)}" do %>
+<% cache "check_boxes_tree/#{Digest::MD5.hexdigest(collection.to_s + request.url)}" do %>
   <% if collection.leaf %>
     <% data_checkboxes_tree_id = "#{check_boxes_tree_id}-#{collection.leaf.value}" %>
     <% hide_node = (hide_node.present? and hide_node == "true") ? true : false %>

--- a/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<% cache cache_with_url(name: "check_boxes_tree", collection: collection, url: request.url) do %>
+<% cache cache_with_url("check_boxes_tree", {collection: collection, url: request.url}) do %>
   <% if collection.leaf %>
     <% data_checkboxes_tree_id = "#{check_boxes_tree_id}-#{collection.leaf.value}" %>
     <% hide_node = (hide_node.present? and hide_node == "true") ? true : false %>

--- a/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<% cache "check_boxes_tree/#{Digest::MD5.hexdigest(collection.to_s + request.url)}" do %>
+<% cache cache_with_url(name: "check_boxes_tree", collection: collection, url: request.url) do %>
   <% if collection.leaf %>
     <% data_checkboxes_tree_id = "#{check_boxes_tree_id}-#{collection.leaf.value}" %>
     <% hide_node = (hide_node.present? and hide_node == "true") ? true : false %>

--- a/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<% cache cache_with_url("check_boxes_tree", {collection: collection, url: request.url}) do %>
+<% cache cache_with_url("check_boxes_tree", { collection: collection, url: request.url }) do %>
   <% if collection.leaf %>
     <% data_checkboxes_tree_id = "#{check_boxes_tree_id}-#{collection.leaf.value}" %>
     <% hide_node = (hide_node.present? and hide_node == "true") ? true : false %>

--- a/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
@@ -5,16 +5,16 @@ require "spec_helper"
 module Decidim
   describe CachingHelper do
     describe "#cache_with_url" do
-      let(:subject) { helper.cache_with_url(options) }
+      let(:subject) { helper.cache_with_url(name, options) }
       let(:options) do
         {
-          name: "dummy_name",
           collection: "dummy_collection",
           url: decidim.root_url(host: organization.host)
         }
       end
       let(:organization) { create(:organization) }
       let(:md5_digest) { Digest::MD5.hexdigest("#{options[:collection]}#{options[:url]}") }
+      let(:name) { "dummy_name" }
 
       it "returns a string" do
         expect(subject).to be_a String
@@ -38,7 +38,6 @@ module Decidim
         context "when collection is missing" do
           let(:options) do
             {
-              name: "dummy_name",
               collection: nil,
               url: decidim.root_url(host: organization.host)
             }
@@ -52,7 +51,6 @@ module Decidim
         context "when url is missing" do
           let(:options) do
             {
-              name: "dummy_name",
               collection: "dummy_collection",
               url: nil
             }
@@ -63,13 +61,8 @@ module Decidim
           end
         end
 
-        context "when name is undefined" do
-          let(:options) do
-            {
-              collection: "dummy_collection",
-              url: decidim.root_url(host: organization.host)
-            }
-          end
+        context "when name is nil" do
+          let(:name) { nil }
 
           it "returns a default name" do
             expect(subject).to eq("decidim_cached_with_url/#{md5_digest}")
@@ -80,7 +73,6 @@ module Decidim
       context "when collection is a TreeNode" do
         let(:options) do
           {
-            name: "dummy_name",
             collection: CheckBoxesTreeHelper::TreeNode.new(
               CheckBoxesTreeHelper::TreePoint.new("", "All"),
               [

--- a/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
@@ -34,6 +34,20 @@ module Decidim
         end
       end
 
+      context "when collection is different" do
+        let(:options) do
+          {
+            collection: "dummy_collection_different",
+            url: decidim.root_url(host: organization.host)
+          }
+        end
+
+        it "generate a different hash" do
+          old_hash = helper.cache_with_url(name, collection: "dummy_collection", url: decidim.root_url(host: organization.host))
+          expect(subject).not_to eq(old_hash)
+        end
+      end
+
       context "when option is missing" do
         context "when collection is missing" do
           let(:options) do

--- a/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/caching_helper_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe CachingHelper do
+    describe "#cache_with_url" do
+      let(:subject) { helper.cache_with_url(options) }
+      let(:options) do
+        {
+          name: "dummy_name",
+          collection: "dummy_collection",
+          url: decidim.root_url(host: organization.host)
+        }
+      end
+      let(:organization) { create(:organization) }
+      let(:md5_digest) { Digest::MD5.hexdigest("#{options[:collection]}#{options[:url]}") }
+
+      it "returns a string" do
+        expect(subject).to be_a String
+      end
+
+      it "returns the cache version name" do
+        expect(subject).to eq("dummy_name/#{md5_digest}")
+      end
+
+      context "when cache is already set" do
+        before do
+          Rails.cache.write("dummy_key", md5_digest)
+        end
+
+        it "returns the cache version name" do
+          expect(subject).to eq("dummy_name/#{md5_digest}")
+        end
+      end
+
+      context "when option is missing" do
+        context "when collection is missing" do
+          let(:options) do
+            {
+              name: "dummy_name",
+              collection: nil,
+              url: decidim.root_url(host: organization.host)
+            }
+          end
+
+          it "returns the cache version name" do
+            expect(subject).to eq("dummy_name/#{md5_digest}")
+          end
+        end
+
+        context "when url is missing" do
+          let(:options) do
+            {
+              name: "dummy_name",
+              collection: "dummy_collection",
+              url: nil
+            }
+          end
+
+          it "returns the cache version name" do
+            expect(subject).to eq("dummy_name/#{md5_digest}")
+          end
+        end
+
+        context "when name is undefined" do
+          let(:options) do
+            {
+              collection: "dummy_collection",
+              url: decidim.root_url(host: organization.host)
+            }
+          end
+
+          it "returns a default name" do
+            expect(subject).to eq("decidim_cached_with_url/#{md5_digest}")
+          end
+        end
+      end
+
+      context "when collection is a TreeNode" do
+        let(:options) do
+          {
+            name: "dummy_name",
+            collection: CheckBoxesTreeHelper::TreeNode.new(
+              CheckBoxesTreeHelper::TreePoint.new("", "All"),
+              [
+                CheckBoxesTreeHelper::TreePoint.new("open", "Open"),
+                CheckBoxesTreeHelper::TreeNode.new(
+                  CheckBoxesTreeHelper::TreePoint.new("closed", "Closed"),
+                  [
+                    CheckBoxesTreeHelper::TreePoint.new("accepted", "Accepted"),
+                    CheckBoxesTreeHelper::TreePoint.new("rejected", "Rejected")
+                  ]
+                )
+              ]
+            ),
+            url: decidim.root_url(host: organization.host)
+          }
+        end
+
+        it "returns the cache version name" do
+          expect(subject).to eq("dummy_name/#{md5_digest}")
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/application_helper.rb
@@ -6,6 +6,7 @@ module Decidim
     #
     module ApplicationHelper
       include Decidim::CheckBoxesTreeHelper
+      include Decidim::CachingHelper
 
       def filter_states_values
         TreeNode.new(

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -16,6 +16,7 @@ module Decidim
       include ControlVersionHelper
       include Decidim::RichTextEditorHelper
       include Decidim::CheckBoxesTreeHelper
+      include Decidim::CachingHelper
 
       delegate :minimum_votes_per_user, to: :component_settings
 


### PR DESCRIPTION
#### :tophat: What? Why?

Filter caching seems to be broken when accessing initiatives view from url.

