### PR TITLE
Fix replace div and span by p for accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/activity/show.erb
+++ b/decidim-core/app/cells/decidim/activity/show.erb
@@ -3,9 +3,9 @@
     <%= created_at %>
   </p>
   <div class="activity__content">
-    <span>
+    <div>
       <% if title.present? %>
-        <p class="inline-block">
+        <p class="activity__content-p">
           <%= title_icon %>
           <%= title %>
         </p>
@@ -13,7 +13,7 @@
       <a href="<%= resource_link_path %>">
         <%= html_truncate decidim_sanitize(resource_link_text, strip_tags: true), length: 80 %>
       </a>
-    </span>
+    </div>
     <% unless hide_participatory_space? %>
       <span>
         <%= participatory_space_link %>

--- a/decidim-core/app/cells/decidim/activity/show.erb
+++ b/decidim-core/app/cells/decidim/activity/show.erb
@@ -1,14 +1,14 @@
 <div class="activity" data-activity>
-  <div class="activity__time">
+  <p class="activity__time">
     <%= created_at %>
-  </div>
+  </p>
   <div class="activity__content">
     <span>
       <% if title.present? %>
-        <span>
+        <p class="inline-block">
           <%= title_icon %>
           <%= title %>
-        </span>
+        </p>
       <% end %>
       <a href="<%= resource_link_path %>">
         <%= html_truncate decidim_sanitize(resource_link_text, strip_tags: true), length: 80 %>

--- a/decidim-core/app/cells/decidim/activity/show.erb
+++ b/decidim-core/app/cells/decidim/activity/show.erb
@@ -5,7 +5,7 @@
   <div class="activity__content">
     <div>
       <% if title.present? %>
-        <p class="activity__content-p">
+        <p>
           <%= title_icon %>
           <%= title %>
         </p>

--- a/decidim-core/app/packs/stylesheets/decidim/_activity.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_activity.scss
@@ -12,12 +12,12 @@
   &__content {
     @apply col-span-2 md:col-span-1 order-first md:order-none space-y-2;
 
-    > span:first-child {
-      span {
-        @apply text-gray-2 text-sm;
+    > div:first-child {
+      p {
+        @apply text-gray-2 text-sm inline-block;
 
         svg {
-          @apply text-gray fill-current;
+          @apply text-gray fill-current inline;
         }
       }
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR replaces in the breadcrumb_menu meaningless `div` and `span` by `p`, to improve accessibility.

This PR comes from the audit of Angers city (page 37) and refers to criteria 1.3.1 from WCAG.

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=122478786&issue=OpenSourcePolitics%7Cintern-tasks%7C81

#### Testing

1. Go to the processes index page
2. Activate your screen reader, and navigate to the breadcrumb menu until you get to the comments (see screenshot)
3. Ensure that the time (1 day ago) and the title (New comment) are identified as text by the screen reader.
4. Open your dev tools and see that they are displayed in a `p` element.

### :camera: Screenshots (optional)
<img width="875" height="879" alt="Capture d’écran 2025-08-29 à 09 11 10" src="https://github.com/user-attachments/assets/ef9c0e90-6562-4356-bcf7-2e38e6e27f28" />

