### PR TITLE
Add missing locale blocking the JS

### DIFF
--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -2044,7 +2044,7 @@ fr:
     buttons:
       close: Fermer
       reset: Réinitialiser
-      select:
+      select: Sélectionner
     formats:
       day_of_month: "%b %d"
       day_of_week: "%a"


### PR DESCRIPTION
#### :tophat: What? Why?

This missing locale was blocking the loading of the text editor on the participatory processes


#### :pushpin: Related Issues
- Related to [🐛 BUG Problème affichage éditeur de texte sur la plateforme en 0.29 ](https://opensourcepolitics.odoo.com/web#id=3496&cids=1&menu_id=330&action=456&active_id=151&model=project.task&view_type=form)

#### How to test 

- First of all you may add the french locale as an available locale !
- Create a development app
- Go through the `config/decidim.rb` in your development_app and change line 17 by `config.available_locales = %w(en ca es fr)`
- Execute `bundle exec rails c` (Warning if you're using Sprint you may have to execute `DISABLE_SPRING=true bundle exec rails c`
- Execute those lines in your rails console (follow the order otherwise it may not work)
```
org = Decidim::Organization.first
org.available_locales+=["fr"]
org.save!
exit
```

You're all set now so next step : 

- Log as an admin
- Navigate through the Back Office
- Try to access processes and to create a new one or update an existing one
- Make sure you're on "french" locale
- Make sure that the editor is displayed correctly and that you can freely submit your new or edit your existing process.

#### :clipboard: Subtasks
- [x] Add missing locale (key was there but content was empty so it made the i18n.js create_dictionary function crash)