### PR TITLE
Fix main bar avatar

### DIFF
--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -1,6 +1,6 @@
 // changes the value "menu" of role attribute set by a11y on div dropdown-menu-account and
 // dropdown-menu-account-mobile which are inappropriate for accessibility
-document.addEventListener("DOMContentLoaded", function(event) {
+document.addEventListener("DOMContentLoaded", () =>  {
   setTimeout(() => {
     document.querySelector("#dropdown-menu-account").setAttribute("role", "dialog")
     document.querySelector("#dropdown-menu-account-mobile").setAttribute("role", "dialog")

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -9,4 +9,10 @@ document.addEventListener("DOMContentLoaded", () => {
       dropdownMobileDiv.setAttribute("role", "dialog")
     }, 300)
   }
+  const triggerButtonMobile = document.querySelector("#dropdown-trigger-links-mobile");
+  if (triggerButtonMobile) {
+    triggerButtonMobile.addEventListener("click", () => {
+      dropdownMobileDiv.setAttribute("aria-modal", "true")
+    })
+  }
 });

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -1,8 +1,12 @@
 // changes the value "menu" of role attribute set by a11y on div dropdown-menu-account and
 // dropdown-menu-account-mobile which are inappropriate for accessibility
-document.addEventListener("DOMContentLoaded", () =>  {
-  setTimeout(() => {
-    document.querySelector("#dropdown-menu-account").setAttribute("role", "dialog")
-    document.querySelector("#dropdown-menu-account-mobile").setAttribute("role", "dialog")
-  }, 300)
+document.addEventListener("DOMContentLoaded", () => {
+  const dropdownDiv = document.querySelector("#dropdown-menu-account");
+  const dropdownMobileDiv = document.querySelector("#dropdown-menu-account-mobile");
+  if (dropdownDiv) {
+    setTimeout(() => {
+      dropdownDiv.setAttribute("role", "dialog")
+      dropdownMobileDiv.setAttribute("role", "dialog")
+    }, 300)
+  }
 });

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -1,0 +1,8 @@
+// changes the value "menu" of role attribute set by a11y on div dropdown-menu-account and
+// dropdown-menu-account-mobile which are inappropriate for accessibility
+document.addEventListener("DOMContentLoaded", function(event) {
+  setTimeout(() => {
+    document.querySelector("#dropdown-menu-account").setAttribute("role", "dialog")
+    document.querySelector("#dropdown-menu-account-mobile").setAttribute("role", "dialog")
+  }, 300)
+});

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -49,6 +49,7 @@ import "src/decidim/sw"
 import "src/decidim/sticky_header"
 import "src/decidim/sticky_footer"
 import "src/decidim/attachments"
+import "src/decidim/dropdown_menu"
 
 // local deps that require initialization
 import ConfirmDialog, { initializeConfirm } from "src/decidim/confirm"

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -30,6 +30,12 @@
       <% unread_data = current_user_unread_data %>
       <% if unread_data[:unread_items] %>
         <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
+        <% if unread_data[:unread_notifications] %>
+          <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
+        <% end %>
+        <% if unread_data[:unread_conversations] %>
+          <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+        <% end %>
       <% end %>
       <% if current_user.avatar.attached? %>
         <span class="main-bar__avatar">

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
@@ -17,6 +17,7 @@
     <span><%= t("layouts.decidim.user_menu.notifications") %></span>
     <% if unread_data[:unread_notifications] %>
       <%= content_tag :span, "", class: "main-bar__dropdown-notification", data: unread_data %>
+      <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
     <% end %>
   <% end %>
 </li>
@@ -26,6 +27,7 @@
     <span><%= t("layouts.decidim.user_menu.conversations") %></span>
     <% if unread_data[:unread_conversations] %>
       <%= content_tag :span, "", class: "main-bar__dropdown-notification", data: unread_data %>
+      <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
     <% end %>
   <% end %>
 </li>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
@@ -1,4 +1,4 @@
-<div id="dropdown-menu-account-mobile" class="main-bar__links-mobile__account" aria-hidden="true" aria-modal="true">
+<div id="dropdown-menu-account-mobile" class="main-bar__links-mobile__account" aria-hidden="true">
   <div class="main-bar">
     <div class="main-bar__logo">
       <div class="main-bar__logo-desktop">
@@ -10,7 +10,7 @@
     </div>
 
     <div>
-      <div class="main-bar__links-mobile__trigger" onclick="document.querySelector('#dropdown-trigger-links-mobile').click();">
+      <div class="main-bar__links-mobile__trigger" onclick="document.querySelector('#dropdown-trigger-links-mobile').click();document.querySelector('#dropdown-menu-account-mobile').removeAttribute('aria-modal')">
         <%= icon "close-line" %>
       </div>
     </div>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
@@ -1,4 +1,4 @@
-<div id="dropdown-menu-account-mobile" class="main-bar__links-mobile__account" aria-hidden="true">
+<div id="dropdown-menu-account-mobile" class="main-bar__links-mobile__account" aria-hidden="true" aria-modal="true">
   <div class="main-bar">
     <div class="main-bar__logo">
       <div class="main-bar__logo-desktop">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2153,8 +2153,8 @@ en:
         profile: My account
         public_profile: My public profile
         title: Profile links
-        unread_conversations: Unread conversations
-        unread_notifications: Unread notifications
+        unread_conversations: You have unread conversations
+        unread_notifications: You have unread notifications
       user_profile:
         account: Account
         authorizations: Authorizations

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2153,6 +2153,8 @@ en:
         profile: My account
         public_profile: My public profile
         title: Profile links
+        unread_conversations: Unread conversations
+        unread_notifications: Unread notifications
       user_profile:
         account: Account
         authorizations: Authorizations


### PR DESCRIPTION
#### :tophat: What? Why?
This PR modifies the dropdonw-menu to improve accessibility, by:
- adding a `aria-modal="true"` on dropdown-menu-account-mobile div
- adding sr-only spans that gives informations on unread notifications and conversations
- modifying the `role="menu"` added by a11y, which is inappropriate on `div id="dropdown-menu-account"` and `div id="dropdown-menu-account-mobile", ` for `role="dialog"`

This PR is issued from the audit of Angers city (page 24, 25 , 26 and 28), and refers to criterias 2.5.3, 4.1.2, 1.3.3 and 1.4.1 from WCAG.


#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112498333&issue=OpenSourcePolitics%7Cintern-tasks%7C27
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112499004&issue=OpenSourcePolitics%7Cintern-tasks%7C28
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112501048&issue=OpenSourcePolitics%7Cintern-tasks%7C30
- https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112500055&issue=OpenSourcePolitics%7Cintern-tasks%7C29

#### Testing

As a logged in user, open your dev tools and inspect the html
- check that the `div id="dropdown-menu-account"` and `div id="dropdown-menu-account-mobile"` have a `role="dialog"`
- in mobile view, click on the avatar to open the menu, and check that the `div id="dropdown-menu-account-mobile"` has an `aria-modal="true"` (cf screenshot one)
- close the modal and check that `div id="dropdown-menu-account-mobile"` has no `aria-modal` attribute
- as a user with unread conversations, check that the button id="trigger-dropdown-account" has a span child sr-only "Unread conversations" (cf screenshot two)
- as a user with unread notifications, check that the button id="trigger-dropdown-account" has a span child sr-only "Unread notifications" 
- as a user with unread conversations or unread notifications, check that the dropdown menu has sr-only spans "Unread conversations" or "Unread notifications" (cf screenshot three)

### :camera: Screenshots (optional)
**SCREENSHOT ONE**
<img width="918" alt="Capture d’écran 2025-06-13 à 14 04 21" src="https://github.com/user-attachments/assets/2d79579c-e4fe-444a-bb0e-c8e3f7157c1f" />

**SCREENSHOT TWO**
<img width="1284" alt="Capture d’écran 2025-06-13 à 14 12 53" src="https://github.com/user-attachments/assets/25e51833-a191-4e27-9f32-87145a2001d6" />

**SCREENSHOT THREE**
<img width="1265" alt="Capture d’écran 2025-06-19 à 11 54 48" src="https://github.com/user-attachments/assets/82a98ac2-0673-4e70-8965-c9f9a1658a48" />
