### PR TITLE
Fix: edit responses on survey with condition question

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def add_responses!(questionnaire:, session_token:, ip_hash:)
         self.responses = questionnaire.questions.map do |question|
-          ResponseForm.from_model(Decidim::Forms::Response.where(question:, user: current_user, session_token:, ip_hash:).first_or_initialize)
+          ResponseForm.from_model(Decidim::Forms::Response.where(question:, user: current_user, session_token:, ip_hash:).first_or_initialize).with_context(context)
         end
       end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -198,6 +198,42 @@ describe "Respond a survey" do
         it_behaves_like "has embedded video in description", :question_description
       end
     end
+
+    context "when the survey allows to edit responses, and question has display conditions" do
+      let!(:question_two) do
+        create(:questionnaire_question,
+               questionnaire:,
+               question_type: "short_response",
+               position: 1,
+               options: [])
+      end
+      let!(:display_condition) do
+        create(:display_condition,
+               condition_type: "not_responded",
+               question: question_two,
+               condition_question: question)
+      end
+
+      before do
+        survey.update!(
+          allow_responses: true,
+          allow_editing_responses: true
+        )
+        login_as user, scope: :user
+        visit_component
+        click_on translated_attribute(questionnaire.title)
+        fill_in "questionnaire_responses_0", with: "test"
+        check "questionnaire_tos_agreement"
+        click_on "Submit"
+        expect(page).to have_callout("Survey successfully responded.")
+      end
+
+      it "allows to edit the responses" do
+        click_on "Edit your responses"
+        expect(page).to have_content(translated_attribute(survey.title))
+        expect(page).to have_content(translated_attribute(question.body))
+      end
+    end
   end
 
   context "when survey has a custom announcement" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR corrects a bug that prevents from editing responses of survey where there were questions with display condition. 
It adds missing context in add_responses! method.

#### Related to
- Fixes https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=175302606&issue=OpenSourcePolitics%7Cintern-tasks%7C410

#### :clipboard: Subtasks
- [X] Add tests


### :camera: Screenshots (optional)
![Description](URL)
