### PR TITLE
fix: hide register button in conference when no registration types

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
@@ -19,7 +19,7 @@
       <% if current_participatory_space.registrations_enabled? %>
         <% if current_participatory_space.has_registration_for?(current_user) %>
           <%= link_to t("layouts.decidim.conference_hero.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
-        <% else %>
+        <% elsif current_participatory_space.registration_types.present? %>
           <%= link_to t("layouts.decidim.conference_hero.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
         <% end %>
       <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -85,7 +85,7 @@ edit_link(
 
     <% if current_participatory_space.registrations_enabled? %>
       <section class="content-block">
-        <% if current_participatory_space.registration_types.present?%>
+        <% if current_participatory_space.registration_types.present? %>
           <h2 class="h2 decorator"><%= t("decidim.conferences.conferences.show.register") %></h2>
         <% end %>
         <% if current_user.present? %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -58,7 +58,7 @@ edit_link(
         <% if current_participatory_space.registrations_enabled? %>
           <% if current_participatory_space.has_registration_for?(current_user) %>
             <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
-          <% else %>
+          <% elsif current_participatory_space.registration_types.present? %>
             <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
           <% end %>
         <% end %>
@@ -85,7 +85,9 @@ edit_link(
 
     <% if current_participatory_space.registrations_enabled? %>
       <section class="content-block">
-        <h2 class="h2 decorator"><%= t("decidim.conferences.conferences.show.register") %></h2>
+        <% if current_participatory_space.registration_types.present?%>
+          <h2 class="h2 decorator"><%= t("decidim.conferences.conferences.show.register") %></h2>
+        <% end %>
         <% if current_user.present? %>
           <div class="conference__box">
             <div>
@@ -96,7 +98,7 @@ edit_link(
             <div>
               <% if current_participatory_space.has_registration_for?(current_user) %>
                 <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
-              <% else %>
+              <% elsif current_participatory_space.registration_types.present? %>
                 <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
               <% end %>
             </div>

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -128,15 +128,24 @@ describe "Conference registrations" do
       end
     end
 
-    context "and there is no registrations types" do
-      let!(:registration_types) { [] }
-
+    context "and there is registrations types" do
       it "allows to register" do
         visit_conference
         within ".conference__hero" do
           expect(page).to have_content "Register"
           click_on "Register"
-          expect(page).to have_content "CHOOSE YOUR REGISTRATION OPTION:"
+        end
+        expect(page).to have_content "CHOOSE YOUR REGISTRATION OPTION:"
+      end
+    end
+
+    context "and there is no registrations types" do
+      let(:registration_types) { [] }
+
+      it "does not show register button" do
+        visit_conference
+        within ".conference__hero" do
+          expect(page).to have_no_content "Register"
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?


#### :pushpin: Related Issues
- Related to #?
- Fixes #12704

#### :clipboard: Subtasks

1. go to admin dashboard
2. create a conference with registrations enabled and without registration_types
3. publish the conference
4. click on See conference button
5. there is no register button

co-author @BarbaraOliveira13 
### :camera: Screenshots (optional)
![Description](URL)
