### PR TITLE
Fix accessibility by update aria-current to static pages nav

### DIFF
--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria-current": (page == sibling).to_s %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria-current": ("page" if page == sibling) %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves accessibility compliance on static pages by ensuring the current page is programmatically identifiable by assistive technologies.
- Adds the aria-current="page" attribute to the active item in the sidebar navigation of static pages.

This change follows recommendations from the Angers accessibility audit (page 56) and targets:
RGAA Criterion 10.9 – Indicate the current item within navigation.

#### :pushpin: Related Issues
- Related to
https://github.com/OpenSourcePolitics/intern-tasks/issues/85

🧪 Testing Instructions

1. Visit a static page with the sidebar navigation (e.g., /pages/help)
3. Inspect the currently selected navigation item
5. Ensure the aria-current="page" attribute is present only on the active item
7. Confirm with a screen reader (e.g., VoiceOver ) that the active page is announced as “current page”

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
<img width="1439" height="733" alt="Capture d’écran 2025-08-26 à 12 42 57" src="https://github.com/user-attachments/assets/66189e85-a805-4534-998d-eef6d763c9ca" />

