### PR TITLE
WCAG status messages when update filter

### DIFF
--- a/decidim-debates/app/views/decidim/debates/debates/_debates.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_debates.html.erb
@@ -1,7 +1,7 @@
 <% if debates.empty? %>
   <%= cell("decidim/announcement", params[:filter].present? ? t(".empty_filters") : t(".empty")) %>
 <% else %>
-  <h2 class="h5 md:h3 decorator"><%= t("debates_count", scope: "decidim.debates.debates.count", count: paginated_debates.total_count) %></h2>
+  <h2 class="h5 md:h3 decorator" aria-live="polite" aria-atomic="true"><%= t("debates_count", scope: "decidim.debates.debates.count", count: paginated_debates.total_count) %></h2>
 
   <%= order_selector available_orders, i18n_scope: "decidim.debates.debates.orders" %>
 

--- a/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
@@ -11,7 +11,7 @@
 <% if meetings.length.zero? %>
   <%= cell("decidim/announcement", t("decidim.meetings.meetings.meetings.no_meetings_warning"), callout_class: "warning" ) %>
 <% else %>
-  <h2 class="h5 md:h3 decorator"><%= t("meetings_count", scope: "decidim.meetings.meetings.count", count: meetings.total_count) %></h2>
+  <h2 class="h5 md:h3 decorator" aria-live="polite" aria-atomic="true"><%= t("meetings_count", scope: "decidim.meetings.meetings.count", count: meetings.total_count) %></h2>
 
   <%= cell("decidim/announcement", t("decidim.meetings.meetings.meetings.upcoming_meetings_warning"), callout_class: "warning" ) if @forced_past_meetings %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -8,7 +8,7 @@
   <%= cell("decidim/announcement", params[:filter].present? ? t(".empty_filters") : t(".empty")) %>
 <% else %>
   <div class="flex items-center justify-between">
-    <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.total_count) %></h2>
+    <h2 class="h5 md:h3 decorator" aria-live="polite" aria-atomic="true"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.total_count) %></h2>
     <div class="view-layout__links flex view_mode__links">
       <%= toggle_view_mode_link(@view_mode, "list", t("list_mode", scope: "decidim.proposals.proposals.index"), params) %>
       <%= toggle_view_mode_link(@view_mode, "grid", t("grid_mode", scope: "decidim.proposals.proposals.index"), params) %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_sortitions.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_sortitions.html.erb
@@ -1,5 +1,5 @@
 <% if @sortitions.any? %>
-  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.sortitions.sortitions.sortitions_count", count: @sortitions.total_count) %></h2>
+  <h2 class="h5 md:h3 decorator" aria-live="polite" aria-atomic="true"><%= t("count", scope: "decidim.sortitions.sortitions.sortitions_count", count: @sortitions.total_count) %></h2>
 
   <%= order_selector available_orders, i18n_scope: "decidim.sortitions.sortitions.orders" %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds `aria-live="polite"` and `aria-atomic="true"` attributes to the `h2` element displaying the number of results on the components index page: **proposals, debates, meetings & sortitions**. These attributes ensure that the updates to the number of results, are announced by screen readers when filters are applied.

#### :tophat: What? Why?
This change addresses accessibility issues related to [WCAG 4.1.3 - Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html). It ensures that screen readers announce the updated results count dynamically.

#### :pushpin: Related Issues
[Grist](https://grist.simone-de-beauvoir.indiehosters.net/o/team-osp/7Mwbi3TEFVCs/Accessibilite-Lyon/p/5#a1.s10.r24.c41) => _I manage to add the changes, in the others components related: debates, meetings & sortitions_
WCAG [4.1.3 - Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)

:clipboard: Steps to Test
1. Navigate to the proposals, debates, meetings or sortitions index page (e.g., /processes/budget-participatif/f/1/proposals).
2. Apply filters.
3. Verify with the inspector:
- aria-live="polite" and aria-atomic="true" are present in the `h2` element

### :camera: Screenshots (optional)
<img width="1396" alt="Capture d’écran 2025-01-20 à 15 57 55" src="https://github.com/user-attachments/assets/77a6d6bc-2038-4cd3-b926-f8ef84283593" />

**Additional context**
This issue was identified during an accessibility audit targeting compliance with RGAA and WCAG standards. The change ensures that users relying on assistive technologies are informed of updates in real time when filters are applied.