### PR TITLE
ensure body is saved when user go back

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -117,7 +117,7 @@ module Decidim
 
       def finish_step(_parameters)
         enforce_permission_to :create, :initiative
-        session[:initiative][:description] = nil
+
         render_wizard
       end
 

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -159,6 +159,13 @@ describe "Initiative", type: :system do
           expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
           expect(page).to have_content(initiative.author_name)
         end
+
+        it "keeps fields in session when go back" do
+          click_link "Back"
+
+          expect(find("#initiative_title").value).to eq(translated(initiative.title, locale: :en))
+          expect(find("#initiative_description", visible: :hidden).value).to eq(translated(initiative.description, locale: :en))
+        end
       end
 
       context "when Create initiative" do
@@ -406,6 +413,17 @@ describe "Initiative", type: :system do
           end
 
           it_behaves_like "initiatives path redirection"
+        end
+
+        context "when user go back to fill_data step" do
+          before do
+            visit decidim_initiatives.create_initiative_path(id: :fill_data)
+          end
+
+          it "keeps fields in session and render in form" do
+            expect(find("#initiative_title").value).to eq(translated(initiative.title, locale: :en))
+            expect(find("#initiative_description", visible: :hidden).value).to eq(translated(initiative.description, locale: :en))
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Save body when user decides to go back on initiative creation form

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
