### PR TITLE
Fix deleted users follow

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -38,10 +38,10 @@ module Decidim
 
       def find_children_follows_ids(follows, space)
         follows.map do |follow|
-          object = find_object_followed(follow) || nil
+          object = find_object_followed(follow).presence
           next unless object.respond_to?("decidim_component_id")
           return follow.id if space.components.ids.include?(object.decidim_component_id)
-        end
+        end.compact
       end
 
       def find_object_followed(follow)

--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -13,6 +13,32 @@ module Decidim
           }
         }
       end
+
+      def run_after_hooks
+        # A hook to destroy the follows of user on private non transparent assembly and its children
+        # when private user is destroyed
+        return unless resource.privatable_to_type == "Decidim::Assembly"
+
+        assembly = Decidim::Assembly.find(resource.privatable_to_id)
+        return unless assembly.private_space == true && assembly.is_transparent == false
+
+        user = Decidim::User.find(resource.decidim_user_id)
+        ids = []
+        ids << Decidim::Follow.where(user:)
+                              .where(decidim_followable_type: "Decidim::Assembly")
+                              .where(decidim_followable_id: assembly.id)
+                              .first.id
+        children_ids = Decidim::Follow.where(user:)
+                                      .select { |follow| find_object(follow).respond_to?("decidim_component_id") }
+                                      .select { |follow| assembly.components.ids.include?(find_object(follow).decidim_component_id) }
+                                      .map(&:id)
+        ids << children_ids
+        Decidim::Follow.where(user:).where(id: ids.flatten).destroy_all if ids.present?
+      end
+
+      def find_object(follow)
+        follow.decidim_followable_type.constantize.find(follow.decidim_followable_id)
+      end
     end
   end
 end

--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -28,11 +28,12 @@ module Decidim
         follows = Decidim::Follow.where(user:)
         ids << follows.where(decidim_followable_type: resource.privatable_to_type)
                       .where(decidim_followable_id: space.id)
-                      .first.id
+                      &.first&.id
         children_ids = follows.select { |follow| find_object_followed(follow).respond_to?("decidim_component_id") }
                               .select { |follow| space.components.ids.include?(find_object_followed(follow).decidim_component_id) }
-                              .map(&:id)
+                              &.map(&:id)
         ids << children_ids
+
         follows.where(id: ids.flatten).destroy_all if ids.present?
       end
 

--- a/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/meetings/test/factories"
 
 module Decidim::Admin
   describe DestroyParticipatorySpacePrivateUser do
@@ -55,10 +54,12 @@ module Decidim::Admin
 
         context "and user follows meeting belonging to assembly" do
           let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
-          let(:meeting) { create(:meeting, component: meetings_component) }
-          let!(:second_follow) { create(:follow, followable: meeting, user: normal_user) }
 
           it "destroys all follows" do
+            meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                         description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                         component: meetings_component, author: user)
+            create(:follow, followable: meeting, user: normal_user)
             expect(Decidim::Follow.where(user: normal_user).count).to eq(2)
             subject.call
             expect(Decidim::Follow.where(user: normal_user).count).to eq(0)
@@ -77,19 +78,23 @@ module Decidim::Admin
 
         it "destroys the follow" do
           expect(Decidim::Follow.where(user: normal_user).count).to eq(1)
-          subject.call
-          expect(Decidim::Follow.where(user: normal_user).count).to eq(0)
+          expect do
+            subject.call
+          end.to change(Decidim::Follow, :count).by(-1)
         end
 
         context "and user follows meeting belonging to process" do
           let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
-          let(:meeting) { create(:meeting, component: meetings_component) }
-          let!(:second_follow) { create(:follow, followable: meeting, user: normal_user) }
 
           it "destroys all follows" do
+            meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                         description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                         component: meetings_component, author: user)
+            create(:follow, followable: meeting, user: normal_user)
             expect(Decidim::Follow.where(user: normal_user).count).to eq(2)
-            subject.call
-            expect(Decidim::Follow.where(user: normal_user).count).to eq(0)
+            expect do
+              subject.call
+            end.to change(Decidim::Follow, :count).by(-2)
           end
         end
       end

--- a/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_participatory_space_private_user_spec.rb
@@ -48,8 +48,9 @@ module Decidim::Admin
 
         it "destroys the follow" do
           expect(Decidim::Follow.where(user: normal_user).count).to eq(1)
-          subject.call
-          expect(Decidim::Follow.where(user: normal_user).count).to eq(0)
+          expect do
+            subject.call
+          end.to change(Decidim::Follow, :count).by(-1)
         end
 
         context "and user follows meeting belonging to assembly" do
@@ -61,8 +62,9 @@ module Decidim::Admin
                                                          component: meetings_component, author: user)
             create(:follow, followable: meeting, user: normal_user)
             expect(Decidim::Follow.where(user: normal_user).count).to eq(2)
-            subject.call
-            expect(Decidim::Follow.where(user: normal_user).count).to eq(0)
+            expect do
+              subject.call
+            end.to change(Decidim::Follow, :count).by(-2)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When a private user of a non transparent private assembly (or a private participatory process) is deleted, the follows of assembly or its components are also deleted

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes issue 12851

#### Testing

1. As an admin, edit an assembly and make it private and non transparent (in the Visibility tab)
2. If there is no meeting, add a meeting component to it
3. Invite "[user@example.org](mailto:user@example.org)" as a private user of this assembly
4. As a user, access to the private assembly and click on the follow button
5. Go to the meeting inside assembly and follow it
6. As an admin, delete the private user "[user@example.org](mailto:user@example.org)"
7. As a user, check that you can’t access to the private assembly anymore
8. As an admin, add again "[user@example.org](mailto:user@example.org)" as a private user
9. As a user, go to the assembly and see that your follow has been deleted
10. As a user, go to the meeting and see that your follow has also been deleted
11. 

:hearts: Thank you!
