### PR TITLE
Fix wcag: aria-current

### DIFF
--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), aria_current: (page == sibling).to_s %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria_current": (page == sibling).to_s %>
           </li>
         <% end %>
       </ul>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug) %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), aria_current: (page == sibling).to_s %>
           </li>
         <% end %>
       </ul>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2207,6 +2207,8 @@ en:
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       language_chooser:
         choose_language: Choose language
+      navigation:
+        aria_label: Navigation menu- %{title}
       notifications_dashboard:
         mark_all_as_read: Mark all as read
         mark_as_read: Mark as read

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2207,8 +2207,6 @@ en:
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       language_chooser:
         choose_language: Choose language
-      navigation:
-        aria_label: Navigation menu- %{title}
       notifications_dashboard:
         mark_all_as_read: Mark all as read
         mark_as_read: Mark as read


### PR DESCRIPTION
#### :tophat: What? 
Added aria-current="true" to correctly mark active links within navigation menus, addressing WCAG [2.4.8 - Location](https://www.w3.org/WAI/WCAG21/Understanding/location.html) (Level AAA).

#### :tophat: Why?
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.

#### :pushpin: Related Issues
- Related to: WCAG [2.4.8 - Location](https://www.w3.org/WAI/WCAG21/Understanding/location.html)
- 
#### :clipboard: Subtasks
- [x]  Add aria-current="true" to active links in navigation menus to comply with WCAG [2.4.8 - Location](https://www.w3.org/WAI/WCAG21/Understanding/location.html).
- [x] Verify the changes comply with RGAA best practices.
- [ ] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="1187" alt="Capture d’écran 2024-12-18 à 17 16 17" src="https://github.com/user-attachments/assets/d57a60d0-1c18-44f5-97d1-d7b7132f869b" />

:hearts: Thank you!
