### PR TITLE
Fix add task to delete users follow

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,11 @@ You can read more about this change on PR [#12616](https://github.com/decidim/de
 
 These are one time actions that need to be done after the code is updated in the production database.
 
+To delete the follows of ex private users of non transparent assemblies or processes, run from decidim-admin
+```console
+bundle exec rake decidim:upgrade:fix_deleted_private_follows
+```
+
 ### 3.1. CarrierWave removal
 
 Back in Decidim 0.25 we have added ActiveStorage (via [\#7902](https://github.com/decidim/decidim/pull/7902)) as main uploader instead of CarrierWave.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,7 @@ You can read more about this change on PR [#12616](https://github.com/decidim/de
 These are one time actions that need to be done after the code is updated in the production database.
 
 To delete the follows of ex private users of non transparent assemblies or processes, run from decidim-admin
+
 ```console
 bundle exec rake decidim:upgrade:fix_deleted_private_follows
 ```

--- a/decidim-admin/lib/tasks/delete_follows_of_ex_private_users_task.rake
+++ b/decidim-admin/lib/tasks/delete_follows_of_ex_private_users_task.rake
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :upgrade do
+    desc "Delete follows of ex private users"
+    task fix_deleted_private_follows: :environment do
+      def find_object(follow)
+        follow.decidim_followable_type.constantize.find(follow.decidim_followable_id)
+      end
+
+      def delete_unwanted_follows(model, elements, children_follows)
+        count = 0
+        p "begin deleting follows"
+        elements.each do |element|
+          # for each element, find their private users
+          private_users_ids = Decidim::ParticipatorySpacePrivateUser.where(privatable_to_id: element.id, privatable_to_type: model.to_s).pluck(:decidim_user_id)
+          # delete follows from non private users
+          direct_follows_to_delete = Decidim::Follow.where(followable: element.id, decidim_followable_type: model.to_s)
+                                                    .reject { |follow| private_users_ids.include?(follow.decidim_user_id) }
+          count += direct_follows_to_delete.size
+          direct_follows_to_delete.map { |follow| Decidim::Follow.delete(follow.id) }
+          # children of element
+          element_components_ids = element.components.ids
+          children_follows_to_delete = children_follows.select { |follow| element_components_ids.include?(find_object(follow).decidim_component_id) }
+                                                       .reject { |follow| private_users_ids.include?(follow.decidim_user_id) }
+          count += children_follows_to_delete.size
+          children_follows_to_delete.map { |follow| Decidim::Follow.delete(follow.id) }
+        end
+        p "#{count} follows have been deleted for #{model} and their children"
+      end
+      children_follows = Decidim::Follow.select { |follow| find_object(follow).respond_to?(:decidim_component_id) }
+      # find private non transparent assemblies
+      assemblies = Decidim::Assembly.where(private_space: true, is_transparent: false).published
+      # delete unwanted follows
+      delete_unwanted_follows(Decidim::Assembly, assemblies, children_follows)
+      # find private processes
+      processes = Decidim::ParticipatoryProcess.where(private_space: true).published
+      # delete unwanted follows
+      delete_unwanted_follows(Decidim::ParticipatoryProcess, processes, children_follows)
+    end
+  end
+end

--- a/decidim-admin/spec/lib/tasks/delete_follows_of_ex_private_users_task_spec.rb
+++ b/decidim-admin/spec/lib/tasks/delete_follows_of_ex_private_users_task_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:fix_deleted_private_follows", type: :task do
+  let(:task) { Rake::Task["decidim:upgrade:fix_deleted_private_follows"] }
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:second_user) { create(:user, :confirmed, organization:) }
+
+  it "preloads the Rails environment" do
+    expect(task.prerequisites).to include "environment"
+  end
+
+  context "when assembly is private and non transparent" do
+    context "and assembly has one private user" do
+      let(:assembly) { create(:assembly, :private, :published, :opaque, organization: user.organization) }
+      let!(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
+      let!(:participatory_space_private_user) { create(:participatory_space_private_user, user:, privatable_to: assembly) }
+      let!(:follow) { create(:follow, user:, followable: assembly) }
+      let!(:unwanted_follow) { create(:follow, user: second_user, followable: assembly) }
+
+      it "deletes follows of non private users" do
+        meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                     description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                     component: meetings_component, author: user)
+        create(:follow, followable: meeting, user:)
+        create(:follow, followable: meeting, user: second_user)
+        # we have 2 unwanted follows, one for assembly, and one for a "child" meeting
+        expect do
+          task.execute
+        end.to change(Decidim::Follow, :count).by(-2)
+      end
+    end
+  end
+
+  context "when process is private" do
+    context "and process has one private user" do
+      let(:participatory_process) { create(:participatory_process, :private, :published, organization: user.organization) }
+      let!(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
+      let!(:participatory_space_private_user) { create(:participatory_space_private_user, user:, privatable_to: participatory_process) }
+      let!(:follow) { create(:follow, user:, followable: participatory_process) }
+      let!(:unwanted_follow) { create(:follow, user: second_user, followable: participatory_process) }
+
+      it "deletes follows of non private users" do
+        meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                     description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                     component: meetings_component, author: user)
+        create(:follow, followable: meeting, user:)
+        create(:follow, followable: meeting, user: second_user)
+        # we have 2 unwanted follows, one for process, and one for a "child" meeting
+        expect do
+          task.execute
+        end.to change(Decidim::Follow, :count).by(-2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Add a rake task to delete existing unwanted follows of ex-private users from non transparent private assemblies or private processes


#### Testing
1. As an admin, go to an existing assembly with meetings and update assembly to be private and non-transparent (or create one)
2. In rails console, add a follow for the assembly and one for a child meeting from a user that is not a private user
ex: Decidim::Follow.create!(decidim_user_id: non_private_user_id, decidim_followable_type: "Decidim::Meetings::Meeting", decidim_followable_id: meeting_from_private_assembly_id)
4. In terminal, moove to development_app and run bundle exec rake decidim:upgrade:fix_deleted_private_follows
5. See that follows added are deleted


:hearts: Thank you!
