### PR TITLE
Fix highlight card displaying unpublished process

### DIFF
--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -68,8 +68,8 @@ module Decidim
       @menu_highlighted_participatory_process ||= (
         # The queries already include the order by weight
         Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization) |
-        Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new
-      ).first
+          Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new
+      ).select(&:published?)&.first
     end
 
     def home_content_block_menu

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -69,7 +69,13 @@ module Decidim
         # The queries already include the order by weight
         Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization) |
           Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new
-      ).select(&:published?)&.first
+      ).select(&:published?).map { |process| remove_private_space_if_not_private_user(process) }&.compact&.first
+    end
+
+    def remove_private_space_if_not_private_user(process)
+      return nil if process.private_space == true && !process.can_participate?(current_user)
+
+      process
     end
 
     def home_content_block_menu

--- a/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
@@ -54,13 +54,35 @@ module Decidim
         end
       end
 
-      context "when there are 2 promoted processes but the one with minimum weight is not published" do
-        before do
-          process_two.update!(promoted: true, published_at: nil)
+      context "when there are 2 promoted processes" do
+        context "and the one with minimum weight is not published" do
+          before do
+            process_two.update!(promoted: true, published_at: nil)
+          end
+
+          it "returns the other published promoted process" do
+            expect(helper.menu_highlighted_participatory_process).to eq(process_three)
+          end
         end
 
-        it "returns the other published promoted process" do
-          expect(helper.menu_highlighted_participatory_process).to eq(process_three)
+        context "and the promoted published process with minimum weight is private" do
+          before do
+            process_two.update!(promoted: true, private_space: true)
+          end
+
+          context "and current_user is private user of that process" do
+            let!(:participatory_space_private_user) { create(:participatory_space_private_user, privatable_to: process_two, user:) }
+
+            it "returns the private process" do
+              expect(helper.menu_highlighted_participatory_process).to eq(process_two)
+            end
+          end
+
+          context "and current_user is not private user of that process" do
+            it "returns the other published promoted process" do
+              expect(helper.menu_highlighted_participatory_process).to eq(process_three)
+            end
+          end
         end
       end
     end

--- a/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe MenuHelper do
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, organization: organization) }
+    let!(:process) { create(:participatory_process, :active, weight: 1, organization:) }
+    let!(:process_two) { create(:participatory_process, :active, weight: 2, organization:) }
+    let!(:process_three) { create(:participatory_process, :active, :promoted, weight: 3, organization:) }
+
+    before do
+      allow(helper).to receive(:current_organization).and_return(organization)
+      allow(helper).to receive(:current_user).and_return(user)
+    end
+
+    describe "#menu_highlighted_participatory_process" do
+      context "when all processes are unpublished" do
+        before do
+          process.update!(published_at: nil)
+          process_two.update!(published_at: nil)
+          process_three.update!(published_at: nil)
+        end
+
+        it "returns nil" do
+          expect(helper.menu_highlighted_participatory_process).to be_nil
+        end
+      end
+
+      context "when all processes are published" do
+        it "returns the published promoted process" do
+          expect(helper.menu_highlighted_participatory_process).to eq(process_three)
+        end
+      end
+
+      context "when promoted process is unpublished" do
+        before do
+          process_three.update!(published_at: nil)
+        end
+
+        it "returns nil" do
+          expect(helper.menu_highlighted_participatory_process).to be_nil
+        end
+      end
+
+      context "when there are 2 promoted published processes" do
+        before do
+          process_two.update!(promoted: true)
+        end
+
+        it "returns the published promoted process with minimum weight" do
+          expect(helper.menu_highlighted_participatory_process).to eq(process_two)
+        end
+      end
+
+      context "when there are 2 promoted processes but the one with minimum weight is not published" do
+        before do
+          process_two.update!(promoted: true, published_at: nil)
+        end
+
+        it "returns the other published promoted process" do
+          expect(helper.menu_highlighted_participatory_process).to eq(process_three)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the menu_helper so that the process displayed in main-dropdown-menu is a published one.

#### :pushpin: Related Issues
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=133646863&issue=OpenSourcePolitics%7Cintern-tasks%7C182
- Fixes https://github.com/decidim/decidim/issues/15364

#### Testing

1. As an admin, promote 2 processes in the BO
2. As a user, in the FO go to the index of processes, open the main-dropdown-menu and see which process appears as highlighted in the menu, let call it process one (screenshot one)
3. As an admin, unpublish process one (screenshot two)
4. Go back to the index of processes in the FO and see that process one is not displayed anymore, but the other promoted published process is displayed ((screenshot three)

#### :clipboard: Subtasks
- [X] Add tests

### :camera: Screenshots (optional)
**ONE**
<img width="1174" height="669" alt="Capture d’écran 2025-10-16 à 09 42 58" src="https://github.com/user-attachments/assets/0c7211db-abb8-41bd-b248-fc8a661bdf7b" />

**TWO**
<img width="1279" height="448" alt="Capture d’écran 2025-10-16 à 09 42 43" src="https://github.com/user-attachments/assets/4d56624b-16d2-4c29-9b7f-00f6c92a46be" />


**THREE**
<img width="1171" height="670" alt="Capture d’écran 2025-10-16 à 09 43 13" src="https://github.com/user-attachments/assets/629d2630-fa96-4993-9459-18fae29f17ed" />
