### PR TITLE
Fix wcag search filters navigation

### DIFF
--- a/decidim-core/app/views/decidim/searches/_count.html.erb
+++ b/decidim-core/app/views/decidim/searches/_count.html.erb
@@ -15,6 +15,6 @@
   <% end %>
 </div>
 
-<h1 class="h3 decorator mb-10 md:my-10">
+<h1 id="search-results-title" class="h3 decorator mb-10 md:my-10">
   <%= t("decidim.search.results_found_for_term", count: @results_count, term:) %>
 </h1>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,7 +1,4 @@
-<nav role="navigation" aria-labelledby="filters-title">
-  <h1 id="filters-title" class="sr-only">
-    <%= t("decidim.searches.filters.title") %>
-  </h1>
+<nav role="navigation" aria-labelledby="proposals-count">
   <div class="filter-container search__filter">
     <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
       <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,4 +1,4 @@
-<nav role="navigation" aria-labelledby="proposals-count">
+<nav role="navigation" aria-labelledby="search-results-title">
   <div class="filter-container search__filter">
     <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
       <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,44 +1,49 @@
-<div class="filter-container search__filter">
-  <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
-    <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>
-    <% @blocks.each do |elements| %>
-      <% elements.each do |type, results| %>
-        <%= content_tag :span, class: "#{"is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
-          <span><%= searchable_resource_human_name(type) %></span>
+<nav role="navigation" aria-labelledby="filters-title">
+  <h1 id="filters-title" class="sr-only">
+    <%= t("decidim.searches.filters.title", default: "Search filters") %>
+  </h1>
+  <div class="filter-container search__filter">
+    <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
+      <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>
+      <% @blocks.each do |elements| %>
+        <% elements.each do |type, results| %>
+          <%= content_tag :span, class: "#{"is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
+            <span><%= searchable_resource_human_name(type) %></span>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-    <%= icon "arrow-down-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
-    <%= icon "arrow-up-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
-  </button>
-  <div id="dropdown-menu-search" aria-hidden="true">
-    <div>
-      <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}" do %>
-        <%= resource_type_icon("all") %>
-        <span><%= t("all", scope: "decidim.searches.filters.state") %></span>
-        <span class="label ml-auto"><%= @results_count %></span>
-      <% end %>
-    </div>
-    <% @blocks.each do |elements| %>
+      <%= icon "arrow-down-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
+      <%= icon "arrow-up-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
+    </button>
+    <div id="dropdown-menu-search" aria-hidden="true">
       <div>
-        <% elements.each do |type, results| %>
-          <div>
-            <% if results[:count].positive? %>
-              <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
-                <%= resource_type_icon(type) %>
-                <span><%= searchable_resource_human_name(type) %></span>
-                <span class="label ml-auto"><%= results[:count] %></span>
-              <% end %>
-            <% else %>
-              <%= content_tag :div, class: "filter#{" is-empty" if results[:count].zero?}" do %>
-                <%= resource_type_icon(type) %>
-                <span><%= searchable_resource_human_name(type) %></span>
-                <span class="label ml-auto"><%= results[:count] %></span>
-              <% end %>
-            <% end %>
-          </div>
+        <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}" do %>
+          <%= resource_type_icon("all") %>
+          <span><%= t("all", scope: "decidim.searches.filters.state") %></span>
+          <span class="label ml-auto"><%= @results_count %></span>
         <% end %>
       </div>
-    <% end %>
+      <% @blocks.each do |elements| %>
+        <div>
+          <% elements.each do |type, results| %>
+            <div>
+              <% if results[:count].positive? %>
+                <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
+                  <%= resource_type_icon(type) %>
+                  <span><%= searchable_resource_human_name(type) %></span>
+                  <span class="label ml-auto"><%= results[:count] %></span>
+                <% end %>
+              <% else %>
+                <%= content_tag :div, class: "filter#{" is-empty" if results[:count].zero?}" do %>
+                  <%= resource_type_icon(type) %>
+                  <span><%= searchable_resource_human_name(type) %></span>
+                  <span class="label ml-auto"><%= results[:count] %></span>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
-</div>
+</nav>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,6 +1,6 @@
 <nav role="navigation" aria-labelledby="filters-title">
   <h1 id="filters-title" class="sr-only">
-    <%= t("decidim.searches.filters.title", default: "Search filters") %>
+    <%= t("decidim.searches.filters.title") %>
   </h1>
   <div class="filter-container search__filter">
     <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1774,7 +1774,6 @@ en:
           all: All
           future: Future
           past: Past
-        title: Search filters
       filters_small_view:
         filter: Filter
         filter_and_search: Filter and search

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1774,7 +1774,7 @@ en:
           all: All
           future: Future
           past: Past
-        title: "Search filters"
+        title: Search filters
       filters_small_view:
         filter: Filter
         filter_and_search: Filter and search

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1774,6 +1774,7 @@ en:
           all: All
           future: Future
           past: Past
+        title: "Search filters"
       filters_small_view:
         filter: Filter
         filter_and_search: Filter and search


### PR DESCRIPTION
#### :tophat: What? 
Updated the search filters container to improve accessibility compliance. Changes include:
1. Add a `<nav>` element with `role="navigation"` to define the navigation region.
2. Add an `aria-labelledby` attribute referencing a hidden `<h1>` to programmatically name the navigation area for screen readers.

#### :tophat: Why?
These changes address accessibility concerns highlighted during the city of Lyon rgaa audit, and align with WCAG 2.1 standards:

### :link: WCAG References:
1. [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html): Ensures information and relationships are perceivable for assistive technologies.
2. [4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html): Provides programmatically determinable names and roles for interactive elements.

#### :tophat: Related to
[In grist, array Diagnostique Decidim, line 31](https://grist.simone-de-beauvoir.indiehosters.net/o/team-osp/7Mwbi3TEFVCs/Accessibilite-Lyon/p/5) 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry.
- [ ] If there's a new public field, add it to GraphQL API.
- [ ] Add documentation regarding the feature.
- [ ] Add/modify seeds.
- [ ] Add tests.
- [ ] Verify compliance with WCAG and visually validate changes in a local environment.

#### :camera: Screenshots (optional)
<img width="1499" alt="Capture d’écran 2024-12-23 à 15 59 00" src="https://github.com/user-attachments/assets/0d16038b-b4e8-4999-9c4d-345537a76559" />

---

