### PR TITLE
Fix characters limit when editing comment

### DIFF
--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -51,7 +51,7 @@ module Decidim
         enforce_permission_to(:update, :comment, comment:)
 
         form = Decidim::Comments::CommentForm.from_params(
-          params.merge(commentable: comment.commentable)
+          params.merge(commentable: comment.commentable, current_component:)
         ).with_context(
           current_user:,
           current_organization:
@@ -76,7 +76,7 @@ module Decidim
         enforce_permission_to(:create, :comment, commentable:)
 
         form = Decidim::Comments::CommentForm.from_params(
-          params.merge(commentable:)
+          params.merge(commentable:, current_component:)
         ).with_context(
           current_organization:,
           current_component:,

--- a/decidim-comments/app/forms/decidim/comments/comment_form.rb
+++ b/decidim-comments/app/forms/decidim/comments/comment_form.rb
@@ -12,11 +12,13 @@ module Decidim
       attribute :user_group_id, Integer
       attribute :commentable
       attribute :commentable_gid
+      attribute :current_component, Decidim::Component
 
       mimic :comment
 
       validates :body, presence: true, length: { maximum: ->(form) { form.max_length } }
       validates :alignment, inclusion: { in: [0, 1, -1] }, if: ->(form) { form.alignment.present? }
+      validates :current_component, presence: true
 
       validate :max_depth
       validate :commentable_can_have_comments

--- a/decidim-comments/app/forms/decidim/comments/comment_form.rb
+++ b/decidim-comments/app/forms/decidim/comments/comment_form.rb
@@ -18,7 +18,6 @@ module Decidim
 
       validates :body, presence: true, length: { maximum: ->(form) { form.max_length } }
       validates :alignment, inclusion: { in: [0, 1, -1] }, if: ->(form) { form.alignment.present? }
-      validates :current_component, presence: true
 
       validate :max_depth
       validate :commentable_can_have_comments

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
@@ -18,7 +18,8 @@ RSpec.shared_context "when creating a comment" do
         "body" => body,
         "alignment" => alignment,
         "user_group_id" => user_group_id,
-        "commentable" => commentable
+        "commentable" => commentable,
+        "current_component" => component
       }
     }
   end

--- a/decidim-comments/spec/commands/update_comment_spec.rb
+++ b/decidim-comments/spec/commands/update_comment_spec.rb
@@ -17,7 +17,8 @@ module Decidim
         {
           "comment" => {
             "body" => body,
-            "commentable" => commentable
+            "commentable" => commentable,
+            "current_component" => component
           }
         }
       end

--- a/decidim-comments/spec/forms/comment_form_spec.rb
+++ b/decidim-comments/spec/forms/comment_form_spec.rb
@@ -34,7 +34,8 @@ module Decidim
             "body" => body,
             "alignment" => alignment,
             "user_group_id" => user_group_id,
-            "commentable" => commentable
+            "commentable" => commentable,
+            "current_component" => component
           }
         }
       end
@@ -95,7 +96,7 @@ module Decidim
           let!(:component) { nil }
           let(:body) { "c" * 1000 }
 
-          it { is_expected.to be_valid }
+          it { is_expected.not_to be_valid }
         end
 
         context "when the component settings do not define comments_max_length" do

--- a/decidim-comments/spec/forms/comment_form_spec.rb
+++ b/decidim-comments/spec/forms/comment_form_spec.rb
@@ -96,7 +96,7 @@ module Decidim
           let!(:component) { nil }
           let(:body) { "c" * 1000 }
 
-          it { is_expected.not_to be_valid }
+          it { is_expected.to be_valid }
         end
 
         context "when the component settings do not define comments_max_length" do


### PR DESCRIPTION
#### :tophat: What? Why?
When I set a max length for a proposal comment superior to 1000, and I post a comment with a length superior to 1000, I can edit the comment.

#### :pushpin: Related Issues
- Fixes #https://github.com/decidim/decidim/issues/14012?

#### Test

- Log in as admin and access Back-Office
- Go to a participatory process, and access to the proposal component of it
- Modify the component to fix a limit of characters for comments superior to 1000 chars (= default value)
- Access Front-Office of this component
- Access a proposal and submit a comment over 1000 chars but below your limit
- Try to edit it and stay over the 1000 chars limit
- See that your comment has been updated
