### PR TITLE
Fix accessibility on avatars links

### DIFF
--- a/decidim-core/app/cells/decidim/author/avatar.erb
+++ b/decidim-core/app/cells/decidim/author/avatar.erb
@@ -1,6 +1,6 @@
 <%= content_tag :span, class: "author__avatar-container" do %>
   <% if profile_path? %>
-    <%= link_to profile_path do %>
+    <%= link_to profile_path, tabindex: 0 do %>
       <%= render :avatar_image %>
     <% end %>
   <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR allows avatars links to be accessible when navigating with Voice Over or another screen reader. 
This PR is issued from the audit of Angers city (page 21) and is rrlatd to criterias critères 1.4.1 and R.4.7 from WCAG.

#### :pushpin: Related Issues
Github card https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112401383&issue=OpenSourcePolitics%7Cintern-tasks%7C25

#### Testing

1. As a user, enable Voice Over
2. On processes index page, click on the home icon to open the dropdown menu
3. Navigate with voice over in the menu and see that the focus is well displayed on avatars links and that you can access them (cf screenshot one)
4. Go to the show of a proposal and navigate with voice over on the page, see that the avatar link gets the focus and that you can access it (cf screenshot two)

  
### :camera: Screenshots (optional)
ONE
<img width="1159" height="789" alt="Capture d’écran 2025-07-30 à 09 18 45" src="https://github.com/user-attachments/assets/d0512d51-ebf0-4391-afa5-041d9a55743f" />

TWO
<img width="839" height="659" alt="Capture d’écran 2025-07-30 à 09 19 51" src="https://github.com/user-attachments/assets/7f774137-ede6-446e-bc6a-c1f9dd653c2e" />


