### PR TITLE
Fix initiative check published tasks to ignore archived item

### DIFF
--- a/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
@@ -10,6 +10,7 @@ module Decidim
       def query
         Decidim::Initiative
           .includes(:scoped_type)
+          .not_archived
           .where(state: "published")
           .where(signature_type: "online")
           .where("signature_end_date < ?", Date.current)


### PR DESCRIPTION
#### :tophat: What? Why?

The `check_published` tasks (which _reject_ initiatives without enough support after the signature end date) should not have effect on the archived initiatives.


