### PR TITLE
Feat: add author notification on proposal publication

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/publish_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/publish_proposal.rb
@@ -27,6 +27,7 @@ module Decidim
           increment_scores
           send_notification
           send_notification_to_participatory_space
+          send_publication_notification
         end
 
         broadcast(:ok, @proposal)
@@ -84,6 +85,17 @@ module Decidim
           extra: {
             participatory_space: true
           }
+        )
+      end
+
+      def send_publication_notification
+        Decidim::EventsManager.publish(
+          event: "decidim.events.proposals.author_confirmation_proposal_event",
+          event_class: Decidim::Proposals::AuthorConfirmationProposalEvent,
+          resource: @proposal,
+          affected_users: [@proposal.creator_identity],
+          extra: { force_email: true },
+          force_send: true
         )
       end
 

--- a/decidim-proposals/app/events/decidim/proposals/author_confirmation_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/author_confirmation_proposal_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class AuthorConfirmationProposalEvent < Decidim::Events::SimpleEvent
+      def self.model_name
+        ActiveModel::Name.new(self, nil, I18n.t("decidim.events.proposals.author_confirmation_proposal_event.email_subject"))
+      end
+
+      def resource_title
+        decidim_sanitize_translated(resource.title)
+      end
+    end
+  end
+end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -290,6 +290,11 @@ en:
             email_outro: You have received this notification because you are the author of the note.
             email_subject: "%{author_name} has replied your private note in %{resource_title}."
             notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> has replied your private note in <a href="%{resource_path}">%{resource_title}</a>. Check it out at <a href="%{admin_proposal_info_path}">the admin panel</a>.
+        author_confirmation_proposal_event:
+          email_intro: 'Your proposal " %{resource_title} " was successfully received and is now public. Thank you for participating ! You can view it here:'
+          email_outro: You received this notification because you are the author of the proposal. You can unfollow it by visiting the proposal page (" %{resource_title} ") and clicking on " Unfollow ".
+          email_subject: Your proposal has been published!
+          notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> is now live.
         coauthor_accepted_invite:
           notification_title: <a href="%{coauthor_path}">%{coauthor_name}</a> has accepted your invitation to become a co-author of the proposal <a href="%{resource_path}">%{resource_title}</a>.
         coauthor_invited:

--- a/decidim-proposals/config/locales/fr.yml
+++ b/decidim-proposals/config/locales/fr.yml
@@ -259,6 +259,11 @@ fr:
             email_outro: Vous avez reçu cette notification parce que vous êtes l'auteur/autrice de la note.
             email_subject: "%{author_name} a répondu à votre note privée dans %{resource_title}."
             notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> a répondu à votre note privée dans <a href="%{resource_path}">%{resource_title}</a>. Consultez-la sur <a href="%{admin_proposal_info_path}">le panneau d'administration</a>.
+        author_confirmation_proposal_event:
+          email_intro: 'Votre proposition « %{resource_title} » a été reçue avec succès et est maintenant publique. Merci pour votre participation ! Vous pouvez la consulter ici :'
+          email_outro: Vous recevez cette notification car vous êtes l’auteur de la proposition. Vous pouvez vous désabonner en visitant la page de la proposition (« %{resource_title} ») et en cliquant sur « Ne plus suivre ».
+          email_subject: Votre proposition a été publiée !
+          notification_title: Votre proposition <a href="%{resource_path}">%{resource_title}</a> est maintenant en ligne.
         coauthor_accepted_invite:
           notification_title: <a href="%{coauthor_path}">%{coauthor_name}</a> a accepté votre invitation à devenir co-auteur de la proposition <a href="%{resource_path}">%{resource_title}</a>.
         coauthor_invited:

--- a/decidim-proposals/spec/commands/decidim/proposals/publish_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/publish_proposal_spec.rb
@@ -61,6 +61,17 @@ module Decidim
                 }
               )
 
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.proposals.author_confirmation_proposal_event",
+                event_class: Decidim::Proposals::AuthorConfirmationProposalEvent,
+                resource: kind_of(Decidim::Proposals::Proposal),
+                affected_users: [proposal_draft.creator_identity],
+                extra: { force_email: true },
+                force_send: true
+              )
+
             subject.call
           end
         end

--- a/decidim-proposals/spec/events/decidim/proposals/author_confirmation_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/author_confirmation_proposal_event_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe AuthorConfirmationProposalEvent do
+      let(:resource) { create(:proposal) }
+      let(:participatory_process) { create(:participatory_process, organization:) }
+      let(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }
+      let(:event_name) { "decidim.events.proposals.author_confirmation_proposal_event" }
+
+      include_context "when a simple event"
+
+      it_behaves_like "a simple event"
+
+      describe "resource_title" do
+        it "returns the proposal title" do
+          expect(subject.resource_title).to eq(decidim_sanitize_translated(resource.title))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The goal of this PR is to send a confirmation of publication, by notification and email, to the author of a proposal.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/17894

#### Testing

1. After login, go to your account and then to notification settings, and check "Real time" for "How often do you want to receive the notifications email"
2. Go to a participatory process
3. Click on proposals
4. Add a proposal
5. Publish it
6. Verify that you receive a notification and an email

#### :clipboard: Subtasks
- [X] Add tests

