### PR TITLE
Fix aria-current on active filter in search page

### DIFF
--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -30,7 +30,7 @@
     </button>
     <ul id="dropdown-menu-search" aria-hidden="true">
       <li>
-        <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}" do %>
+        <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}", "aria-current": params.dig(:filter, :with_resource_type) == nil ? "true" : "" do %>
           <%= resource_type_icon("all") %>
           <span><%= t("all", scope: "decidim.searches.filters.state") %></span>
           <span class="label ml-auto"><%= @results_count %></span>
@@ -42,7 +42,7 @@
             <% elements.each do |type, results| %>
               <% if results[:count].positive? %>
                 <li>
-                <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
+                <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}", "aria-current": params.dig(:filter, :with_resource_type) == type ? "true" : "" do %>
                   <%= resource_type_icon(type) %>
                   <span><%= searchable_resource_human_name(type) %></span>
                   <span class="label ml-auto"><%= results[:count] %></span>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a `aria-current="true"` to the current filter in search page, to improve accessibility.

The PR comes form the audit of Angers city (page 53) and refers to criterias 1.3.3 and 1.4.1 from WCAG.

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=122481570&issue=OpenSourcePolitics%7Cintern-tasks%7C84


#### Testing
1. As a non logged in user, on the home page, go to the search input in the header and make a research by entering for example a word from the title of a process
2. On the search page, open your screenreader and navigate to the filter area
3. Ensure that when you are on the "All" filter, the information that it is the current filter is read
4. Select another filter, navigate again to that filter and ensure that the information on it being the current filter is read


### :camera: Screenshots (optional)
<img width="1110" height="730" alt="Capture d’écran 2025-08-25 à 11 31 49" src="https://github.com/user-attachments/assets/a90ae6ff-e7af-4701-9626-9c70be352a65" />
<img width="1163" height="720" alt="Capture d’écran 2025-08-25 à 11 32 55" src="https://github.com/user-attachments/assets/78c3a084-1428-40a7-bbfc-d7ca2f942d9c" />

