### PR TITLE
Fix accessibility on mobile logo alt text

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_logo_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo_mobile.html.erb
@@ -1,7 +1,7 @@
 <% if organization %>
-  <%= link_to root_url, "aria-label": t("front_page_link", scope: "decidim.accessibility") do %>
+  <%= link_to root_url do %>
     <% if organization.favicon.attached? %>
-      <%= image_tag organization.attached_uploader(:favicon).variant_path(:medium), alt: t("logo", scope: "decidim.accessibility", organization: current_organization_name) %>
+      <%= image_tag organization.attached_uploader(:favicon).variant_path(:medium), alt: "#{current_organization_name} (#{t("decidim.errors.not_found.back_home")})" %>
     <% else %>
       <span><%= current_organization_name %></span>
     <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -170,7 +170,6 @@ en:
   decidim:
     accessibility:
       external_link: External link
-      front_page_link: Go to front page
       logo: "%{organization}'s official logo"
       opens_in_new_tab: Opens in new tab
       secondary_menu: Secondary menu


### PR DESCRIPTION
#### :tophat: What? Why?
This PR update the mobile logo alt text to match the desktop version that had been changed to fix accessibility issues

#### :pushpin: Related Issues

- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112402939&issue=OpenSourcePolitics%7Cintern-tasks%7C26

#### Testing

1. As an admin, go to the back-office and access settings
2. In "Configuration" scroll down to put a logo and an icon to your application
3. Once it was updated go back to the front-office and open your "Inspect" and select the logo
4. Make sure that in the desktop version there is no `aria-label` and that the image contains the following translation : 
`${org_name} (Back Home)`
5. Switch to mobile version using the "Responsive" element
6. Make sure the mobile icon does no longer have any `aria-label` and that the translation of the logo alt text is the same that the one above

### :camera: Screenshots
![expected_behaviour](https://github.com/user-attachments/assets/4156bc22-ed23-4398-96b7-d1ab94c3a995)

