### PR TITLE
Fix wcag decorative image description from title to description

### DIFF
--- a/decidim-core/app/cells/decidim/card_g/show.erb
+++ b/decidim-core/app/cells/decidim/card_g/show.erb
@@ -1,7 +1,7 @@
 <%= link_to resource_path, class: classes[:default], id: resource_id do %>
   <div class="<%= classes[:img] %>">
     <% if has_image? %>
-      <%= image_tag resource_image_url, alt: "", role: "presentation" %>
+      <%= image_tag resource_image_url, alt: "" %>
     <% else %>
       <%= external_icon "media/images/placeholder-card-g.svg", class: "card__placeholder-g" %>
     <% end %>

--- a/decidim-core/app/cells/decidim/card_g/show.erb
+++ b/decidim-core/app/cells/decidim/card_g/show.erb
@@ -1,7 +1,7 @@
 <%= link_to resource_path, class: classes[:default], id: resource_id do %>
   <div class="<%= classes[:img] %>">
     <% if has_image? %>
-      <%= image_tag resource_image_url, alt: alt_title %>
+      <%= image_tag resource_image_url, alt: "", role: "presentation" %>
     <% else %>
       <%= external_icon "media/images/placeholder-card-g.svg", class: "card__placeholder-g" %>
     <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
@@ -2,7 +2,7 @@
 <%= link_to resource_path, class: classes[:default], id: resource_id do %>
   <div class="<%= classes[:img] %>">
     <% if has_image? %>
-      <%= image_tag resource_image_path, alt: "", role: t("decidim.accessibility.decorative_image_role") %>
+      <%= image_tag resource_image_path, alt: "", role: "presentation" %>
     <% else %>
       <%= external_icon "media/images/proposal-placeholder-card-g.svg", class: "card__proposal-placeholder-g" %>
     <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
@@ -2,7 +2,7 @@
 <%= link_to resource_path, class: classes[:default], id: resource_id do %>
   <div class="<%= classes[:img] %>">
     <% if has_image? %>
-      <%= image_tag resource_image_path, alt: "", role: "presentation" %>
+      <%= image_tag resource_image_path, alt: "" %>
     <% else %>
       <%= external_icon "media/images/proposal-placeholder-card-g.svg", class: "card__proposal-placeholder-g" %>
     <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
@@ -2,7 +2,7 @@
 <%= link_to resource_path, class: classes[:default], id: resource_id do %>
   <div class="<%= classes[:img] %>">
     <% if has_image? %>
-      <%= image_tag resource_image_path, alt: alt_title %>
+      <%= image_tag resource_image_path, alt: "", role: t("decidim.accessibility.decorative_image_role") %>
     <% else %>
       <%= external_icon "media/images/proposal-placeholder-card-g.svg", class: "card__proposal-placeholder-g" %>
     <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves accessibility on cards, by fixing non-informative labels on decorative images.

✅ Problem
In several cards, the alt attribute of decorative images was filled with text like:
`alt="Image média: XYZ..."`
This caused assistive technologies (like screen readers) to read this text as part of the link label, making it unclear and redundant.

#### :pushpin: Related WCAG
This was flagged in the Angers audit (page 35), related to:

RGAA 6.1 – Liens : intitulé explicite
WCAG 1.1.1 (Non-text content)
WCAG 2.4.4 (Link purpose)
WCAG 2.5.3 (Label in Name)

#### :pushpin: Related tasks:
https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=122477175&issue=OpenSourcePolitics%7Cintern-tasks%7C78

#### :clipboard: Subtasks
Made images fully decorative by:
- an empty alt => tells assistive technologies to skip the image.
- role="presentation" => removes the image from the accessibility tree entirely.
👉 This combination maximizes compatibility, especially with older or inconsistent screen readers.
CF: See [WAI-ARIA Spec: role="presentation"](https://www.w3.org/TR/wai-aria/?utm_source=chatgpt.com#presentation)

### :camera: Screenshots (optional)
<img width="1439" height="604" alt="Capture d’écran 2025-08-28 à 14 51 03" src="https://github.com/user-attachments/assets/4bfc3fd2-0b43-4f27-b52e-25ced004f0ca" />
<img width="1441" height="607" alt="Capture d’écran 2025-08-28 à 15 54 43" src="https://github.com/user-attachments/assets/fdb59723-51b7-4769-a704-02ba3f5fff0d" />