### PR TITLE
Change the progress bar backgroung color when archived

### DIFF
--- a/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
+++ b/decidim-initiatives/app/assets/stylesheet/decidim/initiatives/initiatives.scss
@@ -118,6 +118,10 @@ fieldset{
     border-color: $archived-color;
   }
 
+  .progress__bar__bar--complete{
+    background-color: $archived-color;
+  }
+
   border-top-width: 8px;
   border-top-color: $archived-color;
 


### PR DESCRIPTION
#### :tophat: What? Why?
When an initiative is archived, I want the progress bar (complete) to be displayed in grey. 


<img width="897" alt="Capture d’écran 2021-06-16 à 17 42 02" src="https://user-images.githubusercontent.com/52420208/122250742-343c1300-ceca-11eb-80c2-a0117bf16b75.png">

