### PR TITLE
Change cookies link to ensure RGAA

### DIFF
--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -3,6 +3,6 @@
     <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
   </li>
   <li>
-    <a href="#" data-dialog-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>
+    <button data-dialog-open="dc-modal" class="underline"><%= t("layouts.decidim.footer.data_consent_settings") %></button>
   </li>
 </ul>


### PR DESCRIPTION
### Describe the bug

The link for "cookies settings" in the footer has an inappropriate role attribute for accessibility. This prevents proper functionality for keyboard users and assistive technologies as VoiceOver, NVDA...

More precisely, when it was a link, we couldn't interact with it using the Spacebar and it wasn't identified as it is, a button that permits to open a modal (not a link that permits to navigate somewhere else)

### Expected behavior to ensure RGAA

- The "cookies settings" link should have the role="button" attribute
- It should be possible to open the modal using the <SPACE> keyboard key

### To Reproduce

1. On the homepage, go to the footer
3. Locate "cookies settings" link
4. **As keyboard users**: attempt to open the modal with keyboard navigation: `<ENTER> + <TAB> + <SPACE>`
5. **For assistive technologies**: inspect the HTML and verify that the <a> tag don't have `role="button"` attribute

#### :clipboard: Subtasks
- [x] Change link to button

