### PR TITLE
Fix delete users follow with job

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -21,32 +21,12 @@ module Decidim
 
         return unless space.private_space?
 
-        return if space.respond_to?("is_transparent") && space.is_transparent?
+        return if space.respond_to?(:is_transparent) && space.is_transparent?
 
-        ids = []
-        follows = Decidim::Follow.where(user: resource.decidim_user_id)
-        ids << find_space_follow_id(follows, resource, space)
-        ids << find_children_follows_ids(follows, space)
-        follows.where(id: ids.flatten.compact).destroy_all if ids.present?
-      end
+        decidim_user_id = resource.decidim_user_id
+        privatable_to_type = resource.privatable_to_type
 
-      def find_space_follow_id(follows, resource, space)
-        follows.where(decidim_followable_type: resource.privatable_to_type)
-               .where(decidim_followable_id: space.id)
-               &.first&.id
-      end
-
-      def find_children_follows_ids(follows, space)
-        follows.map do |follow|
-          object = find_object_followed(follow).presence
-          next unless object.respond_to?("decidim_component_id")
-
-          follow.id if space.components.ids.include?(object.decidim_component_id)
-        end
-      end
-
-      def find_object_followed(follow)
-        follow.decidim_followable_type.constantize.find(follow.decidim_followable_id)
+        DestroyPrivateUsersFollowsJob.perform_later(decidim_user_id, privatable_to_type, space)
       end
     end
   end

--- a/decidim-admin/app/jobs/decidim/admin/destroy_private_users_follows_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/destroy_private_users_follows_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Custom ApplicationJob scoped to the admin panel.
+    #
+    class DestroyPrivateUsersFollowsJob < ApplicationJob
+      queue_as :default
+
+      def perform(decidim_user_id, privatable_to_type, space)
+        follows = Decidim::Follow.where(user: decidim_user_id)
+        destroy_space_follow(follows, privatable_to_type, space)
+        destroy_children_follows(follows, space)
+      end
+
+      def destroy_space_follow(follows, privatable_to_type, space)
+        follows.where(decidim_followable_type: privatable_to_type)
+               .where(decidim_followable_id: space.id).destroy_all
+      end
+
+      def destroy_children_follows(follows, space)
+        follows.map do |follow|
+          object = find_object_followed(follow).presence
+          next unless object.respond_to?("decidim_component_id")
+
+          follow.destroy if space.component_ids.include?(object.decidim_component_id)
+        end
+      end
+
+      def find_object_followed(follow)
+        follow.decidim_followable_type.constantize.find(follow.decidim_followable_id)
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/jobs/destroy_private_users_follows_job_spec.rb
+++ b/decidim-admin/spec/jobs/destroy_private_users_follows_job_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe DestroyPrivateUsersFollowsJob do
+      let(:organization) { create(:organization) }
+      let(:user) { create(:user, :admin, :confirmed, organization:) }
+      let(:participatory_space_private_user) { create(:participatory_space_private_user, user:) }
+
+      context "when assembly is not transparent and user follows assembly and one meeting belonging to assembly" do
+        let(:normal_user) { create(:user, organization:) }
+        let(:assembly) { create(:assembly, :private, :opaque, :published, organization: user.organization) }
+        let!(:participatory_space_private_user) { create(:participatory_space_private_user, user: normal_user, privatable_to: assembly) }
+        let!(:follow) { create(:follow, followable: assembly, user: normal_user) }
+        let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
+
+        it "destroys 2 follows" do
+          meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                       description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                       component: meetings_component, author: user)
+          create(:follow, followable: meeting, user: normal_user)
+
+          expect(Decidim::Follow.where(user: normal_user).count).to eq(2)
+          expect do
+            described_class.perform_now(normal_user.id, "Decidim::Assembly", assembly)
+          end.to change(Decidim::Follow, :count).by(-2)
+        end
+      end
+
+      context "when participatory process is private" do
+        let(:normal_user) { create(:user, organization:) }
+        let(:participatory_process) { create(:participatory_process, :private, :published, organization: user.organization) }
+        let!(:participatory_space_private_user) { create(:participatory_space_private_user, user: normal_user, privatable_to: participatory_process) }
+
+        context "and user follows process and follows meeting belonging to process" do
+          let!(:follow) { create(:follow, followable: participatory_process, user: normal_user) }
+          let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
+
+          it "destroys 2 follows" do
+            meeting = Decidim::Meetings::Meeting.create!(title: generate_localized_title(:meeting_title, skip_injection: false),
+                                                         description: generate_localized_description(:meeting_description, skip_injection: false),
+                                                         component: meetings_component, author: user)
+            create(:follow, followable: meeting, user: normal_user)
+
+            expect(Decidim::Follow.where(user: normal_user).count).to eq(2)
+            expect do
+              described_class.perform_now(normal_user.id, "Decidim::ParticipatoryProcess", participatory_process)
+            end.to change(Decidim::Follow, :count).by(-2)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Update the delete of private users follow after review from decidim

#### :pushpin: Related Issues
- Related to this PR on decidim => https://github.com/decidim/decidim/pull/12878

#### Testing

1. As an admin, edit an assembly and make it private and non transparent (in the Visibility tab)
2. If there is no meeting, add a meeting component to it
3. Invite "[user@example.org](mailto:user@example.org)" as a private user of this assembly
4. As a user, access to the private assembly and click on the follow button
5. Go to the meeting inside assembly and follow it
6. As an admin, delete the private user "[user@example.org](mailto:user@example.org)"
7. As a user, check that you can’t access to the private assembly anymore
8. As an admin, add again "[user@example.org](mailto:user@example.org)" as a private user
9. As a user, go to the assembly and see that your follow has been deleted
10. As a user, go to the meeting and see that your follow has also been deleted

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ X] Add tests
- [ ] Another subtask


