### PR TITLE
Fix/deleted users follow

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -13,6 +13,32 @@ module Decidim
           }
         }
       end
+
+      def run_after_hooks
+        # A hook to destroy the follows of user on private non transparent assembly and its children
+        # when private user is destroyed
+        return unless resource.privatable_to_type == "Decidim::Assembly"
+
+        assembly = Decidim::Assembly.find(resource.privatable_to_id)
+        return unless assembly.private_space == true && assembly.is_transparent == false
+
+        user = Decidim::User.find(resource.decidim_user_id)
+        ids = []
+        ids << Decidim::Follow.where(user:)
+                              .where(decidim_followable_type: "Decidim::Assembly")
+                              .where(decidim_followable_id: assembly.id)
+                              .first.id
+        children_ids = Decidim::Follow.where(user:)
+                                      .select { |follow| find_object(follow).respond_to?("decidim_component_id") }
+                                      .select { |follow| assembly.components.ids.include?(find_object(follow).decidim_component_id) }
+                                      .map(&:id)
+        ids << children_ids
+        Decidim::Follow.where(user:).where(id: ids.flatten).destroy_all if ids.present?
+      end
+
+      def find_object(follow)
+        follow.decidim_followable_type.constantize.find(follow.decidim_followable_id)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When a private user of a non transparent private assembly is deleted, its follows of assembly or its components are also deleted

#### :pushpin: Related Issues
- Fixes issue 12851


#### Testing

1. As an admin, edit an assembly and make it  private and non transparent (in the Visibility tab)
2. If there is no meeting, add a meeting component to it
3. Invite "user@example.org" as a private user of this assembly
4. As a user, access to the private assembly and click on the follow button
5. Go to the meeting inside assembly and follow it
6. As an admin, delete the private user "user@example.org"
7. As a user, check that you can’t access to the private assembly anymore
8. As an admin, add again "user@example.org" as a private user
9. As a user, go to the assembly and see that your follow has been deleted
10. As a user, go to the meeting and see that your follow has also been deleted


:hearts: Thank you!
