### PR TITLE
Update context sentences in system test

### DIFF
--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -128,7 +128,7 @@ describe "Conference registrations" do
       end
     end
 
-    context "and there is published registrations types" do
+    context "and there are published registrations types" do
       it "allows to register" do
         visit_conference
         within ".conference__hero" do
@@ -142,12 +142,12 @@ describe "Conference registrations" do
       end
     end
 
-    context "and there is unpublished registrations types" do
+    context "and there are unpublished registrations types" do
       let!(:registration_types) do
         create_list(:registration_type, 5, :unpublished, conference:)
       end
 
-      it "does not show register button" do
+      it "does not show the register button" do
         visit_conference
         within ".conference__hero" do
           expect(page).to have_no_content "Register"
@@ -158,10 +158,10 @@ describe "Conference registrations" do
       end
     end
 
-    context "and there is no registrations types" do
+    context "and there are no registrations types" do
       let(:registration_types) { [] }
 
-      it "does not show register button" do
+      it "does not show the register button" do
         visit_conference
         within ".conference__hero" do
           expect(page).to have_no_content "Register"


### PR DESCRIPTION
🎩 What? Why?
Fix conferences registers when the registration types are empty and registration is enabled

📌 Related Issues
Link your PR to an issue

Related to #?
Fixes Conference registering is broken when no registration_types  #12704
Testing
go to admin dashboard
create a conference with registrations enabled and without registration_types
publish the conference
click on See conference button
click on Register button
can access to the registration page
📷 Screenshots
Please add screenshots of the changes you are proposing
Description

co-writter: @BarbaraOliveira13 

♥️ Thank you!