### PR TITLE
Fix WCAG add nav tag in proposals index

### DIFF
--- a/decidim-core/app/cells/decidim/participatory_space_dropdown_metadata/show.erb
+++ b/decidim-core/app/cells/decidim/participatory_space_dropdown_metadata/show.erb
@@ -3,7 +3,9 @@
     <%= render :metadata %>
     <%= cell "decidim/content_blocks/menu_breadcrumb_last_activity", model, hide_participatory_space: true %>
   </div>
-  <ul class="menu-bar__secondary-dropdown__menu">
-    <%= render :links %>
-  </ul>
+  <nav role="navigation" aria-label="Secondary menu">
+    <ul class="menu-bar__secondary-dropdown__menu">
+      <%= render :links %>
+    </ul>
+  </nav>
 </div>


### PR DESCRIPTION
🎩 What?
Wraps the menu-bar__secondary-dropdown__menu element in a <nav> tag with appropriate ARIA attributes, to ensure better semantic structure and improved accessibility.

🎩 Why?
This change addresses accessibility issues by aligning the markup with [WCAG 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html). It ensures that the menu is programmatically identified as navigation, providing better support for assistive technologies.

📌 Related Issues
WCAG Criterion: [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)

**Steps to Test**
1. Navigate to a paginated proposals index page (e.g., /processes/budget-participatif/f/1/proposals?page=2).
2. Inspect the HTML structure of the dropdown menu:
- The menu-bar__secondary-dropdown__menu is wrapped in a <nav> tag.
- The <nav> includes the attributes role="navigation" and aria-label.

#### :clipboard: Subtasks
- [x] Wrapped `menu-bar__secondary-dropdown__menu` in a `<nav>` tag
- [x] Added role="navigation" and aria-label="Secondary menu" to the <nav> tag.
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="1149" alt="Capture d’écran 2025-01-09 à 17 23 22" src="https://github.com/user-attachments/assets/5da86202-3b79-4ffb-a454-8ce838dd6000" />

**Additional context**
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.
