### PR TITLE
Fix password for zip of personal data

### DIFF
--- a/decidim-core/app/services/decidim/download_your_data_exporter.rb
+++ b/decidim-core/app/services/decidim/download_your_data_exporter.rb
@@ -43,7 +43,7 @@ module Decidim
 
     def data
       enc = Zip::TraditionalEncrypter.new(@password)
-      buffer = Zip::OutputStream.write_buffer(::StringIO.new(""), enc) do |out|
+      buffer = Zip::OutputStream.write_buffer(::StringIO.new("".dup), enc) do |out|
         user_data, attachments = data_for(@user, @export_format)
 
         add_user_data_to_zip_stream(out, user_data)

--- a/decidim-core/app/services/decidim/download_your_data_exporter.rb
+++ b/decidim-core/app/services/decidim/download_your_data_exporter.rb
@@ -32,7 +32,7 @@ module Decidim
       dirname = File.dirname(@path)
       FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
       File.open(@path, "wb") do |file|
-        SevenZipRuby::Writer.open(file, password: @password) do |szw|
+        SevenZipRuby::Writer.open(file) do |szw|
           szw.header_encryption = true
           szw.add_data(data, ZIP_FILE_NAME)
         end
@@ -42,7 +42,8 @@ module Decidim
     private
 
     def data
-      buffer = Zip::OutputStream.write_buffer do |out|
+      enc = Zip::TraditionalEncrypter.new(@password)
+      buffer = Zip::OutputStream.write_buffer(::StringIO.new(""), enc) do |out|
         user_data, attachments = data_for(@user, @export_format)
 
         add_user_data_to_zip_stream(out, user_data)


### PR DESCRIPTION
#### :tophat: What? Why?
When I load my personal data, I receive an email with a zip file and a password to open it. The password is now functional, I can open the file and access my personal data.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to issue https://github.com/decidim/decidim/issues/13037
- Notion card https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=54547f3ef83a4d1e806cdeee4a43cf60&pm=c

#### Testing

1. After login, go to "My account"
2. Go to "My data"
3. Click on "Request data"
4. Go to you mail and download the zip file
5. Open the zip file and enter the password provided in the mail
6. See that you open the zip and access to your personal data file

:hearts: Thank you!
