### PR TITLE
Change logos to match accessibility

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,5 +1,5 @@
 <% if organization %>
-  <%= link_to decidim.root_url(host: organization.host) do %>
+  <%= link_to decidim.root_url(host: organization.host), "aria-label": t("front_page_link", scope: "decidim.accessibility") do %>
     <% if organization.logo.attached? %>
       <%= image_tag organization.attached_uploader(:logo).variant_url(:medium), alt: t("logo", scope: "decidim.accessibility", organization: current_organization_name) %>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,5 +1,5 @@
 <% if organization %>
-  <%= link_to decidim.root_url(host: organization.host), "aria-label": t("front_page_link", scope: "decidim.accessibility") do %>
+  <%= link_to decidim.root_url(host: organization.host) do %>
     <% if organization.logo.attached? %>
       <%= image_tag organization.attached_uploader(:logo).variant_url(:medium), alt: t("logo", scope: "decidim.accessibility", organization: current_organization_name) %>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
@@ -1,6 +1,6 @@
 <% if current_organization.official_img_footer.attached? %>
   <%= link_to current_organization.official_url, class: "block mb-6" do %>
-    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: current_organization_name, class: "max-h-16" %>
+    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: t("logo", scope: "decidim.accessibility", organization: current_organization_name), class: "max-h-16" %>
   <% end %>
 <% end %>
 <div class="text-sm text-white prose">


### PR DESCRIPTION
#### :tophat: What? Why?

This PR change logos from footer and header to be RGAA compliant, as the alt of the footer wasn't on the last changes from the header, and the header had an aria-label which wasn't accessible because hid the alt of the logo.

#### Testing
*Describe the best way to test or validate your PR.*
- Go to back office
- Go to organization settings
- Add a logo to your application and a footer logo
- Go back to the main page
- Make sure they have the same alt
- Make sure the aria-label has been deleted

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
