### PR TITLE
Fix accessibility in footer

### DIFF
--- a/decidim-core/app/cells/decidim/footer_topics/show.erb
+++ b/decidim-core/app/cells/decidim/footer_topics/show.erb
@@ -1,5 +1,5 @@
-<nav role="navigation" aria-label="Help">
-  <h2 class="h4 mb-4">Help</h2>
+<nav role="navigation" aria-label="<%= t("layouts.decidim.footer.help") %>">
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.help") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <% topics.each do |topic| %>
       <%= topic_item(topic, class: "font-semibold underline") %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
@@ -11,7 +11,7 @@
     <nav class="md:w-1/2 lg:w-auto" role="navigation" aria-label="Legal">
       <%= render partial: "layouts/decidim/footer/main_legal" %>
     </nav>
-    <nav class="w-full md:w-auto md:ml-auto" role="navigation" aria-label="Social media">
+    <nav class="w-full md:w-auto md:ml-auto" role="navigation" aria-label="<%= t("layouts.decidim.footer.social_media") %>">
       <%= render partial: "layouts/decidim/footer/main_social_media_links" %>
     </nav>
     <%= render partial: "layouts/decidim/footer/main_language_chooser" %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
@@ -1,6 +1,6 @@
 <% if current_organization.official_img_footer.attached? %>
   <%= link_to current_organization.official_url, class: "block mb-6" do %>
-    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: "#{current_organization_name} (#{t("decidim.errors.not_found.back_home")})", class: "max-h-16" %>
+    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: t("layouts.decidim.footer.current_organization_img", organization: current_organization_name), class: "max-h-16" %>
   <% end %>
 <% end %>
 <div class="text-sm text-white prose">

--- a/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
@@ -1,6 +1,6 @@
 <% if current_organization.official_img_footer.attached? %>
   <%= link_to current_organization.official_url, class: "block mb-6" do %>
-    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: current_organization_name, class: "max-h-16" %>
+    <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: "#{current_organization_name} (#{t("decidim.errors.not_found.back_home")})", class: "max-h-16" %>
   <% end %>
 <% end %>
 <div class="text-sm text-white prose">

--- a/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
@@ -4,9 +4,9 @@
       <a rel="decidim noopener noreferrer" href="https://decidim.org/" target="_blank" data-external-link="text-only">
         <%= image_pack_tag("media/images/decidim-logo.svg", alt: t("layouts.decidim.footer.decidim_logo"), class: "max-h-8 block") %>
       </a>
-      <div class="text-xs mt-2 [&_a]:underline">
+      <p class="text-xs mt-2 [&_a]:underline">
         <%= t("layouts.decidim.footer.made_with_open_source").html_safe %>
-      </div>
+      </p>
     </div>
     <a class="flex gap-1 hover:opacity-50" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" data-external-link="text-only">
       <span class="sr-only"><%= t("layouts.decidim.footer.cc_by_license") %></span>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2102,6 +2102,7 @@ en:
         edit: Edit
       footer:
         cc_by_license: Creative Commons License
+        current_organization_img: "%{organization} (Back home)"
         data_consent_settings: Cookie settings
         decidim_logo: Decidim Logo
         decidim_title: Decidim

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2105,11 +2105,13 @@ en:
         data_consent_settings: Cookie settings
         decidim_logo: Decidim Logo
         decidim_title: Decidim
+        help: Help
         log_in: Log in
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
         open_data: Open Data
         resources: Resources
         sign_up: Create an account
+        social_media: Social media
         terms_of_service: Terms of Service
       header:
         back: Back to list

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -43,7 +43,7 @@ shared_examples "proposals wizards" do |options|
 
       context "when the back button is clicked" do
         before do
-          click_on "Back"
+          click_on "Back to proposals"
         end
 
         it "redirects to proposals_path" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves accessibility in footer, by:
- replacing a meaningless div by a p
- adding new translations for Social media and Help
- adding more explicit text in alt attribute on logo

This PR comes from the audit of Angers city (pages 32, 33 and 34), and refers to criterias 1.1.1, 1.3.1, 2.4.4, 2.5.3 and 3.1.2 from WCAG.

#### :pushpin: Related Issues
- Related to https://github.com/OpenSourcePolitics/intern-tasks/issues/80 https://github.com/OpenSourcePolitics/intern-tasks/issues/79 https://github.com/OpenSourcePolitics/intern-tasks/issues/77

#### Testing

1. As a user, go to the footer of the page and open dev tools
2. Check that the `alt` attribute of the organization's logo `img` has a "Back home" displayed (screenshot one)
3. Check that the Help title and that the `aria-label="Social media"` on `nav` links are well displayed (screenshot two)
4. Check that the `div` displaying the text "Website made with..." has been replaced by a `p` 

### :camera: Screenshots (optional)
ONE 
<img width="830" height="801" alt="Capture d’écran 2025-08-18 à 16 26 41" src="https://github.com/user-attachments/assets/14be3a2e-30c2-4790-a527-d49de6033e78" />

TWO 
<img width="1018" height="681" alt="Capture d’écran 2025-08-19 à 10 03 56" src="https://github.com/user-attachments/assets/e4154a5f-9e2d-4851-b397-59a60e8bb087" />

THREE
<img width="750" height="515" alt="Capture d’écran 2025-08-19 à 10 04 34" src="https://github.com/user-attachments/assets/f60f21dd-4dad-4d79-a5bf-bde91bd5a84b" />
