### PR TITLE
Fix missing concern in result model

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -22,6 +22,7 @@ module Decidim
       include Decidim::TranslatableResource
       include Decidim::FilterableResource
       include Decidim::SoftDeletable
+      include Decidim::Reportable
 
       component_manifest_name "accountability"
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a missing concern in result model, to fix an error when moderating a comment in accountability.

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=129203267&issue=OpenSourcePolitics%7Cdecidim-app%7C881
- Fixes https://github.com/decidim/decidim/issues/15196

#### :testing
1. As a user go to a process, and then to the accountability page, click on an item, and then click again on an item.  
2. Report a comment if there is one, otherwise create a comment and then report it.
3. See that there is no error (screenshot one)
4. After that, as an admin, go to the BO and go to global moderation tab. 
5. See that there is no error.

### :camera: Screenshots (optional)
**ONE**
<img width="1198" height="709" alt="accountability_success" src="https://github.com/user-attachments/assets/43eecd13-7842-4859-ab59-4617219714ac" />

**TWO**
<img width="1289" height="596" alt="moderation_success" src="https://github.com/user-attachments/assets/c074c0df-a412-44db-a3ad-c4976184885f" />

