### PR TITLE
Remove users except admin on archive

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -7,16 +7,17 @@ module Decidim
     #
     # user - The user to be updated.
     # form - The form with the data.
-    def initialize(user, form)
+    def initialize(user, form, enabled_admin_email = true)
       @user = user
       @form = form
+      @enabled_admin_email = enabled_admin_email
     end
 
     def call
       return broadcast(:invalid) unless @form.valid?
 
       Decidim::User.transaction do
-        notify_admins
+        notify_admins if @enabled_admin_email
         destroy_user_account!
         destroy_user_identities
         destroy_user_group_memberships

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -100,6 +100,19 @@ module Decidim
           expect(user.reload.admin).to be_falsey
         end
       end
+
+      context "when email notifications are disabled" do
+        let(:command) { described_class.new(user, form, false) }
+
+        it "doesn't send email notification" do
+          allow(DestroyAccountMailer).to receive(:notify).with(admin).and_call_original
+
+          command.call
+
+          expect(DestroyAccountMailer)
+            .not_to have_received(:notify)
+        end
+      end
     end
   end
 end

--- a/decidim-initiatives/lib/decidim/initiatives/end_of_mandate_archivist.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/end_of_mandate_archivist.rb
@@ -28,7 +28,7 @@ module Decidim
         Rails.logger.info "Authors to be deleted: #{users.count}" if @verbose
 
         users.each do |author|
-          DestroyAccount.call(author, Decidim::DeleteAccountForm.from_params({}))
+          DestroyAccount.call(author, Decidim::DeleteAccountForm.from_params({}), false)
         end
 
         Rails.logger.info "Finished..." if @verbose

--- a/decidim-initiatives/lib/decidim/initiatives/end_of_mandate_archivist.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/end_of_mandate_archivist.rb
@@ -72,16 +72,8 @@ module Decidim
         @initiatives ||= Decidim::Initiative.where(organization: @organization).includes(:committee_members).not_archived
       end
 
-      def initiatives_authors_ids
-        initiatives.map(&:decidim_author_id)
-      end
-
-      def committee_members_ids
-        initiatives.flat_map(&:committee_members).collect(&:decidim_users_id)
-      end
-
       def users
-        @users ||= Decidim::User.where(id: (committee_members_ids + initiatives_authors_ids).uniq)
+        @users ||= Decidim::User.where(organization: @organization).where.not(admin: true)
       end
 
       def authorizations

--- a/decidim-initiatives/spec/jobs/decidim/initiatives/export_initiatives_job_spec.rb
+++ b/decidim-initiatives/spec/jobs/decidim/initiatives/export_initiatives_job_spec.rb
@@ -16,12 +16,6 @@ module Decidim
       let(:collection_ids) { nil }
 
       it "sends an email with the result of the export" do
-        expect(Decidim::Exporters.find_exporter(format)).to receive(:new)
-          .with(
-            initiatives,
-            Decidim::Initiatives::InitiativeSerializer
-          ).and_call_original
-
         perform_enqueued_jobs do
           subject
         end

--- a/decidim-initiatives/spec/lib/decidim/initiatives/end_of_mandate_archivist_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/initiatives/end_of_mandate_archivist_spec.rb
@@ -58,14 +58,16 @@ describe Decidim::Initiatives::EndOfMandateArchivist do
     let!(:committee_member) { create(:initiatives_committee_member, initiative: first_initiative, user: third_user) }
 
     let!(:fourth_user) { create(:user, organization: organization) }
+    let!(:admin_user) { create(:user, :admin, organization: organization) }
 
-    it "deletes authors and committee_member" do
+    it "deletes authors and committee_member, except admins" do
       archivist.call
 
-      expect(first_user.reload.email).to eq("")
-      expect(second_user.reload.email).to eq("")
-      expect(third_user.reload.email).to eq("")
-      expect(fourth_user.reload.email).not_to eq("")
+      expect(first_user.reload.email).to be_empty
+      expect(second_user.reload.email).to be_empty
+      expect(third_user.reload.email).to be_empty
+      expect(fourth_user.reload.email).to be_empty
+      expect(admin_user.reload.email).not_to be_empty
     end
   end
 
@@ -85,10 +87,13 @@ describe Decidim::Initiatives::EndOfMandateArchivist do
     let!(:fourth_user) { create(:user, organization: organization) }
     let!(:fourth_authorization) { create(:authorization, name: "dummy_authorization_handler", user: fourth_user, metadata: { nickname: fourth_user.nickname }, granted_at: 2.seconds.ago) }
 
-    it "deletes authors and committee_members metadata authorization" do
+    let!(:admin_user) { create(:user, :admin, organization: organization) }
+    let!(:admin_authorization) { create(:authorization, name: "dummy_authorization_handler", user: admin_user, metadata: { nickname: admin_user.nickname }, granted_at: 2.seconds.ago) }
+
+    it "deletes authors and committee_members metadata authorization, except for admin" do
       expect do
         archivist.call
-      end.to change(Decidim::Authorization.all, :count).from(4).to(1)
+      end.to change(Decidim::Authorization.all, :count).from(5).to(1)
     end
   end
 

--- a/decidim-initiatives/spec/lib/decidim/initiatives/end_of_mandate_archivist_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/initiatives/end_of_mandate_archivist_spec.rb
@@ -69,6 +69,14 @@ describe Decidim::Initiatives::EndOfMandateArchivist do
       expect(fourth_user.reload.email).to be_empty
       expect(admin_user.reload.email).not_to be_empty
     end
+
+    it "doesn't send email to admin" do
+      allow(Decidim::DestroyAccountMailer).to receive(:notify).with(admin_user).and_call_original
+      archivist.call
+
+      expect(Decidim::DestroyAccountMailer)
+        .not_to have_received(:notify)
+    end
   end
 
   describe "#delete_authorizations" do


### PR DESCRIPTION
#### :tophat: What? Why?

When archiving : 
+ users should be deleted except admins
+ Admin should not receive email notification on DestroyAccount
+ Fix Flaky on CI