### PR TITLE
Feat: allow to choose if notification when attachment added

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -58,12 +58,15 @@ module Decidim
 
       def notify_followers
         return unless @attachment.attached_to.is_a?(Decidim::Followable)
+        return unless form.send_notification_to_followers
 
         Decidim::EventsManager.publish(
           event: "decidim.events.attachments.attachment_created",
           event_class: Decidim::AttachmentCreatedEvent,
           resource: @attachment,
-          followers: @attachment.attached_to.followers
+          followers: @attachment.attached_to.followers,
+          extra: { force_email: true },
+          force_send: true
         )
       end
 

--- a/decidim-admin/app/forms/decidim/admin/attachment_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/attachment_form.rb
@@ -13,6 +13,7 @@ module Decidim
       attribute :weight, Integer, default: 0
       attribute :attachment_collection_id, Integer
       attribute :link, String
+      attribute :send_notification_to_followers, Boolean, default: false
 
       mimic :attachment
 

--- a/decidim-admin/app/views/decidim/admin/attachments/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/_form.html.erb
@@ -39,6 +39,9 @@
           }
         ] %>
       </div>
+      <div class="row column">
+        <%= form.check_box :send_notification_to_followers, label: t(".send_notification_to_followers") %>
+      </div>
     </div>
   </div>
 </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -285,6 +285,8 @@ en:
         edit:
           title: Edit attachment
           update: Update
+        form:
+          send_notification_to_followers: Send a notification to all the people following the consultation who have agreed to receive email notifications
         index:
           attachments_title: Attachments
         new:

--- a/decidim-admin/config/locales/fr.yml
+++ b/decidim-admin/config/locales/fr.yml
@@ -283,6 +283,8 @@ fr:
         edit:
           title: Modifier le document lié
           update: Mettre à jour
+        form:
+          send_notification_to_followers: Envoyer une notification à toutes les personnes qui suivent la concertation ayant accepté de recevoir des notifications par mail
         index:
           attachments_title: Documents liés
         new:
@@ -562,7 +564,7 @@ fr:
           text: Recherche par adresse e-mail, nom ou pseudonyme.
           user: Utilisateur
         logs_list:
-          no_logs_yet: Il n'y a pas encore de journaux d'activité. 
+          no_logs_yet: Il n'y a pas encore de journaux d'activité.
           no_matching_logs: Il n'y a pas de journaux avec les filtres de recherche fournis. Essayez de les modifier et réessayez.
       manage_trash:
         deleted_items_warning: Vous visualisez actuellement des éléments de la corbeille. Pour effectuer des modifications ou des modifications, vous devez d'abord les restaurer.
@@ -811,7 +813,7 @@ fr:
           title: Sélectionner les destinataires
           warning: "<strong>Attention :</strong> Cette newsletter ne sera envoyée qu'aux utilisateurs qui ont activé <em>Je veux recevoir newsletters</em> dans leurs paramètres de notifications."
         send:
-          no_recipients: Selon votre sélection, cette newsletter ne sera envoyée à aucun destinataire. 
+          no_recipients: Selon votre sélection, cette newsletter ne sera envoyée à aucun destinataire.
         send_to_user:
           sent_successfully: La newsletter a été envoyée avec succès à %{email}
         show:
@@ -941,7 +943,7 @@ fr:
       participatory_space_private_users_csv_imports:
         create:
           invalid: Un problème est survenu lors de la lecture du fichier CSV. Veuillez vous assurer que vous avez suivi les instructions.
-          success: Le fichier CSV a été téléchargé avec succès. Une invitation par courriel sera envoyée sous peu à chaque participant. Cela peut prendre quelques instants. 
+          success: Le fichier CSV a été téléchargé avec succès. Une invitation par courriel sera envoyée sous peu à chaque participant. Cela peut prendre quelques instants.
         new:
           csv_upload:
             title: Téléchargez votre fichier CSV
@@ -1177,7 +1179,7 @@ fr:
       user_group:
         csv_verify:
           invalid: Une erreur s'est produite lors de la lecture du fichier CSV.
-          success: Le fichier CSV a été téléchargé avec succès, une vérification des groupes correspondant aux critères est en cours. Cela peut prendre quelques instants. 
+          success: Le fichier CSV a été téléchargé avec succès, une vérification des groupes correspondant aux critères est en cours. Cela peut prendre quelques instants.
         reject:
           invalid: Une erreur s'est produite lors du refus de ce groupe d'utilisateurs.
           success: Groupe d'utilisateurs refusé avec succès.

--- a/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
@@ -6,6 +6,7 @@ module Decidim::Admin
   describe CreateAttachment do
     subject { described_class.call(form, attached_to) }
     let(:user) { create(:user) }
+    let(:send_notification) { true }
     let(:form) do
       instance_double(
         AttachmentForm,
@@ -22,6 +23,7 @@ module Decidim::Admin
         file:,
         attachment_collection: nil,
         current_user: user,
+        send_notification_to_followers: send_notification,
         weight: 0
       )
     end
@@ -51,10 +53,26 @@ module Decidim::Admin
             event: "decidim.events.attachments.attachment_created",
             event_class: Decidim::AttachmentCreatedEvent,
             resource: kind_of(Decidim::Attachment),
-            followers: [follower]
+            followers: [follower],
+            extra: { force_email: true },
+            force_send: true
           )
 
         subject
+      end
+
+      context "when send notification option is false" do
+        let(:send_notification) { false }
+
+        it "does not notify the followers" do
+          follower = create(:user, organization: attached_to.organization)
+          create(:follow, followable: attached_to, user: follower)
+
+          expect(Decidim::EventsManager)
+            .not_to receive(:publish)
+
+          subject
+        end
       end
 
       it "traces the action", versioning: true do


### PR DESCRIPTION
#### :tophat: What? Why?
The aim of this PR is to allow admin to choose if he wants followers of a process to be notified when adding a new attachment to a process.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/17895?

#### testing

1. Log in as admin
2. Follow a process
3. Access Backoffice
4. Go to the process you followed, and go to Attachments
5. Add new attachment
6. Check the notification checkbox
7. Submit form
8. See notification in-app and email
