### PR TITLE
Fix unread notifications or conversations on avatar

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -30,12 +30,6 @@
       <% unread_data = current_user_unread_data %>
       <% if unread_data[:unread_items] %>
         <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
-        <% if unread_data[:unread_notifications] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
-        <% end %>
-        <% if unread_data[:unread_conversations] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
-        <% end %>
       <% end %>
       <% if current_user.avatar.attached? %>
         <span class="main-bar__avatar">
@@ -44,11 +38,23 @@
                   current_user.attached_uploader(:avatar).variant_url(:thumb),
                   alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
                 ) %>
+            <% if unread_data[:unread_notifications] %>
+              <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
+            <% end %>
+            <% if unread_data[:unread_conversations] %>
+              <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+            <% end %>
           </span>
         </span>
       <% else %>
         <span class="main-bar__links-desktop__item-account">
           <%= text_initials(current_user.name) %>
+          <% if unread_data[:unread_notifications] %>
+        <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
+      <% end %>
+          <% if unread_data[:unread_conversations] %>
+        <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+      <% end %>
         </span>
       <% end %>
     </button>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is an update on https://github.com/decidim/decidim/pull/14869. It changes the implementation of sr-only spans about unread notifications or conversations so that they are indeed read by screenreaders.

#### :pushpin: Related Issues
- Related to [#?](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=122481135&issue=OpenSourcePolitics%7Cintern-tasks%7C83)
- Fixes https://github.com/decidim/decidim/pull/14869

#### Testing
1. As a logged in user with unread conversations or notifications, activate your screenreader and navigate to the avatar in the header.
2. When the focus is on the avatar, ensure that the message indicating unread conversations or notifications is well read.

### :camera: Screenshots (optional)
<img width="1240" height="760" alt="Capture d’écran 2025-08-19 à 15 50 21" src="https://github.com/user-attachments/assets/0e53b985-6e07-485d-8093-c1b0915bef4c" />

