### PR TITLE
Send upstream moderation email to administrators

### DIFF
--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -35,10 +35,9 @@ module Decidim
     def generate
       return unless resource
       return unless event_class.types.include?(:email)
-
       followers.each do |recipient|
         next unless ["all", "followed-only"].include?(recipient.try(:notification_types))
-        next unless participatory_space.present? && participatory_space.is_a?(Decidim::Participable) && participatory_space.can_participate?(recipient)
+
         send_email_to(recipient, user_role: :follower)
       end
 
@@ -64,6 +63,7 @@ module Decidim
     def send_email_to(recipient, user_role:)
       return unless recipient
       return unless recipient.email_on_notification?
+      return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
 
       NotificationMailer
         .event_received(
@@ -79,7 +79,7 @@ module Decidim
 
     def component
       return resource.component if resource.is_a?(Decidim::HasComponent)
-      return resource if resource.is_a?(Decidim::Component)
+      resource if resource.is_a?(Decidim::Component)
     end
 
     def participatory_space

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -50,6 +50,8 @@ module Decidim
     attr_reader :event, :event_class, :resource, :followers, :affected_users, :extra
 
     def generate_notification_for(recipient, user_role:)
+      return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
+
       NotificationGeneratorForRecipientJob.perform_later(
         event,
         event_class.name,

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -396,6 +396,11 @@ en:
         content_doesnt_exist: This address is incorrect or has been removed.
         title: The page you're looking for can't be found
     events:
+      admin:
+        upstream_pending:
+          follower:
+            email_outro: en.decidim.events.admin.upstream_pending.follower.email_outro
+            email_intro: en.decidim.events.admin.upstream_pending.follower.email_intro
       amendments:
         amendment_accepted:
           affected_user:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -399,9 +399,9 @@ en:
       admin:
         upstream_pending:
           follower:
-            email_subject: Nouveau message à valider et à publier
             email_intro: Bonjour, Un nouveau message a été soumis par un internaute et requiert votre validation.
             email_outro: Gérer les modérations
+            email_subject: Nouveau message à valider et à publier
             notification_title: '"<a href="%{resource_url}">%{resource_title}</a>" est en attente de modération.'
       amendments:
         amendment_accepted:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -399,8 +399,8 @@ en:
       admin:
         upstream_pending:
           follower:
-            email_outro: en.decidim.events.admin.upstream_pending.follower.email_outro
             email_intro: en.decidim.events.admin.upstream_pending.follower.email_intro
+            email_outro: en.decidim.events.admin.upstream_pending.follower.email_outro
       amendments:
         amendment_accepted:
           affected_user:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -399,8 +399,10 @@ en:
       admin:
         upstream_pending:
           follower:
-            email_intro: en.decidim.events.admin.upstream_pending.follower.email_intro
-            email_outro: en.decidim.events.admin.upstream_pending.follower.email_outro
+            email_subject: Nouveau message à valider et à publier
+            email_intro: Bonjour, Un nouveau message a été soumis par un internaute et requiert votre validation.
+            email_outro: Gérer les modérations
+            notification_title: '"<a href="%{resource_url}">%{resource_title}</a>" est en attente de modération.'
       amendments:
         amendment_accepted:
           affected_user:

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -385,6 +385,14 @@ fr:
         content_doesnt_exist: Cette adresse web est incorrecte ou n'existe plus.
         title: La page que vous recherchez ne peut être trouvée
     events:
+      events:
+        admin:
+          upstream_pending:
+            follower:
+              email_subject: Nouveau message à valider et à publier
+              email_intro: Bonjour, Un nouveau message a été soumis par un internaute et requiert votre validation.
+              email_outro: Gérer les modérations
+              notification_title: '"<a href="%{resource_url}">%{resource_title}</a>" est en attente de modération.'
       amendments:
         amendment_accepted:
           affected_user:

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -71,13 +71,13 @@ describe Decidim::EmailNotificationGenerator do
           it "enqueues the job" do
             expect(Decidim::NotificationMailer)
               .to receive(:event_received)
-                    .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
-                    .and_return(mailer)
+              .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
+              .and_return(mailer)
 
             expect(Decidim::NotificationMailer)
               .to receive(:event_received)
-                    .with(event, event_class_name, resource, follower, :follower.to_s, extra)
-                    .and_return(mailer)
+              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .and_return(mailer)
 
             expect(mailer).to receive(:deliver_later)
 

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -58,6 +58,46 @@ describe Decidim::EmailNotificationGenerator do
           subject.generate
         end
       end
+
+      context "when participatory space is participable" do
+        before do
+          resource.published_at = Time.current
+          resource.component.published_at = Time.current
+          resource.component.participatory_space.published_at = Time.current
+          resource.save!
+        end
+
+        context "and the user can participate" do
+          it "enqueues the job" do
+            expect(Decidim::NotificationMailer)
+              .to receive(:event_received)
+                    .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
+                    .and_return(mailer)
+
+            expect(Decidim::NotificationMailer)
+              .to receive(:event_received)
+                    .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+                    .and_return(mailer)
+
+            expect(mailer).to receive(:deliver_later)
+
+            subject.generate
+          end
+        end
+
+        context "and the user can't participate" do
+          before do
+            allow(resource).to receive(:can_participate?).with(kind_of(Decidim::User)).and_return(false)
+          end
+
+          it "doesn't schedule a job" do
+            expect(Decidim::NotificationMailer)
+              .not_to receive(:event_received)
+
+            subject.generate
+          end
+        end
+      end
     end
 
     context "when the event_class does not support emails" do

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -117,6 +117,37 @@ describe Decidim::NotificationGenerator do
           end
         end
       end
+
+      context "when participatory space is participable" do
+        before do
+          resource.published_at = Time.current
+          resource.component.published_at = Time.current
+          resource.component.participatory_space.published_at = Time.current
+          resource.save!
+        end
+
+        context "and the user can participate" do
+          it "enqueues the job" do
+            expect(Decidim::NotificationGeneratorForRecipientJob)
+              .to receive(:perform_later).twice
+
+            subject.generate
+          end
+        end
+
+        context "and the user can't participate" do
+          before do
+            allow(resource).to receive(:can_participate?).with(kind_of(Decidim::User)).and_return(false)
+          end
+
+          it "doesn't schedule a job" do
+            expect(Decidim::NotificationGeneratorForRecipientJob)
+              .not_to receive(:perform_later)
+
+            subject.generate
+          end
+        end
+      end
     end
 
     context "when the event_class does not support notifications" do


### PR DESCRIPTION
#### :tophat: What? Why?

When upstream moderation is enabled, administrators doesn't receive email about new comments.
Backport from #5370

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
