### PR TITLE
Fix semantic on flash messages

### DIFF
--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -72,10 +72,14 @@ module Decidim
     end
 
     def clean_announcement
+      return if announcement.is_a?(Hash) && announcement.values.any?(&:empty?)
+
       clean(announcement)
     end
 
     def clean(value)
+      return if value.blank? || value.nil?
+
       if value.include?("rich-text-display")
         decidim_sanitize_admin(translated_attribute(value))
       else

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -76,7 +76,7 @@ module Decidim
     end
 
     def clean(value)
-      if value == "<div class=\"rich-text-display\"></div>"
+      if value.include?("rich-text-display")
         decidim_sanitize_admin(translated_attribute(value))
       else
         tag.p(decidim_sanitize_admin(translated_attribute(value)))

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -68,7 +68,7 @@ module Decidim
     def clean_body
       return unless body
 
-      Array(body).map { |paragraph| tag.p(clean(paragraph)) }.join
+      Array(body).map { |paragraph| clean(paragraph) }.join
     end
 
     def clean_announcement
@@ -76,7 +76,11 @@ module Decidim
     end
 
     def clean(value)
-      decidim_sanitize_admin(translated_attribute(value))
+      if value == "<div class=\"rich-text-display\"></div>"
+        decidim_sanitize_admin(translated_attribute(value))
+      else
+        tag.p(decidim_sanitize_admin(translated_attribute(value)))
+      end
     end
   end
 end

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -118,7 +118,6 @@ module Decidim
       end
 
       def message(value)
-        debugger
         return content_tag(:p, value, class: "flash__message") unless value.is_a?(Hash)
 
         content_tag(:p, class: "flash__message") do

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -118,9 +118,9 @@ module Decidim
       end
 
       def message(value)
-        return content_tag(:div, value, class: "flash__message") unless value.is_a?(Hash)
+        return content_tag(:p, value, class: "flash__message") unless value.is_a?(Hash)
 
-        content_tag(:div, class: "flash__message") do
+        content_tag(:span, class: "flash__message") do
           concat value[:title]
           concat content_tag(:span, value[:body], class: "flash__message-body")
         end

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -118,9 +118,10 @@ module Decidim
       end
 
       def message(value)
+        debugger
         return content_tag(:p, value, class: "flash__message") unless value.is_a?(Hash)
 
-        content_tag(:span, class: "flash__message") do
+        content_tag(:p, class: "flash__message") do
           concat value[:title]
           concat content_tag(:span, value[:body], class: "flash__message-body")
         end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -53,7 +53,7 @@ describe "Organizations" do
         check "Example authorization (Direct)"
         click_on "Create organization & invite admin"
 
-        within ".flash__message" do
+        within ".flash.success" do
           expect(page).to have_content("Organization successfully created.")
           expect(page).to have_content("config/environment/production.rb")
           expect(page).to have_content("config.hosts << \"www.example.org\"")


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds semantic `p` tag in flash messages.
- it updates the announcement_cell.rb file methods to add p tags when it is relevant.
The issue has been spotted in the audit of Angers city (page 82)
- it also adds `p` tag in the flash_helper_extension

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=133478303&issue=OpenSourcePolitics%7Cintern-tasks%7C178

#### Testing
- log in to the application and see that the text of the flash message is displayed in a `p` tag (screenshot one)
- go to the show page of an evaluating proposal and see that the flash messages are displayed in a `p` tag, and that there is not empty `p` tags before and after the `div class="rich-text-display"` (screenshot two)

### :camera: Screenshots
**ONE**
<img width="1048" height="839" alt="Capture d’écran 2025-12-09 à 10 39 58" src="https://github.com/user-attachments/assets/45a942b7-7959-44b2-8f43-d58060dbb4cb" />

**TWO**
<img width="1040" height="925" alt="Capture d’écran 2025-12-09 à 16 25 52" src="https://github.com/user-attachments/assets/dbafd493-f64a-42a3-9bf1-b2bca5a0a3cc" />

:hearts: Thank you!
