### PR TITLE
Fix wcag logo link description 

### DIFF
--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -556,7 +556,7 @@ describe "Orders" do
 
         expect(page).to have_content("Budget vote completed")
 
-        page.find("a[aria-label='Go to front page']").click
+        page.find("a[href='#{decidim.root_path}']").click
 
         expect(page).to have_current_path decidim.root_path
       end

--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,7 +1,8 @@
 <% if organization %>
-  <%= link_to root_url, "aria-label": t("front_page_link", scope: "decidim.accessibility") do %>
+  <%= link_to root_url do %>
     <% if organization.logo.attached? %>
-      <%= image_tag organization.attached_uploader(:logo).variant_url(:medium), alt: t("logo", scope: "decidim.accessibility", organization: current_organization_name) %>
+      <%= image_tag organization.attached_uploader(:logo).variant_url(:medium),
+        alt: "#{current_organization_name} (#{t('decidim.errors.not_found.back_home')})" %>
     <% else %>
       <span><%= current_organization_name %></span>
     <% end %>

--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,8 +1,7 @@
 <% if organization %>
   <%= link_to root_url do %>
     <% if organization.logo.attached? %>
-      <%= image_tag organization.attached_uploader(:logo).variant_url(:medium),
-        alt: "#{current_organization_name} (#{t('decidim.errors.not_found.back_home')})" %>
+      <%= image_tag organization.attached_uploader(:logo).variant_url(:medium), alt: "#{current_organization_name} (#{t("decidim.errors.not_found.back_home")})" %>
     <% else %>
       <span><%= current_organization_name %></span>
     <% end %>


### PR DESCRIPTION
🎩 What?
This change improves accessibility by making the homepage logo more understandable for screen readers:
Removed the aria-label from the <a> tag around the logo.
Updated the <img> tag's alt attribute to include a clear description: the organization's name followed by (Back home).
These changes help screen readers correctly describe the logo and its purpose, without confusion or repetition.
They align with:
WCAG Criterion: [1.1.1 - Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content): the image now has meaningful alternative text.
WCAG Criterion: [2.4.4 - Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context) (In Context): users understand that the logo is a link back to the homepage.

🎯 Why?
This issue comes from an accessibility audit funded by the City of Lyon, targeting compliance with RGAA (based on WCAG 1.3.1 – Info and Relationships).
Improvements:
- Ensures assistive technologies properly announce the purpose of the logo.
- Provides a meaningful alternative text for the image, improving WCAG compliance.

📌 Related Issues
WCAG Criterion: [1.1.1 - Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content)
WCAG Criterion: [2.4.4 - Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context)

✅ Steps to Test
1. Navigate to the homepage.
2. Inspect the logo <img> tag: (if needed add one in the admin dashboard: settings/appearance/logo)
3. Inspect the header logo:
- <a> has no aria-label.
- <img> has alt="Organization name (Back home)".
5. Activate a screen reader (VoiceOver on macOS, NVDA on Windows):
6. - Ensure it announces the correct text when focusing on the logo.

📋 Subtasks
-  Removed aria-label from <a> tag.
-  Updated alt attribute to use the complete description.
-  Verified accessibility with screen readers.

📸 Screenshots (optional)
<img width="1369" alt="Capture d’écran 2025-02-26 à 10 43 10" src="https://github.com/user-attachments/assets/106d5bcb-1a95-4980-8ab8-eae3e0f5e41f" />

🔍 Additional Context
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.
