### PR TITLE
Fix view mode active icon in proposals for accessibility

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
@@ -20,8 +20,14 @@ module Decidim
         icon_name = target_mode == "grid" ? "layout-grid-fill" : "list-check"
         icon_class = "view-icon--disabled" unless current_mode == target_mode
 
-        link_to path, remote: true, title: do
-          icon(icon_name, class: icon_class, role: "img", "aria-hidden": true)
+        if icon_class == "view-icon--disabled"
+          link_to path, remote: true, role: "button", title: do
+            icon(icon_name, class: icon_class, role: "img", "aria-hidden": true)
+          end
+        else
+          link_to path, remote: true, role: "button", "aria-current": true, title: do
+            icon(icon_name, class: icon_class, role: "img", "aria-hidden": true, style: "border:1px solid black")
+          end
         end
       end
 

--- a/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
@@ -18,15 +18,14 @@ module Decidim
       def toggle_view_mode_link(current_mode, target_mode, title, params)
         path = proposals_path(params.permit(:order, filter: {}).merge({ view_mode: target_mode }))
         icon_name = target_mode == "grid" ? "layout-grid-fill" : "list-check"
-        icon_class = "view-icon--disabled" unless current_mode == target_mode
 
-        if icon_class == "view-icon--disabled"
-          link_to path, remote: true, role: "button", title: do
-            icon(icon_name, class: icon_class, role: "img", "aria-hidden": true)
+        if current_mode == target_mode
+          link_to path, remote: true, role: "button", "aria-current": true, title: do
+            icon(icon_name, class: "view-icon", role: "img", "aria-hidden": true)
           end
         else
-          link_to path, remote: true, role: "button", "aria-current": true, title: do
-            icon(icon_name, class: icon_class, role: "img", "aria-hidden": true, style: "border:1px solid black")
+          link_to path, remote: true, role: "button", title: do
+            icon(icon_name, class: "view-icon--disabled", role: "img", "aria-hidden": true)
           end
         end
       end

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -84,6 +84,10 @@
     svg {
       @apply inline-block w-5 h-5;
 
+      &.view-icon {
+        @apply border border-black border-solid;
+      }
+
       &.view-icon--disabled {
         @apply fill-gray;
       }


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the style of the active view mode icon to improve its accessibility by:
- adding a border to it
- adding a `aria-current=true"` to it 

This PR also adds to the 2 links  a `role="button"`.

The problem was raised in the audit of Angers city (p 77) and refers to criterias 1.3.1, 1.4.1, 2.5.3 et 4.1.2 from WCAG.

#### :pushpin: Related Issues
- Related to Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112532517&issue=OpenSourcePolitics%7Cintern-tasks%7C33

#### Testing
As a user, go to a process with proposals, go the index page of proposals
See that the current view mode is displayed with a border
Open your inspector and check that the `a` link of the current view mode has the `aria-current="true" `

### :camera: Screenshots (optional)
<img width="1222" alt="Capture d’écran 2025-05-28 à 11 22 22" src="https://github.com/user-attachments/assets/678b1fa4-b292-4e22-8f25-fa4cac4b11ea" />

