### PR TITLE
Fix empty alt attributes to decorative images according to WCAG 2.1

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment_form/comment_as.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/comment_as.erb
@@ -1,7 +1,7 @@
 <div class="comment__as">
   <div class="comment__as-author-info">
     <div class="author__avatar-container border border-white">
-      <%= image_tag author_presenter.avatar_url(:thumb), alt: t("decidim.author.avatar", name: author_presenter.name), class: "author__avatar" %>
+      <%= image_tag author_presenter.avatar_url(:thumb), alt: "", role: t("decidim.accessibility.decorative_image_role"), class: "author__avatar" %>
     </div>
 
     <p class="comment__as-author-name"><%= author_presenter.name %></p>

--- a/decidim-core/app/cells/decidim/author/avatar_image.erb
+++ b/decidim-core/app/cells/decidim/author/avatar_image.erb
@@ -1,1 +1,1 @@
-<%= image_tag model.avatar_url(:thumb), alt: t("decidim.author.avatar", name: display_name), class: "author__avatar" %>
+<%= image_tag model.avatar_url(:thumb), alt: "", role: t("decidim.accessibility.decorative_image_role"), class: "author__avatar" %>

--- a/decidim-core/app/cells/decidim/images_panel/show.erb
+++ b/decidim-core/app/cells/decidim/images_panel/show.erb
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
   <% photos.each_with_index do |photo, index| %>
     <%= link_to photo.big_url, target: "_blank", rel: "noopener", class: "overflow-hidden rounded aspect-video" do %>
-      <%= image_tag photo.thumbnail_url, class:"w-full h-full object-cover", alt: strip_tags(translated_attribute(photo.title)) %>
+      <%= image_tag photo.thumbnail_url, class:"w-full h-full object-cover", alt: "", role: "presentation" %>
     <% end %>
   <% end %>
 </div>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -34,9 +34,7 @@
             <span><%= title_for(attachment) %> (<%= truncated_file_name_for(attachment) %>)</span>
             <%= form.hidden_field attribute, multiple: true, value: attachment.id, id: attachment.id %>
           <% else %>
-            <% if blob(attachment).image? %>
-              <span><%= truncated_file_name_for(attachment, 15) %></span>
-            <% else %>
+            <% unless blob(attachment).image? %>
               <%= link_to truncated_file_name_for(attachment), file_attachment_path(attachment) %>
             <% end %>
           <% end %>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -25,7 +25,10 @@
 
         <div class="attachment-details" data-attachment-id="<%= attachment.id %>" data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded">
           <% if file_attachment_path(attachment) && blob(attachment).image? %>
-            <div><%= image_tag(file_attachment_path(attachment), alt: "", role: t("decidim.accessibility.decorative_image_role")) %></div>
+            <div>
+              <%= image_tag(file_attachment_path(attachment), alt: "", role: t("decidim.accessibility.decorative_image_role")) %>
+              <span class="sr-only"><%= file_name_for(attachment) %></span>
+            </div>
           <% elsif uploader_default_image_path(attribute).present? %>
             <div><%= image_tag uploader_default_image_path(attribute) %></div>
           <% end %>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -25,7 +25,7 @@
 
         <div class="attachment-details" data-attachment-id="<%= attachment.id %>" data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded">
           <% if file_attachment_path(attachment) && blob(attachment).image? %>
-            <div><%= image_tag(file_attachment_path(attachment), alt: title_for(attachment) || file_name_for(attachment)) %></div>
+            <div><%= image_tag(file_attachment_path(attachment), alt: "", role: t("decidim.accessibility.decorative_image_role")) %></div>
           <% elsif uploader_default_image_path(attribute).present? %>
             <div><%= image_tag uploader_default_image_path(attribute) %></div>
           <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
         other: "%{count} seconds"
   decidim:
     accessibility:
+      decorative_image_role: presentation
       external_link: External link
       front_page_link: Go to front page
       logo: "%{organization}'s official logo"

--- a/decidim-core/config/locales/fr.yml
+++ b/decidim-core/config/locales/fr.yml
@@ -157,6 +157,7 @@ fr:
         other: "%{count} secondes"
   decidim:
     accessibility:
+      decorative_image_role: presentation
       external_link: Lien externe
       front_page_link: Aller à la première page
       logo: "Logo officiel de %{organization}"


### PR DESCRIPTION
#### :tophat: What?
This change improves WCAG 2.1 compliance by correctly identifying decorative images across several key areas of the Decidim UI, ensuring they are ignored by assistive technologies. While the visual appearance remains unchanged for standard users, these updates reduce noise and redundancy for screen reader users.

Technically:
- Sets `alt=""` on decorative images
- Adds `role="presentation"` via I18n key (decidim.accessibility.decorative_image_role) to reinforce their semantic neutrality for assistive technologies, align with best practices from ARIA and WCAG recommendations.
- Removes redundant textual content (e.g., filenames or alt text containing usernames that are already displayed next to the image)

#### :tophat: Why?
This work addresses [WCAG Criterion 1.1.1 - Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html), which requires that decorative images be ignored by screen readers.
Previously, some images were rendered with:
- the filename as `alt`
- or with a descriptive `alt `even though the information was already visually present in text
This led to redundant and non-informative output for screen reader users.

#### :pushpin: Related Issues
This PR resolves the issue reported in:
🔗 https://github.com/decidim/decidim/issues/14461

The issue originates from an accessibility audit funded by the City of Lyon, focusing on RGAA and WCAG compliance.

#### :wrench: Scope of Changes
✅ User profile page: avatar image now uses alt="" and removes visible filename
✅ Comment threads: avatars beside comments are now decorative (empty alt)
✅ Comment modal form: avatar image above textarea marked as decorative
✅ Proposal show page: proposal images rendered with empty alt instead of filename or title

#### Testing
Go to a user profile page
⟶ Avatar image has alt="", no filename is visually rendered
<img width="1452" alt="Capture d’écran 2025-04-03 à 18 01 26" src="https://github.com/user-attachments/assets/6adfce61-d6e0-4aef-9ce0-9319774dacb8" />

Go to a proposal page with comments
⟶ Comment avatars now have alt=""
<img width="1430" alt="Capture d’écran 2025-04-03 à 18 00 54" src="https://github.com/user-attachments/assets/e9a1dfe6-fdd4-46dc-a51f-e5613ad0c542" />

Open comment modal
⟶ Avatar in header is decorative (alt="" role="presentation")
<img width="1433" alt="Capture d’écran 2025-04-03 à 18 00 40" src="https://github.com/user-attachments/assets/69036f53-7ed3-4ceb-b0ee-be2bc6fb22c6" />

On a proposal show page
⟶ Associated image has alt="", no fallback filename
<img width="1445" alt="Capture d’écran 2025-04-03 à 10 22 07" src="https://github.com/user-attachments/assets/3b59fd67-bd79-4088-be02-55789c3c1e39" />

Inspect HTML structure with dev tools and test with a screen reader (e.g. VoiceOver, NVDA) to confirm that these images are now ignored.

#### :clipboard: Subtasks
- [x] User profile avatar: alt="", removed filename
- [x] Comment avatars: alt="", role="presentation"
- [x] Comment modal avatar: alt="", role="presentation"
- [x] Proposal images: alt=""


### :camera: Screenshots (optional)


:heart: Thanks for reviewing and supporting accessibility improvements!
