### PR TITLE
Fix(rgaa): Nav attributes and aria-current for accessibility compliance

### DIFF
--- a/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
@@ -50,7 +50,7 @@ describe Decidim::Accountability::DiffRenderer, versioning: true do
     it "generates the labels correctly" do
       expected_labels = {
         description_ca: "Description (Català)",
-        description_machine_translations_es: "Description (automatic translation in Castellano)",
+        description_machine_translations_es: "Description (traducción automática a Castellano)",
         progress: "Progress",
         start_date: "Start date",
         title_en: "Title (English)",

--- a/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
@@ -50,7 +50,7 @@ describe Decidim::Accountability::DiffRenderer, versioning: true do
     it "generates the labels correctly" do
       expected_labels = {
         description_ca: "Description (Català)",
-        description_machine_translations_es: "Description (traducción automática a Castellano)",
+        description_machine_translations_es: "Description (automatic translation in Castellano)",
         progress: "Progress",
         start_date: "Start date",
         title_en: "Title (English)",

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug) %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), aria_current: ("true"if page == sibling) %>
           </li>
         <% end %>
       </ul>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), aria_current: ("true"if page == sibling) %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), aria_current: (page == sibling).to_s %>
           </li>
         <% end %>
       </ul>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -10,7 +10,7 @@
   </header>
 
   <div class="vertical-tabs">
-    <nav role="navigation" aria-label="Sous menu - <%= translated_attribute(page.title) %>">
+    <nav role="navigation" aria-label="<%= i18n.t(".navigation.aria_label", title: translated_attribute(page.title)) %>">
       <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -10,7 +10,7 @@
   </header>
 
   <div class="vertical-tabs">
-    <nav>
+    <nav role="navigation" aria-label="Sous menu - <%= translated_attribute(page.title) %>">
       <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -10,8 +10,8 @@
   </header>
 
   <div class="vertical-tabs">
-    <nav role="navigation" aria-label="<%= i18n.t(".navigation.aria_label", title: translated_attribute(page.title)) %>">
-      <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
+    <nav role="navigation" aria-label="<%= I18n.t("layouts.decidim.navigation.aria_label", title: translated_attribute(page.title)) %>">
+    <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>
         </span>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2123,6 +2123,8 @@ en:
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       language_chooser:
         choose_language: Choose language
+      navigation:
+        aria_label: Navigation menu - %{title}
       notifications_dashboard:
         mark_all_as_read: Mark all as read
         mark_as_read: Mark as read


### PR DESCRIPTION
#### :tophat: What? 
Two parts:
1. Added dynamic aria-label attributes to navigation menus to provide better context for screen readers, improving compliance with WCAG [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)(Level A).
2. Added aria-current="true" to correctly mark active links within navigation menus, addressing WCAG [2.4.8 - Location](https://www.w3.org/WAI/WCAG21/Understanding/location.html) (Level AAA).

#### :tophat: Why?
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.

#### :pushpin: Related Issues
- Related to: WCAG 1.3.1, 2.4.8, and RGAA 9.2/10.9.
- Fixes #?

#### :clipboard: Subtasks
- [x] Update <nav> tags to include dynamic aria-label attributes, addressing WCAG [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
- [x]  Add aria-current="true" to active links in navigation menus to comply with WCAG [2.4.8 - Location](https://www.w3.org/WAI/WCAG21/Understanding/location.html).
- [x] Verify the changes comply with RGAA best practices.
- [ ] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="1187" alt="Capture d’écran 2024-12-18 à 17 16 17" src="https://github.com/user-attachments/assets/d57a60d0-1c18-44f5-97d1-d7b7132f869b" />

