### PR TITLE
Fix WCAG explicit close button modal

### DIFF
--- a/decidim-core/app/helpers/decidim/modal_helper.rb
+++ b/decidim-core/app/helpers/decidim/modal_helper.rb
@@ -24,7 +24,7 @@ module Decidim
                    type: :button,
                    data: { dialog_close: opts[:id] || "", dialog_closable: "" },
                    "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal"),
-                   "aria-describedly": "dialog-title-#{opts[:id]}"
+                   "aria-describedby": "dialog-title-#{opts[:id]}"
                  )
                end
 

--- a/decidim-core/app/helpers/decidim/modal_helper.rb
+++ b/decidim-core/app/helpers/decidim/modal_helper.rb
@@ -23,7 +23,8 @@ module Decidim
                    "&times".html_safe,
                    type: :button,
                    data: { dialog_close: opts[:id] || "", dialog_closable: "" },
-                   "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal")
+                   "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal"),
+                   "aria-describedly": "dialog-title-#{opts[:id]}"
                  )
                end
 

--- a/decidim-core/app/helpers/decidim/modal_helper.rb
+++ b/decidim-core/app/helpers/decidim/modal_helper.rb
@@ -24,7 +24,7 @@ module Decidim
                    type: :button,
                    data: { dialog_close: opts[:id] || "", dialog_closable: "" },
                    "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal"),
-                   "aria-describedby": "dialog-title-#{opts[:id]}"
+                   "aria-describedby": "dialog-title-#{sanitize(opts[:id].to_s)}"
                  )
                end
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_add_to_calendar_modal.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_add_to_calendar_modal.html.erb
@@ -1,7 +1,7 @@
 <%= decidim_modal id: "calendarShare_#{id}", class: "calendar-modal" do %>
   <div data-dialog-container>
     <%= icon "calendar-check-line" %>
-    <h2 id="dialog-title-calendarShare" data-dialog-title><%= t("add_to_calendar", scope: "decidim.meetings.meetings.calendar_modal") %></h2>
+    <h2 id="dialog-title-<%= sanitize("calendarShare_#{id}") %>" data-dialog-title><%= t("add_to_calendar", scope: "decidim.meetings.meetings.calendar_modal") %></h2>
     <ul class="space-y-4 mt-4">
       <li>
         <%= link_to t("outlook", scope: "decidim.meetings.meetings.calendar_modal"), ics_url, class: "text-secondary underline" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This change improves WCAG compliance by enhancing the accessibility of modals in Decidim. Specifically, it explicitly associates the close button of modals with their corresponding dialog titles using the aria-describedby attribute. This provides additional context for assistive technologies, improving semantic understanding without altering visual design or functionality for standard users.

Technically:
- Adds an `aria-describedby="dialog-title-#{sanitize(opts[:id].to_s)}"` attribute to the modal close button.
- Preserves existing attributes such as aria-label, type, and data attributes to maintain functionality.

This aligns with WCAG criterion: [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html), enhancing the semantic clarity of UI components.

#### :pushpin: Related Issues
This change is part of a broader effort to enhance accessibility across Decidim.
- WCAG Criterion: [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
- Audit funded by the City of Lyon

#### 🧪 Steps to Reproduce
1. Navigate to a meeting
4. Scroll to the bottom of the page and click the "Add to calendar" link.
6. A modal appears with meeting details and a close (×) button.
8. Inspect the modal close <button>:
- Before fix:
The close button includes an `aria-label`, but lacks an `aria-describedby` linking it to the modal’s title (`<h3>`), which limits context for screen readers.
- After fix:
The button includes:  `aria-describedby="dialog-title-<modal_id>"`, where `<modal_id>` is derived from the modal’s identifier, improving semantic clarity.

#### :memo: Subtasks
 Add aria-describedby to the modal close button
 Sanitize opts[:id] to ensure valid HTML IDs

### :camera: Screenshots (optional)

❤️ Thanks 
